### PR TITLE
Change wallet defaults and fix race condition.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
@@ -87,7 +87,7 @@ object PreferencesHelper {
     }
 
     fun isConnectionAutoCloseEnabled(): Boolean {
-        return sharedPreferences.getBoolean(CONNECTION_AUTO_CLOSE, false)
+        return sharedPreferences.getBoolean(CONNECTION_AUTO_CLOSE, true)
     }
 
     fun setConnectionAutoCloseEnabled(enabled: Boolean) {
@@ -95,7 +95,7 @@ object PreferencesHelper {
     }
 
     fun shouldUseStaticHandover(): Boolean {
-        return sharedPreferences.getBoolean(STATIC_HANDOVER, true)
+        return sharedPreferences.getBoolean(STATIC_HANDOVER, false)
     }
 
     fun setUseStaticHandover(enabled: Boolean) {

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.java
@@ -99,8 +99,12 @@ public class DeviceRetrievalHelper {
         Logger.d(TAG, "reportEReaderKeyReceived: " + eReaderKey);
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onEReaderKeyReceived(eReaderKey));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onEReaderKeyReceived(eReaderKey);
+                }
+            });
         }
     }
 
@@ -108,8 +112,12 @@ public class DeviceRetrievalHelper {
         Logger.d(TAG, "reportDeviceRequest: deviceRequestBytes: " + deviceRequestBytes.length + " bytes");
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onDeviceRequest(deviceRequestBytes));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDeviceRequest(deviceRequestBytes);
+                }
+            });
         }
     }
 
@@ -118,9 +126,12 @@ public class DeviceRetrievalHelper {
                 + transportSpecificTermination);
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onDeviceDisconnected(
-                    transportSpecificTermination));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDeviceDisconnected(transportSpecificTermination);
+                }
+            });
         }
     }
 
@@ -128,8 +139,12 @@ public class DeviceRetrievalHelper {
         Logger.d(TAG, "reportError: error: ", error);
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onError(error));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onError(error);
+                }
+            });
         }
     }
 

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.java
@@ -799,8 +799,12 @@ public class NfcEngagementHelper {
         Logger.d(TAG, "reportTwoWayEngagementDetected");
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onTwoWayEngagementDetected);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onTwoWayEngagementDetected();
+                }
+            });
         }
     }
 
@@ -809,8 +813,12 @@ public class NfcEngagementHelper {
         Logger.d(TAG, "reportDeviceConnecting");
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onDeviceConnecting);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDeviceConnecting();
+                }
+            });
         }
     }
 
@@ -818,8 +826,12 @@ public class NfcEngagementHelper {
         Logger.d(TAG, "reportDeviceConnected");
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onDeviceConnected(transport));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDeviceConnected(transport);
+                }
+            });
         }
     }
 
@@ -827,8 +839,12 @@ public class NfcEngagementHelper {
         Logger.d(TAG, "reportError: error: ", error);
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onError(error));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onError(error);
+                }
+            });
         }
     }
 

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.java
@@ -292,8 +292,12 @@ public class QrEngagementHelper {
         Logger.d(TAG, "reportDeviceEngagementReady");
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onDeviceEngagementReady);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDeviceEngagementReady();
+                }
+            });
         }
     }
 
@@ -301,8 +305,12 @@ public class QrEngagementHelper {
         Logger.d(TAG, "reportDeviceConnecting");
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onDeviceConnecting);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDeviceConnecting();
+                }
+            });
         }
     }
 
@@ -310,8 +318,12 @@ public class QrEngagementHelper {
         Logger.d(TAG, "reportDeviceConnected");
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onDeviceConnected(transport));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDeviceConnected(transport);
+                }
+            });
         }
     }
 
@@ -319,8 +331,12 @@ public class QrEngagementHelper {
         Logger.d(TAG, "reportError: error: ", error);
         final Listener listener = mListener;
         final Executor executor = mExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onError(error));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onError(error);
+                }
+            });
         }
     }
 

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransport.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransport.java
@@ -211,32 +211,48 @@ public abstract class DataTransport {
     protected void reportConnectionMethodReady() {
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onConnectionMethodReady());
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onConnectionMethodReady();
+                }
+            });
         }
     }
 
     protected void reportConnecting() {
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onConnecting);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onConnecting();
+                }
+            });
         }
     }
 
     protected void reportConnected() {
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onConnected);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onConnected();
+                }
+            });
         }
     }
 
     protected void reportDisconnected() {
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onDisconnected);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onDisconnected();
+                }
+            });
         }
     }
 
@@ -244,32 +260,48 @@ public abstract class DataTransport {
         mMessageReceivedQueue.add(data);
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onMessageReceived());
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onMessageReceived();
+                }
+            });
         }
     }
 
     protected void reportMessageProgress(long progress, long max) {
         final TransmissionProgressListener listener = mProgressListener;
         final Executor executor = mProgressListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onProgressUpdate(progress, max));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onProgressUpdate(progress, max);
+                }
+            });
         }
     }
 
     protected void reportTransportSpecificSessionTermination() {
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(listener::onTransportSpecificSessionTermination);
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onTransportSpecificSessionTermination();
+                }
+            });
         }
     }
 
     protected void reportError(@NonNull Throwable error) {
         final Listener listener = mListener;
         final Executor executor = mListenerExecutor;
-        if (!mInhibitCallbacks && listener != null && executor != null) {
-            executor.execute(() -> listener.onError(error));
+        if (listener != null && executor != null) {
+            executor.execute(() -> {
+                if (!mInhibitCallbacks) {
+                    listener.onError(error);
+                }
+            });
         }
     }
 


### PR DESCRIPTION
Make the wallet app default to NFC Negotiated Handover and close the connection after sending the response. This change is to more closely mimic wallets already in production using this code.

Also add additional checks for callback inhibition when inside the executor to avoid transport callbacks after closing a connection. This happened in the reader app - causing a crash - when the mDL included status 20 in the same SessionData message which contained the result (e.g. using auto-close).

Test: Manually tested.
Test: All unit tests pass.
