### PR TITLE
Update Documentation link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ building blocks
 
 Libraries are released on [GMaven](https://maven.google.com/) as needed and version
 numbers are encoded as YYYYMMDD. With each release, we also publish documentation at
-https://google.github.io/identity-credential/.
+https://openwallet-foundation-labs.github.io/identity-credential/.
 
 ## Wallet and Reader Android applications
 


### PR DESCRIPTION
Update the documentation link (GitHub pages). While a redirection on the repository level (https://github.com/google/identity-credential/) is already in place this is not the case for the documentation link: 
* https://google.github.io/identity-credential/

The new place for the documentation is: 
* https://openwallet-foundation-labs.github.io/identity-credential/

Fixes #425

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [x] Appropriate changes to README are included in PR