### PR TITLE
Presentation Log

### DIFF
--- a/appholder/build.gradle
+++ b/appholder/build.gradle
@@ -87,6 +87,7 @@ dependencies {
     implementation libs.exifinterface
     implementation libs.code.scanner
     implementation libs.kotlinx.serialization
+    implementation libs.play.services.location
 
     androidTestImplementation libs.bundles.ui.testing
 

--- a/appholder/src/main/java/com/android/identity/wallet/HolderApp.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/HolderApp.kt
@@ -2,6 +2,7 @@ package com.android.identity.wallet
 
 import android.app.Application
 import android.content.Context
+import android.location.Location
 import com.android.identity.android.securearea.AndroidKeystoreSecureArea
 import com.android.identity.android.storage.AndroidStorageEngine
 import com.android.identity.android.util.AndroidLogPrinter
@@ -19,6 +20,7 @@ import com.android.identity.trustmanagement.TrustManager
 import com.android.identity.trustmanagement.TrustPoint
 import com.android.identity.util.Logger
 import com.android.identity.wallet.document.KeysAndCertificates
+import com.android.identity.presentationlog.PresentationLogStore
 import com.android.identity.wallet.util.PeriodicKeysRefreshWorkRequest
 import com.android.identity.wallet.util.PreferencesHelper
 import com.google.android.material.color.DynamicColors
@@ -87,6 +89,17 @@ class HolderApp: Application() {
             secureAreaRepository.addImplementation(softwareSecureArea)
             return CredentialStore(storageEngine, secureAreaRepository)
         }
+
+        /**
+         * Create a PresentationLogStore
+         */
+        fun createPresentationLogStore(
+            context: Context,
+        ): PresentationLogStore {
+            val storageDir = PreferencesHelper.getKeystoreBackedStorageLocation(context)
+            val storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
+            return PresentationLogStore(storageEngine)
+        }
     }
 
     /**
@@ -96,4 +109,7 @@ class HolderApp: Application() {
         return CertificateFactory.getInstance("X509")
             .generateCertificate(ByteArrayInputStream(certificateBytes)) as X509Certificate
     }
+
+
+
 }

--- a/appholder/src/main/java/com/android/identity/wallet/presentationlog/PresentationHistoryFragment.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/presentationlog/PresentationHistoryFragment.kt
@@ -1,0 +1,560 @@
+package com.android.identity.wallet.presentationlog
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CutCornerShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.activityViewModels
+import co.nstant.`in`.cbor.model.DataItem
+import co.nstant.`in`.cbor.model.Map
+import com.android.identity.internal.Util
+import com.android.identity.mdoc.request.DeviceRequestParser
+import com.android.identity.mdoc.response.DeviceResponseParser
+import com.android.identity.presentationlog.PresentationLogEntry
+import com.android.identity.presentationlog.PresentationLogMetadata
+import com.android.identity.wallet.R
+import com.android.identity.wallet.theme.HolderAppTheme
+import com.android.identity.wallet.util.FormatUtil.millisecondsToFullDateTimeString
+import com.android.identity.wallet.util.FormatUtil.millisecondsToTimeString
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import java.time.Duration
+import java.util.Locale
+
+
+class PresentationHistoryFragment : BottomSheetDialogFragment() {
+
+    private val viewModel: PresentationHistoryViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                val logEntries by viewModel.fetchPresentationLogHistory().collectAsState()
+                HolderAppTheme {
+                    PresentationHistoryContainer(
+                        modifier = Modifier
+                            .fillMaxSize(),
+                        title = stringResource(id = R.string.title_presentation_history),
+                        logEntries = logEntries,
+                        onDeleteSelected = { entryIds ->
+                            viewModel.deleteSelectedEntries(entryIds)
+                        },
+                        onDeleteAll = {
+                            viewModel.deleteAllEntries()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun PresentationHistoryContainer(
+    modifier: Modifier = Modifier,
+    title: String,
+    logEntries: List<PresentationLogEntry>,
+    onDeleteSelected: (List<Long>) -> Unit,
+    onDeleteAll: () -> Unit
+) {
+    val selectedEntries = remember { mutableStateMapOf<Long, Boolean>() }
+
+    Column(modifier = modifier) {
+        BottomSheetHandle(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        )
+
+        Text(
+            text = title,
+            modifier = Modifier
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HistoryActions(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            enabledDeleteSelected = selectedEntries.isNotEmpty(),
+            onDeleteSelected = {
+                onDeleteSelected.invoke(selectedEntries.keys.toList())
+            },
+            enabledDeleteAll = logEntries.isNotEmpty(),
+            onDeleteAll = {
+                onDeleteAll.invoke()
+            }
+        )
+
+        if (logEntries.isEmpty()) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.LightGray,
+                text = "No recent history",
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                LazyColumn(modifier = Modifier.focusGroup()) {
+                    items(logEntries.size) { index ->
+                        val logEntry = logEntries[index]
+                        LogEntryRowContainer(
+                            entry = logEntry,
+                            onSelectedLogEntry = { entryId, checked ->
+                                if (!checked) {
+                                    selectedEntries.remove(entryId)
+                                } else {
+                                    selectedEntries[entryId] = true
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetHandle(
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, horizontalArrangement = Arrangement.Center) {
+        Spacer(
+            modifier = Modifier
+                .size(64.dp, 4.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(Color.Gray)
+        )
+    }
+}
+
+@Composable
+private fun LogEntryRowContainer(
+    modifier: Modifier = Modifier,
+    entry: PresentationLogEntry,
+    onSelectedLogEntry: (entryId: Long, checked: Boolean) -> Unit
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        LogEntryRow(
+            logEntry = entry,
+            onSelectedLogEntry = { entryId, checked ->
+                onSelectedLogEntry.invoke(entryId, checked)
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LogEntryRow(
+    modifier: Modifier = Modifier,
+    logEntry: PresentationLogEntry,
+    onSelectedLogEntry: (entryId: Long, checked: Boolean) -> Unit
+) {
+    var isChecked by remember { mutableStateOf(false) }
+
+    val request = logEntry.getRequest()
+    val response = logEntry.getResponse()
+    val metadata = logEntry.getMetadata()
+        ?: throw IllegalStateException("Expected PresentationLogEntry ${logEntry.id} to have the Metadata component persisted to StorageEngine but none could be found")
+
+    FilterChip(
+        modifier = modifier,
+        selected = isChecked,
+        onClick = {
+            isChecked = !isChecked
+            onSelectedLogEntry.invoke(logEntry.id, isChecked)
+        },
+        label = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                MetadataLogView(metadata = metadata)
+                RequestLogView(request = request)
+                ResponseLogView(response = response)
+            }
+        },
+
+        leadingIcon = {
+            Checkbox(
+                checked = isChecked,
+                onCheckedChange = {
+                    isChecked = !isChecked
+                    onSelectedLogEntry.invoke(logEntry.id, isChecked)
+                }
+            )
+        }
+    )
+}
+
+@Composable
+fun MetadataLogView(metadata: PresentationLogMetadata) {
+    val dateTimeStart = millisecondsToFullDateTimeString(metadata.transactionStartTime)
+    Text(
+        text = dateTimeStart,
+        style = MaterialTheme.typography.titleMedium
+    )
+    val duration = Duration.ofMillis(metadata.transactionEndTime - metadata.transactionStartTime)
+    val dateTimeEnd =
+        "Ended ${duration.seconds} seconds later (at ${millisecondsToTimeString(metadata.transactionEndTime)})"
+    Text(
+        text = dateTimeEnd,
+        style = MaterialTheme.typography.titleSmall
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    var metadataInfo = "Transaction status: ${metadata.presentationTransactionStatus.name}\n"
+    metadataInfo += "Engagement type: ${metadata.engagementType.name}\n"
+    metadataInfo += "Error: ${metadata.error}\n"
+    metadataInfo += "Session transcript length: ${metadata.sessionTranscript.size}\n"
+    val locationText =
+        "Location (lat,long): (${metadata.locationLatitude},${metadata.locationLongitude})"
+    val context = LocalContext.current
+    Text(
+        text = metadataInfo,
+        style = MaterialTheme.typography.bodyMedium
+    )
+    Text(
+        modifier = Modifier
+            .clickable {
+                val uri: String =
+                    java.lang.String.format(
+                        Locale.ENGLISH, "geo:%f,%f?q=%f,%f(mDL Presentation on $dateTimeStart)",
+                        metadata.locationLatitude,
+                        metadata.locationLongitude,
+                        metadata.locationLatitude,
+                        metadata.locationLongitude
+                    )
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
+                context.startActivity(intent)
+            }
+            .padding(16.dp),
+        text = buildAnnotatedString {
+            append(locationText)
+            addStyle(
+                style = SpanStyle(
+                    fontWeight = FontWeight.Bold,
+                    textDecoration = TextDecoration.Underline
+                ),
+                start = 0,
+                end = locationText.length - 1
+            )
+        },
+    )
+}
+
+@Composable
+fun RequestLogView(request: DeviceRequestParser.DeviceRequest?) {
+    var showRequestDetails by remember { mutableStateOf(false) }
+
+    if (request == null) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 10.dp)
+                .border(
+                    2.dp,
+                    SolidColor(Color.Green),
+                    RoundedCornerShape(10.dp)
+                ),
+            text = "Request is null"
+        )
+    }
+
+    request?.let {
+        val multipleDocumentRequests = request.documentRequests.size > 1
+
+        if (multipleDocumentRequests) {
+            Text(
+                text = "${request.documentRequests.size} Document Requests",
+                style = MaterialTheme.typography.titleSmall,
+                color = Color.Cyan
+            )
+        }
+
+
+        request.documentRequests.forEach { docRequest ->
+            val requestHeader = "Request (v${request.version}) for Doc: ${docRequest.docType}"
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 10.dp)
+                    .border(
+                        2.dp,
+                        SolidColor(Color.Green),
+                        RoundedCornerShape(10.dp)
+                    )
+                    .clickable {
+                        showRequestDetails = !showRequestDetails
+                    }
+            ) {
+                Text(
+                    modifier = Modifier.padding(16.dp),
+                    text = requestHeader
+                )
+
+                if (showRequestDetails) {
+                    val itemsRequest: DataItem = Util.cborDecode(docRequest.itemsRequest)
+                    val nameSpaces = Util.cborMapExtractMap(itemsRequest, "nameSpaces")
+                    val itemsMap = Util.castTo(Map::class.java, nameSpaces)
+                    itemsMap.keys.forEach { key ->
+                        val text = "[$key] => ${itemsMap[key]}"
+                        Text(
+                            modifier = Modifier
+                                .padding(start = 5.dp)
+                                .border(
+                                    1.dp,
+                                    SolidColor(MaterialTheme.colorScheme.outline),
+                                    CutCornerShape(5.dp)
+                                ),
+                            text = text
+                        )
+                    }
+                    val requestInfo = docRequest.requestInfo
+
+
+                    val requestText =
+                        "request info: ${requestInfo.size}, Reader Authentication: ${docRequest.readerAuth}"
+                    Text(
+                        modifier = Modifier
+                            .padding(start = 5.dp)
+                            .border(
+                                1.dp,
+                                SolidColor(MaterialTheme.colorScheme.outline),
+                                CutCornerShape(5.dp)
+                            ),
+                        text = requestText
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ResponseLogView(response: DeviceResponseParser.DeviceResponse?) {
+    var showResponseDetails by remember { mutableStateOf(false) }
+
+    var responseHeader = "Response " +
+            if (response == null) {
+                "is null"
+            } else {
+                "(v ${response.version}) status: ${response.status}"
+            }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 10.dp)
+            .border(
+                2.dp,
+                SolidColor(Color.Yellow),
+                RoundedCornerShape(10.dp)
+            )
+            .clickable {
+                showResponseDetails = !showResponseDetails
+            }
+    ) {
+        Text(
+            modifier = Modifier.padding(16.dp),
+            text = responseHeader
+        )
+        if (showResponseDetails) {
+            val statusInfo = "[OK=0|General Err=10|Cbor Decoding Err=11|Cbor Violation Err=12]"
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = statusInfo
+            )
+            response?.let {
+                response.documents.forEach { document ->
+
+                    document.issuerNamespaces.forEach { nameSpace ->
+                        val names = document.getIssuerEntryNames(nameSpace)
+                        var nameSpaceText = "[Issuer NameSpace] $nameSpace\n"
+                        names.forEach { name ->
+                            nameSpaceText += "[IssuerEntry $name] ${
+                                if (name != "portrait")
+                                    String(
+                                        document.getIssuerEntryData(
+                                            nameSpace,
+                                            name
+                                        )
+                                    ) else "[bytes]"
+
+                            }\n"
+                        }
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 5.dp)
+                                .border(
+                                    1.dp,
+                                    SolidColor(MaterialTheme.colorScheme.outline),
+                                    CutCornerShape(5.dp)
+                                ),
+                            text = nameSpaceText
+                        )
+                    }
+
+                    document.deviceNamespaces.forEach { nameSpace ->
+                        val names = document.getDeviceEntryNames(nameSpace)
+                        var nameSpaceText = "[Device NameSpace] $nameSpace\n"
+                        names.forEach { name ->
+                            nameSpaceText += "[DeviceEntry $name] ${
+                                String(
+                                    document.getDeviceEntryData(
+                                        nameSpace,
+                                        name
+                                    )
+                                )
+                            }\n"
+                        }
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 5.dp)
+                                .border(
+                                    1.dp,
+                                    SolidColor(MaterialTheme.colorScheme.outline),
+                                    CutCornerShape(5.dp)
+                                ),
+                            text = nameSpaceText
+                        )
+                    }
+
+                    var text = "[Document] ${document.docType}\n"
+                    text += "[Device NameSpaces] ${document.deviceNamespaces.joinToString()}\n"
+                    text += "[DeviceSigned was authenticated] ${document.deviceSignedAuthenticated}\n"
+                    text += "[DeviceSigned auth via signature ECDSA or MAC] ${document.deviceSignedAuthenticatedViaSignature}\n"
+                    text += "[Issuer NameSpaces] ${document.issuerNamespaces.joinToString()}\n"
+                    text += "[IssuerSigned was authenticated] ${document.issuerSignedAuthenticated}\n"
+                    text += "[Issuer Certificate Chain Count] ${document.issuerCertificateChain.size}\n"
+                    text += "[Issuer entries digest fail count] ${document.numIssuerEntryDigestMatchFailures}\n"
+                    text += "[ValidityInfo (MSO) expectedUpdate] ${
+                        document.validityInfoExpectedUpdate?.let { it1 ->
+                            millisecondsToFullDateTimeString(
+                                it1.toEpochMilli()
+                            )
+                        }
+                    }\n"
+                    text += "[ValidityInfo valid from] ${millisecondsToFullDateTimeString(document.validityInfoValidFrom.toEpochMilli())}\n"
+                    text += "[ValidityInfo valid until] ${millisecondsToFullDateTimeString(document.validityInfoValidUntil.toEpochMilli())}\n"
+                    text += "[ValidityInfo signed date] ${millisecondsToFullDateTimeString(document.validityInfoSigned.toEpochMilli())}"
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 5.dp)
+                            .border(
+                                1.dp,
+                                SolidColor(MaterialTheme.colorScheme.outline),
+                                CutCornerShape(5.dp)
+                            ),
+                        text = text
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryActions(
+    modifier: Modifier = Modifier,
+    enabledDeleteSelected: Boolean,
+    onDeleteSelected: () -> Unit,
+    enabledDeleteAll: Boolean,
+    onDeleteAll: () -> Unit
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        TextButton(
+            modifier = Modifier.weight(1f),
+            enabled = enabledDeleteSelected,
+            onClick = {
+                if (enabledDeleteSelected) {
+                    onDeleteSelected.invoke()
+                }
+            }
+        ) {
+            Text(text = stringResource(id = R.string.btn_log_delete_selected))
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Button(
+            modifier = Modifier.weight(1f),
+            enabled = enabledDeleteAll,
+            onClick = {
+                if (enabledDeleteAll) {
+                    onDeleteAll.invoke()
+                }
+            }
+        ) {
+            Text(text = stringResource(id = R.string.btn_log_delete_all))
+        }
+    }
+}

--- a/appholder/src/main/java/com/android/identity/wallet/presentationlog/PresentationHistoryViewModel.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/presentationlog/PresentationHistoryViewModel.kt
@@ -1,0 +1,47 @@
+package com.android.identity.wallet.presentationlog
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.identity.presentationlog.PresentationLogEntry
+import com.android.identity.presentationlog.PresentationLogStore
+import com.android.identity.wallet.util.ProvisioningUtil
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class PresentationHistoryViewModel(val app: Application) : AndroidViewModel(app) {
+
+    private val presentationHistoryStore: PresentationLogStore.PresentationHistoryStore =
+        ProvisioningUtil.getInstance(app.applicationContext).logStore.presentationHistoryStore
+
+    private val _logEntries = MutableStateFlow(listOf<PresentationLogEntry>())
+    val logEntries: StateFlow<List<PresentationLogEntry>>
+        get() = _logEntries.asStateFlow()
+
+
+    fun fetchPresentationLogHistory(): StateFlow<List<PresentationLogEntry>> {
+        val entries = presentationHistoryStore.fetchAllLogEntries()
+        viewModelScope.launch {
+            _logEntries.value = entries
+        }
+        return logEntries
+    }
+
+    fun deleteSelectedEntries(entryIds: List<Long>) {
+        viewModelScope.launch {
+            entryIds.forEach { entryId ->
+                presentationHistoryStore.deleteLogEntry(entryId)
+            }
+            fetchPresentationLogHistory()
+        }
+    }
+
+    fun deleteAllEntries() {
+        viewModelScope.launch {
+            presentationHistoryStore.deleteAllLogs()
+            fetchPresentationLogHistory()
+        }
+    }
+}

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
@@ -25,6 +25,8 @@ import com.android.identity.util.Timestamp
 import com.android.identity.wallet.document.DocumentManager
 import com.android.identity.wallet.documentdata.DocumentDataReader
 import com.android.identity.wallet.documentdata.DocumentElements
+import com.android.identity.presentationlog.PresentationLogStore
+import com.android.identity.util.EngagementTypeDef
 import com.android.identity.wallet.util.*
 import com.google.zxing.BarcodeFormat
 import com.google.zxing.MultiFormatWriter
@@ -46,6 +48,10 @@ class TransferManager private constructor(private val context: Context) {
                 instance ?: TransferManager(context).also { instance = it }
             }
     }
+
+    private val presentationLogStore: PresentationLogStore =
+        ProvisioningUtil.getInstance(context).logStore
+
 
     private var reversedQrCommunicationSetup: ReverseQrCommunicationSetup? = null
     private var qrCommunicationSetup: QrCommunicationSetup? = null
@@ -83,12 +89,21 @@ class TransferManager private constructor(private val context: Context) {
                 communication.setupPresentation(presentation)
             },
             onNewRequest = { request ->
+                presentationLogStore.newLogEntryWithRequest(
+                    request,
+                    communication.getSessionTranscript(),
+                    EngagementTypeDef.QR_CODE
+                )
                 communication.setDeviceRequest(request)
                 transferStatusLd.value = TransferStatus.REQUEST
             },
-            onDisconnected = { transferStatusLd.value = TransferStatus.DISCONNECTED },
+            onDisconnected = {
+                transferStatusLd.value = TransferStatus.DISCONNECTED
+                presentationLogStore.persistLogEntryTransactionDisconnected()
+            },
             onCommunicationError = { error ->
                 log("onError: ${error.message}")
+                presentationLogStore.persistLogEntryTransactionError(error)
                 transferStatusLd.value = TransferStatus.ERROR
             }
         ).apply {
@@ -111,12 +126,21 @@ class TransferManager private constructor(private val context: Context) {
                 transferStatusLd.value = TransferStatus.CONNECTED
             },
             onNewDeviceRequest = { deviceRequest ->
+                presentationLogStore.newLogEntryWithRequest(
+                    deviceRequest,
+                    communication.getSessionTranscript(),
+                    EngagementTypeDef.QR_CODE
+                )
                 communication.setDeviceRequest(deviceRequest)
                 transferStatusLd.value = TransferStatus.REQUEST
             },
-            onDisconnected = { transferStatusLd.value = TransferStatus.DISCONNECTED }
+            onDisconnected = {
+                transferStatusLd.value = TransferStatus.DISCONNECTED
+                presentationLogStore.persistLogEntryTransactionDisconnected()
+            }
         ) { error ->
             log("onError: ${error.message}")
+            presentationLogStore.persistLogEntryTransactionError(error)
             transferStatusLd.value = TransferStatus.ERROR
         }.apply {
             configure()
@@ -261,6 +285,8 @@ class TransferManager private constructor(private val context: Context) {
     }
 
     fun sendResponse(deviceResponse: ByteArray, closeAfterSending: Boolean) {
+        // log the response
+        presentationLogStore.logResponseData(deviceResponse)
         communication.sendResponse(deviceResponse, closeAfterSending)
         if (closeAfterSending) {
             disconnect()
@@ -278,5 +304,6 @@ class TransferManager private constructor(private val context: Context) {
 
     fun setResponseServed() {
         transferStatusLd.value = TransferStatus.REQUEST_SERVED
+        presentationLogStore.persistLogEntryTransactionComplete()
     }
 }

--- a/appholder/src/main/java/com/android/identity/wallet/util/FormatUtil.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/FormatUtil.kt
@@ -10,6 +10,7 @@ import java.io.ByteArrayOutputStream
 import java.security.PublicKey
 import java.security.interfaces.ECPublicKey
 import java.security.spec.ECPoint
+import java.text.DateFormat.getDateTimeInstance
 import kotlin.math.min
 
 
@@ -90,6 +91,16 @@ object FormatUtil {
 
     fun millisecondsToFullDateString(milliseconds: Long): String {
         val simpleDateFormat = SimpleDateFormat("yyyy-MM-dd")
+        return simpleDateFormat.format(milliseconds)
+    }
+
+    fun millisecondsToFullDateTimeString(milliseconds: Long): String {
+        val simpleDateFormat = SimpleDateFormat("MMM d, yyyy 'at' hh:mm:ss a")
+        return simpleDateFormat.format(milliseconds)
+    }
+
+    fun millisecondsToTimeString(milliseconds: Long): String {
+        val simpleDateFormat = SimpleDateFormat("hh:mm:ss a")
         return simpleDateFormat.format(milliseconds)
     }
 }

--- a/appholder/src/main/java/com/android/identity/wallet/viewmodel/TransferDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/viewmodel/TransferDocumentViewModel.kt
@@ -21,9 +21,11 @@ import com.android.identity.wallet.authconfirmation.RequestedElement
 import com.android.identity.wallet.authconfirmation.SignedElementsCollection
 import com.android.identity.wallet.document.DocumentInformation
 import com.android.identity.wallet.document.DocumentManager
+import com.android.identity.presentationlog.PresentationLogStore
 import com.android.identity.wallet.transfer.AddDocumentToResponseResult
 import com.android.identity.wallet.transfer.TransferManager
 import com.android.identity.wallet.util.PreferencesHelper
+import com.android.identity.wallet.util.ProvisioningUtil
 import com.android.identity.wallet.util.TransferStatus
 import com.android.identity.wallet.util.logWarning
 import kotlinx.coroutines.Dispatchers
@@ -39,6 +41,9 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
     private val closeConnectionMutableLiveData = MutableLiveData<Boolean>()
     private val selectedDocuments = mutableListOf<DocumentInformation>()
 
+    val presentationLogStore: PresentationLogStore =
+        ProvisioningUtil.getInstance(app.applicationContext).logStore
+
     var inProgress = ObservableInt(View.GONE)
     var documentsSent = ObservableField<String>()
     val connectionClosedLiveData: LiveData<Boolean> = closeConnectionMutableLiveData
@@ -48,6 +53,7 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
 
     fun onAuthenticationCancelled() {
         mutableConfirmationState.value = true
+        presentationLogStore.persistLogEntryTransactionCanceled()
     }
 
     fun onAuthenticationCancellationConsumed() {

--- a/appholder/src/main/res/menu/side_navigation_menu.xml
+++ b/appholder/src/main/res/menu/side_navigation_menu.xml
@@ -23,6 +23,14 @@
         android:title="@string/menu_reverse_engagement" />
 
     <item
+        android:id="@+id/presentationLogs"
+        android:enabled="true"
+        android:checkable="true"
+        android:icon="@android:drawable/ic_menu_recent_history"
+        android:title="@string/menu_history" />
+
+
+    <item
         android:id="@+id/settings"
         android:enabled="true"
         android:checkable="true"

--- a/appholder/src/main/res/navigation/navigation_graph.xml
+++ b/appholder/src/main/res/navigation/navigation_graph.xml
@@ -131,7 +131,7 @@
         <action
             android:id="@+id/openPassphrasePrompt"
             app:destination="@id/promptPassphrase"
-            app:popUpTo="@id/authConfirmation"/>
+            app:popUpTo="@id/authConfirmation" />
     </dialog>
     <fragment
         android:id="@+id/selfSignedDetails"
@@ -163,8 +163,13 @@
 
         <argument
             android:name="showIncorrectPassword"
-            app:argType="boolean"
-            android:defaultValue="false"/>
+            android:defaultValue="false"
+            app:argType="boolean" />
 
     </dialog>
+
+    <dialog
+        android:id="@+id/presentationLogs"
+        android:name="com.android.identity.wallet.presentationlog.PresentationHistoryFragment"
+        android:label="History" />
 </navigation>

--- a/appholder/src/main/res/values/strings.xml
+++ b/appholder/src/main/res/values/strings.xml
@@ -40,6 +40,8 @@
     <string name="bt_refresh_auth_keys">Refresh Auth Keys</string>
     <string name="label_refresh_auth_keys">Last Refresh Auth Keys</string>
     <string name="bt_present_documents">Present Documents</string>
+    <string name="btn_log_delete_selected">Delete Selected</string>
+    <string name="btn_log_delete_all">Delete All</string>
 
     <!-- mDL strings -->
     <string name="family_name">Family Name</string>
@@ -131,7 +133,10 @@
     <string name="menu_add_document">Add Document</string>
     <string name="menu_add_self_signed">Add Self Signed Document</string>
     <string name="menu_reverse_engagement">Reverse Engagement</string>
+    <string name="menu_history">History</string>
     <string name="menu_settings">Settings</string>
+
+    <string name="title_presentation_history">mDL Presentation History</string>
     <string name="tap_to_scan_nfc">NFC tap with mdoc reader</string>
     <string name="documents_pager_empty_view_title">No Documents</string>
     <string name="documents_pager_empty_view_message">Start by adding new one</string>

--- a/appverifier/build.gradle
+++ b/appverifier/build.gradle
@@ -72,6 +72,7 @@ dependencies {
     implementation libs.bundles.compose
     implementation libs.cbor
     implementation libs.code.scanner
+    implementation libs.play.services.location
 
     androidTestImplementation libs.bundles.ui.testing
 

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
@@ -23,10 +23,11 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.NavDirections
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
+import com.android.mdl.appreader.R
 import com.android.mdl.appreader.document.RequestDocument
 import com.android.mdl.appreader.document.RequestDocumentList
-import com.android.mdl.appreader.home.HomeScreen
 import com.android.mdl.appreader.home.CreateRequestViewModel
+import com.android.mdl.appreader.home.HomeScreen
 import com.android.mdl.appreader.theme.ReaderAppTheme
 import com.android.mdl.appreader.transfer.TransferManager
 import com.android.mdl.appreader.util.TransferStatus
@@ -36,25 +37,27 @@ class RequestOptionsFragment : Fragment() {
 
     private val createRequestViewModel: CreateRequestViewModel by activityViewModels()
     private val args: RequestOptionsFragmentArgs by navArgs()
-    private val appPermissions: List<String> get() {
-        val permissions = mutableListOf<String>()
-        if (android.os.Build.VERSION.SDK_INT >= 31) {
-            permissions.add(Manifest.permission.BLUETOOTH_ADVERTISE)
-            permissions.add(Manifest.permission.BLUETOOTH_SCAN)
-            permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
+    private val appPermissions: List<String>
+        get() {
+            val permissions = mutableListOf<String>()
+            if (android.os.Build.VERSION.SDK_INT >= 31) {
+                permissions.add(Manifest.permission.BLUETOOTH_ADVERTISE)
+                permissions.add(Manifest.permission.BLUETOOTH_SCAN)
+                permissions.add(Manifest.permission.BLUETOOTH_CONNECT)
+            }
+            return permissions
         }
-        return permissions
-    }
 
-    private val permissionsLauncher = registerForActivityResult(RequestMultiplePermissions()) { permissions ->
-        permissions.entries.forEach { permission ->
-            logDebug("permissionsLauncher ${permission.key} = ${permission.value}")
-            if (!permission.value && !shouldShowRequestPermissionRationale(permission.key)) {
-                openSettings()
-                return@registerForActivityResult
+    private val permissionsLauncher =
+        registerForActivityResult(RequestMultiplePermissions()) { permissions ->
+            permissions.entries.forEach { permission ->
+                logDebug("permissionsLauncher ${permission.key} = ${permission.value}")
+                if (!permission.value && !shouldShowRequestPermissionRationale(permission.key)) {
+                    openSettings()
+                    return@registerForActivityResult
+                }
             }
         }
-    }
 
     private lateinit var transferManager: TransferManager
 
@@ -140,6 +143,10 @@ class RequestOptionsFragment : Fragment() {
         } else {
             RequestOptionsFragmentDirections.toSelectTransport(requestedDocuments)
         }
+        if (findNavController().currentDestination?.id == R.id.presentationLogs) {
+            findNavController().popBackStack()
+        }
+
         findNavController().navigate(destination)
     }
 
@@ -189,7 +196,7 @@ class RequestOptionsFragment : Fragment() {
         findNavController().navigate(destination)
     }
 
-    private fun getCustomMdlDestination():NavDirections {
+    private fun getCustomMdlDestination(): NavDirections {
         val requestDocumentList = calcRequestDocumentList()
         val mdl = requestDocumentList.getAll().first { it.docType == RequestDocument.MDL_DOCTYPE }
         return RequestOptionsFragmentDirections.toRequestCustom(

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/TransferFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/TransferFragment.kt
@@ -10,6 +10,7 @@ import androidx.fragment.app.viewModels
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.android.mdl.appreader.R
+import com.android.mdl.appreader.VerifierApp
 import com.android.mdl.appreader.databinding.FragmentTransferBinding
 import com.android.mdl.appreader.document.RequestDocumentList
 import com.android.mdl.appreader.util.TransferStatus

--- a/appverifier/src/main/java/com/android/mdl/appreader/presentationlog/PresentationHistoryFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/presentationlog/PresentationHistoryFragment.kt
@@ -1,0 +1,561 @@
+package com.android.mdl.appreader.presentationlog
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.focusGroup
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.CutCornerShape
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.FilterChip
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateMapOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.activityViewModels
+import co.nstant.`in`.cbor.model.DataItem
+import co.nstant.`in`.cbor.model.Map
+import com.android.identity.internal.Util
+import com.android.identity.mdoc.request.DeviceRequestParser
+import com.android.identity.mdoc.response.DeviceResponseParser
+import com.android.identity.presentationlog.PresentationLogEntry
+import com.android.identity.presentationlog.PresentationLogMetadata
+import com.android.mdl.appreader.R
+import com.android.mdl.appreader.presentationlog.PresentationHistoryViewModel
+import com.android.mdl.appreader.theme.ReaderAppTheme
+import com.android.mdl.appreader.util.FormatUtil.millisecondsToFullDateTimeString
+import com.android.mdl.appreader.util.FormatUtil.millisecondsToTimeString
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import java.time.Duration
+import java.util.Locale
+
+
+class PresentationHistoryFragment : BottomSheetDialogFragment() {
+
+    private val viewModel: PresentationHistoryViewModel by activityViewModels()
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View {
+        return ComposeView(requireContext()).apply {
+            setContent {
+                val logEntries by viewModel.fetchPresentationLogHistory().collectAsState()
+                ReaderAppTheme {
+                    PresentationHistoryContainer(
+                        modifier = Modifier
+                            .fillMaxSize(),
+                        title = stringResource(id = R.string.title_presentation_history),
+                        logEntries = logEntries,
+                        onDeleteSelected = { entryIds ->
+                            viewModel.deleteSelectedEntries(entryIds)
+                        },
+                        onDeleteAll = {
+                            viewModel.deleteAllEntries()
+                        }
+                    )
+                }
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun PresentationHistoryContainer(
+    modifier: Modifier = Modifier,
+    title: String,
+    logEntries: List<PresentationLogEntry>,
+    onDeleteSelected: (List<Long>) -> Unit,
+    onDeleteAll: () -> Unit
+) {
+    val selectedEntries = remember { mutableStateMapOf<Long, Boolean>() }
+
+    Column(modifier = modifier) {
+        BottomSheetHandle(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(vertical = 8.dp)
+        )
+
+        Text(
+            text = title,
+            modifier = Modifier
+                .fillMaxWidth(),
+            textAlign = TextAlign.Center,
+            style = MaterialTheme.typography.titleMedium,
+            color = MaterialTheme.colorScheme.onSurface
+        )
+        Spacer(modifier = Modifier.height(16.dp))
+
+        HistoryActions(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(16.dp),
+            enabledDeleteSelected = selectedEntries.isNotEmpty(),
+            onDeleteSelected = {
+                onDeleteSelected.invoke(selectedEntries.keys.toList())
+            },
+            enabledDeleteAll = logEntries.isNotEmpty(),
+            onDeleteAll = {
+                onDeleteAll.invoke()
+            }
+        )
+
+        if (logEntries.isEmpty()) {
+            Text(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.titleMedium,
+                color = Color.LightGray,
+                text = "No recent history",
+            )
+        } else {
+            Box(
+                modifier = Modifier
+                    .fillMaxSize()
+            ) {
+                LazyColumn(modifier = Modifier.focusGroup()) {
+                    items(logEntries.size) { index ->
+                        val logEntry = logEntries[index]
+                        LogEntryRowContainer(
+                            entry = logEntry,
+                            onSelectedLogEntry = { entryId, checked ->
+                                if (!checked) {
+                                    selectedEntries.remove(entryId)
+                                } else {
+                                    selectedEntries[entryId] = true
+                                }
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun BottomSheetHandle(
+    modifier: Modifier = Modifier,
+) {
+    Row(modifier = modifier, horizontalArrangement = Arrangement.Center) {
+        Spacer(
+            modifier = Modifier
+                .size(64.dp, 4.dp)
+                .clip(RoundedCornerShape(4.dp))
+                .background(Color.Gray)
+        )
+    }
+}
+
+@Composable
+private fun LogEntryRowContainer(
+    modifier: Modifier = Modifier,
+    entry: PresentationLogEntry,
+    onSelectedLogEntry: (entryId: Long, checked: Boolean) -> Unit
+) {
+    Row(
+        modifier = modifier,
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        LogEntryRow(
+            logEntry = entry,
+            onSelectedLogEntry = { entryId, checked ->
+                onSelectedLogEntry.invoke(entryId, checked)
+            }
+        )
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun LogEntryRow(
+    modifier: Modifier = Modifier,
+    logEntry: PresentationLogEntry,
+    onSelectedLogEntry: (entryId: Long, checked: Boolean) -> Unit
+) {
+    var isChecked by remember { mutableStateOf(false) }
+
+    val request = logEntry.getRequest()
+    val response = logEntry.getResponse()
+    val metadata = logEntry.getMetadata()
+        ?: throw IllegalStateException("Expected PresentationLogEntry ${logEntry.id} to have the Metadata component persisted to StorageEngine but none could be found")
+
+    FilterChip(
+        modifier = modifier,
+        selected = isChecked,
+        onClick = {
+            isChecked = !isChecked
+            onSelectedLogEntry.invoke(logEntry.id, isChecked)
+        },
+        label = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                MetadataLogView(metadata = metadata)
+                RequestLogView(request = request)
+                ResponseLogView(response = response)
+            }
+        },
+
+        leadingIcon = {
+            Checkbox(
+                checked = isChecked,
+                onCheckedChange = {
+                    isChecked = !isChecked
+                    onSelectedLogEntry.invoke(logEntry.id, isChecked)
+                }
+            )
+        }
+    )
+}
+
+@Composable
+fun MetadataLogView(metadata: PresentationLogMetadata) {
+    val dateTimeStart = millisecondsToFullDateTimeString(metadata.transactionStartTime)
+    Text(
+        text = dateTimeStart,
+        style = MaterialTheme.typography.titleMedium
+    )
+    val duration = Duration.ofMillis(metadata.transactionEndTime - metadata.transactionStartTime)
+    val dateTimeEnd =
+        "Ended ${duration.seconds} seconds later (at ${millisecondsToTimeString(metadata.transactionEndTime)})"
+    Text(
+        text = dateTimeEnd,
+        style = MaterialTheme.typography.titleSmall
+    )
+    Spacer(modifier = Modifier.height(16.dp))
+
+    var metadataInfo = "Transaction status: ${metadata.presentationTransactionStatus.name}\n"
+    metadataInfo += "Engagement type: ${metadata.engagementType.name}\n"
+    metadataInfo += "Error: ${metadata.error}\n"
+    metadataInfo += "Session transcript length: ${metadata.sessionTranscript.size}\n"
+    val locationText =
+        "Location (lat,long): (${metadata.locationLatitude},${metadata.locationLongitude})"
+    val context = LocalContext.current
+    Text(
+        text = metadataInfo,
+        style = MaterialTheme.typography.bodyMedium
+    )
+    Text(
+        modifier = Modifier
+            .clickable {
+                val uri: String =
+                    java.lang.String.format(
+                        Locale.ENGLISH, "geo:%f,%f?q=%f,%f(mDL Presentation on $dateTimeStart)",
+                        metadata.locationLatitude,
+                        metadata.locationLongitude,
+                        metadata.locationLatitude,
+                        metadata.locationLongitude
+                    )
+                val intent = Intent(Intent.ACTION_VIEW, Uri.parse(uri))
+                context.startActivity(intent)
+            }
+            .padding(16.dp),
+        text = buildAnnotatedString {
+            append(locationText)
+            addStyle(
+                style = SpanStyle(
+                    fontWeight = FontWeight.Bold,
+                    textDecoration = TextDecoration.Underline
+                ),
+                start = 0,
+                end = locationText.length - 1
+            )
+        },
+    )
+}
+
+@Composable
+fun RequestLogView(request: DeviceRequestParser.DeviceRequest?) {
+    var showRequestDetails by remember { mutableStateOf(false) }
+
+    if (request == null) {
+        Text(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(start = 10.dp)
+                .border(
+                    2.dp,
+                    SolidColor(Color.Green),
+                    RoundedCornerShape(10.dp)
+                ),
+            text = "Request is null"
+        )
+    }
+
+    request?.let {
+        val multipleDocumentRequests = request.documentRequests.size > 1
+
+        if (multipleDocumentRequests) {
+            Text(
+                text = "${request.documentRequests.size} Document Requests",
+                style = MaterialTheme.typography.titleSmall,
+                color = Color.Cyan
+            )
+        }
+
+
+        request.documentRequests.forEach { docRequest ->
+            val requestHeader = "Request (v${request.version}) for Doc: ${docRequest.docType}"
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(start = 10.dp)
+                    .border(
+                        2.dp,
+                        SolidColor(Color.Green),
+                        RoundedCornerShape(10.dp)
+                    )
+                    .clickable {
+                        showRequestDetails = !showRequestDetails
+                    }
+            ) {
+                Text(
+                    modifier = Modifier.padding(16.dp),
+                    text = requestHeader
+                )
+
+                if (showRequestDetails) {
+                    val itemsRequest: DataItem = Util.cborDecode(docRequest.itemsRequest)
+                    val nameSpaces = Util.cborMapExtractMap(itemsRequest, "nameSpaces")
+                    val itemsMap = Util.castTo(Map::class.java, nameSpaces)
+                    itemsMap.keys.forEach { key ->
+                        val text = "[$key] => ${itemsMap[key]}"
+                        Text(
+                            modifier = Modifier
+                                .padding(start = 5.dp)
+                                .border(
+                                    1.dp,
+                                    SolidColor(MaterialTheme.colorScheme.outline),
+                                    CutCornerShape(5.dp)
+                                ),
+                            text = text
+                        )
+                    }
+                    val requestInfo = docRequest.requestInfo
+
+
+                    val requestText =
+                        "request info: ${requestInfo.size}, Reader Authentication: ${docRequest.readerAuth}"
+                    Text(
+                        modifier = Modifier
+                            .padding(start = 5.dp)
+                            .border(
+                                1.dp,
+                                SolidColor(MaterialTheme.colorScheme.outline),
+                                CutCornerShape(5.dp)
+                            ),
+                        text = requestText
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun ResponseLogView(response: DeviceResponseParser.DeviceResponse?) {
+    var showResponseDetails by remember { mutableStateOf(false) }
+
+    var responseHeader = "Response " +
+            if (response == null) {
+                "is null"
+            } else {
+                "(v ${response.version}) status: ${response.status}"
+            }
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(start = 10.dp)
+            .border(
+                2.dp,
+                SolidColor(Color.Yellow),
+                RoundedCornerShape(10.dp)
+            )
+            .clickable {
+                showResponseDetails = !showResponseDetails
+            }
+    ) {
+        Text(
+            modifier = Modifier.padding(16.dp),
+            text = responseHeader
+        )
+        if (showResponseDetails) {
+            val statusInfo = "[OK=0|General Err=10|Cbor Decoding Err=11|Cbor Violation Err=12]"
+            Text(
+                modifier = Modifier.padding(16.dp),
+                text = statusInfo
+            )
+            response?.let {
+                response.documents.forEach { document ->
+
+                    document.issuerNamespaces.forEach { nameSpace ->
+                        val names = document.getIssuerEntryNames(nameSpace)
+                        var nameSpaceText = "[Issuer NameSpace] $nameSpace\n"
+                        names.forEach { name ->
+                            nameSpaceText += "[IssuerEntry $name] ${
+                                if (name != "portrait")
+                                    String(
+                                        document.getIssuerEntryData(
+                                            nameSpace,
+                                            name
+                                        )
+                                    ) else "[bytes]"
+
+                            }\n"
+                        }
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 5.dp)
+                                .border(
+                                    1.dp,
+                                    SolidColor(MaterialTheme.colorScheme.outline),
+                                    CutCornerShape(5.dp)
+                                ),
+                            text = nameSpaceText
+                        )
+                    }
+
+                    document.deviceNamespaces.forEach { nameSpace ->
+                        val names = document.getDeviceEntryNames(nameSpace)
+                        var nameSpaceText = "[Device NameSpace] $nameSpace\n"
+                        names.forEach { name ->
+                            nameSpaceText += "[DeviceEntry $name] ${
+                                String(
+                                    document.getDeviceEntryData(
+                                        nameSpace,
+                                        name
+                                    )
+                                )
+                            }\n"
+                        }
+                        Text(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(start = 5.dp)
+                                .border(
+                                    1.dp,
+                                    SolidColor(MaterialTheme.colorScheme.outline),
+                                    CutCornerShape(5.dp)
+                                ),
+                            text = nameSpaceText
+                        )
+                    }
+
+                    var text = "[Document] ${document.docType}\n"
+                    text += "[Device NameSpaces] ${document.deviceNamespaces.joinToString()}\n"
+                    text += "[DeviceSigned was authenticated] ${document.deviceSignedAuthenticated}\n"
+                    text += "[DeviceSigned auth via signature ECDSA or MAC] ${document.deviceSignedAuthenticatedViaSignature}\n"
+                    text += "[Issuer NameSpaces] ${document.issuerNamespaces.joinToString()}\n"
+                    text += "[IssuerSigned was authenticated] ${document.issuerSignedAuthenticated}\n"
+                    text += "[Issuer Certificate Chain Count] ${document.issuerCertificateChain.size}\n"
+                    text += "[Issuer entries digest fail count] ${document.numIssuerEntryDigestMatchFailures}\n"
+                    text += "[ValidityInfo (MSO) expectedUpdate] ${
+                        document.validityInfoExpectedUpdate?.let { it1 ->
+                            millisecondsToFullDateTimeString(
+                                it1.toEpochMilli()
+                            )
+                        }
+                    }\n"
+                    text += "[ValidityInfo valid from] ${millisecondsToFullDateTimeString(document.validityInfoValidFrom.toEpochMilli())}\n"
+                    text += "[ValidityInfo valid until] ${millisecondsToFullDateTimeString(document.validityInfoValidUntil.toEpochMilli())}\n"
+                    text += "[ValidityInfo signed date] ${millisecondsToFullDateTimeString(document.validityInfoSigned.toEpochMilli())}"
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(start = 5.dp)
+                            .border(
+                                1.dp,
+                                SolidColor(MaterialTheme.colorScheme.outline),
+                                CutCornerShape(5.dp)
+                            ),
+                        text = text
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun HistoryActions(
+    modifier: Modifier = Modifier,
+    enabledDeleteSelected: Boolean,
+    onDeleteSelected: () -> Unit,
+    enabledDeleteAll: Boolean,
+    onDeleteAll: () -> Unit
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.SpaceEvenly
+    ) {
+        TextButton(
+            modifier = Modifier.weight(1f),
+            enabled = enabledDeleteSelected,
+            onClick = {
+                if (enabledDeleteSelected) {
+                    onDeleteSelected.invoke()
+                }
+            }
+        ) {
+            Text(text = stringResource(id = R.string.btn_log_delete_selected))
+        }
+        Spacer(modifier = Modifier.width(8.dp))
+        Button(
+            modifier = Modifier.weight(1f),
+            enabled = enabledDeleteAll,
+            onClick = {
+                if (enabledDeleteAll) {
+                    onDeleteAll.invoke()
+                }
+            }
+        ) {
+            Text(text = stringResource(id = R.string.btn_log_delete_all))
+        }
+    }
+}

--- a/appverifier/src/main/java/com/android/mdl/appreader/presentationlog/PresentationHistoryViewModel.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/presentationlog/PresentationHistoryViewModel.kt
@@ -1,0 +1,47 @@
+package com.android.mdl.appreader.presentationlog
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.android.identity.presentationlog.PresentationLogEntry
+import com.android.identity.presentationlog.PresentationLogStore
+import com.android.mdl.appreader.VerifierApp
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+class PresentationHistoryViewModel(val app: Application) : AndroidViewModel(app) {
+
+    private val presentationHistoryStore: PresentationLogStore.PresentationHistoryStore =
+        VerifierApp.presentationLogStoreInstance.presentationHistoryStore
+
+    private val _logEntries = MutableStateFlow(listOf<PresentationLogEntry>())
+    val logEntries: StateFlow<List<PresentationLogEntry>>
+        get() = _logEntries.asStateFlow()
+
+
+    fun fetchPresentationLogHistory(): StateFlow<List<PresentationLogEntry>> {
+        val entries = presentationHistoryStore.fetchAllLogEntries()
+        viewModelScope.launch {
+            _logEntries.value = entries
+        }
+        return logEntries
+    }
+
+    fun deleteSelectedEntries(entryIds: List<Long>) {
+        viewModelScope.launch {
+            entryIds.forEach { entryId ->
+                presentationHistoryStore.deleteLogEntry(entryId)
+            }
+            fetchPresentationLogHistory()
+        }
+    }
+
+    fun deleteAllEntries() {
+        viewModelScope.launch {
+            presentationHistoryStore.deleteAllLogs()
+            fetchPresentationLogHistory()
+        }
+    }
+}

--- a/appverifier/src/main/java/com/android/mdl/appreader/util/FormatUtil.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/util/FormatUtil.kt
@@ -1,5 +1,6 @@
 package com.android.mdl.appreader.util
 
+import android.icu.text.SimpleDateFormat
 import co.nstant.`in`.cbor.CborDecoder
 import co.nstant.`in`.cbor.CborException
 import co.nstant.`in`.cbor.model.AbstractFloat
@@ -193,5 +194,15 @@ object FormatUtil {
             }
         }
         return true
+    }
+
+    fun millisecondsToFullDateTimeString(milliseconds: Long): String {
+        val simpleDateFormat = SimpleDateFormat("MMM d, yyyy 'at' hh:mm:ss a")
+        return simpleDateFormat.format(milliseconds)
+    }
+
+    fun millisecondsToTimeString(milliseconds: Long): String {
+        val simpleDateFormat = SimpleDateFormat("hh:mm:ss a")
+        return simpleDateFormat.format(milliseconds)
     }
 }

--- a/appverifier/src/main/res/menu/side_navigation_menu.xml
+++ b/appverifier/src/main/res/menu/side_navigation_menu.xml
@@ -16,6 +16,13 @@
         android:title="@string/menu_reverse_engagement" />
 
     <item
+        android:id="@+id/presentationLogs"
+        android:enabled="true"
+        android:checkable="true"
+        android:icon="@android:drawable/ic_menu_recent_history"
+        android:title="@string/menu_history" />
+
+    <item
         android:id="@+id/settings"
         android:checkable="true"
         android:enabled="true"

--- a/appverifier/src/main/res/navigation/nav_graph.xml
+++ b/appverifier/src/main/res/navigation/nav_graph.xml
@@ -150,4 +150,9 @@
         android:id="@+id/caCertificateDetails"
         android:name="com.android.mdl.appreader.settings.CaCertificateDetailsFragment"
         android:label="Certificate Details" />
+
+    <dialog
+        android:id="@+id/presentationLogs"
+        android:name="com.android.identity.wallet.presentationlog.PresentationHistoryFragment"
+        android:label="History" />
 </navigation>

--- a/appverifier/src/main/res/values/strings.xml
+++ b/appverifier/src/main/res/values/strings.xml
@@ -106,6 +106,13 @@
     <!-- Side Menu Items -->
     <string name="menu_reader_home">Home</string>
     <string name="menu_reverse_engagement">Reverse Engagement</string>
+    <string name="menu_history">History</string>
     <string name="menu_settings">Settings</string>
+
+    <!-- Presentation History -->
+    <string name="title_presentation_history">mDL Presentation History</string>
+    <string name="btn_log_delete_selected">Delete Selected</string>
+    <string name="btn_log_delete_all">Delete All</string>
+
 
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -35,6 +35,7 @@
     junit-jupiter = "5.10.0"
     truth = "1.1.5"
     navigation-compose = "2.7.5"
+    play-services-location = "21.0.1"
 
 [libraries]
     androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
@@ -87,6 +88,7 @@
     kotlinx-coroutine-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines-version" }
     truth = { module = "com.google.truth:truth", version.ref = "truth" }
     androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigation-compose" }
+    play-services-location = { group = "com.google.android.gms", name = "play-services-location", version.ref = "play-services-location" }
 
 [bundles]
     androidx-core = ["androidx-core-ktx", "androidx-appcompat", "androidx-material", "androidx-contraint-layout", "androidx-fragment-ktx", "androidx-legacy-v4", "androidx-preference-ktx", "androidx-work"]

--- a/identity-android/src/androidTest/java/com/android/identity/presentationlog/PresentationLogStoreTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/presentationlog/PresentationLogStoreTest.kt
@@ -1,0 +1,418 @@
+package com.android.identity.presentationlog
+
+import android.content.Context
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.android.identity.android.storage.AndroidStorageEngine
+import com.android.identity.storage.StorageEngine
+import com.android.identity.util.EngagementTypeDef
+import org.junit.After
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.io.File
+
+@RunWith(AndroidJUnit4::class)
+class PresentationLogStoreTest {
+
+    private lateinit var storageEngine: StorageEngine
+    private lateinit var presentationLogStore: PresentationLogStore
+    private val presentationHistoryStore: PresentationLogStore.PresentationHistoryStore
+        get() = presentationLogStore.presentationHistoryStore
+    @Before
+    fun setUp() {
+        /**
+         * Localized function for obtaining identity storage location dir.
+         */
+        fun getKeystoreBackedStorageLocation(context: Context): File {
+            // As per the docs, the credential data contains reference to Keystore aliases so ensure
+            // this is stored in a location where it's not automatically backed up and restored by
+            // Android Backup as per https://developer.android.com/guide/topics/data/autobackup
+            val storageDir = File(context.noBackupFilesDir, "identity")
+            if (!storageDir.exists()) {
+                storageDir.mkdir()
+            }
+            return storageDir;
+        }
+
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val storageDir = getKeystoreBackedStorageLocation(context)
+        storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
+        presentationLogStore = PresentationLogStore(storageEngine)
+    }
+
+
+    /**
+     * After every test case, remove any persisted log entries.
+     */
+    @After
+    fun teardown() {
+        presentationLogStore.presentationHistoryStore.deleteAllLogs()
+    }
+
+    private object TestConst {
+        const val REQUEST_DATA_PREFIX = "Request_Data_"
+        const val RESPONSE_DATA_PREFIX = "Response_Data_"
+        const val ERROR_PREFIX = "ERROR_"
+    }
+
+    /**
+     * Singleton object providing functions that generate text during testing.
+     */
+    private object TestGen {
+        fun getSampleRequestText(id: Int) = TestConst.REQUEST_DATA_PREFIX + id
+        fun getSampleRequestBytes(id: Int) = getSampleRequestText(id).toByteArray()
+
+        fun getSampleResponseText(id: Int) = TestConst.RESPONSE_DATA_PREFIX + id
+        fun getSampleResponseBytes(id: Int) = getSampleResponseText(id).toByteArray()
+
+        fun getSampleErrorText(id: Int) = TestConst.ERROR_PREFIX + id
+        fun getSampleErrorThrowable(id: Int) = Throwable(getSampleErrorText(id))
+    }
+
+
+    /**
+     * Verify a single full entry with Request, Response and Metadata are logged properly
+     * which confirms the transaction's start and end timestamps, engagement type (NFC), and the
+     * data of request and response match what was asked to be logged.
+     */
+    @Test
+    fun logOneEntry_Component_Request_Response_1Metadata() {
+        val id = 10
+
+        val startTime = 1L
+        val endTime = 2L
+
+        // create a new log entry with sample request bytes
+        val entryBuilder = presentationLogStore.newLogEntryWithRequest(
+            TestGen.getSampleRequestBytes(id),
+            null,
+            EngagementTypeDef.NFC_STATIC_HANDOVER
+        )
+        entryBuilder.metadataBuilder.transactionStartTimestamp(startTime)
+        entryBuilder.metadataBuilder.transactionEndTimestamp(endTime)
+
+
+        // add the response
+        presentationLogStore.logResponseData(
+            data = TestGen.getSampleResponseBytes(id),
+            currentEntryId = entryBuilder.id
+        )
+        // mark that we have completed presentation (persist data to secure store)
+        presentationLogStore.persistLogEntryTransactionComplete(currentEntryId = entryBuilder.id)
+
+        // get all stored entries
+        val entries = presentationHistoryStore.fetchAllLogEntries()
+
+        // verify there's only 1 log entry stored
+        Assert.assertEquals(entries.size, 1)
+
+        val entry = entries.first()
+
+        // verify metadata was logged correctly by checking start & end millis and engagement type
+        val metadata = entry.getMetadata()
+        Assert.assertNotNull(metadata)
+        Assert.assertEquals(metadata!!.transactionStartTime, startTime)
+        Assert.assertEquals(metadata.transactionEndTime, endTime)
+        Assert.assertEquals(metadata.engagementType, EngagementTypeDef.NFC_STATIC_HANDOVER)
+
+        // verify the request data matches what was stored (string with ID, not necessarily a DeviceRequest object)
+        val requestBytes = entry.componentLogs[PresentationLogStore.LogComponent.Request]
+        Assert.assertNotNull(requestBytes)
+        Assert.assertEquals(java.lang.String(requestBytes), TestConst.REQUEST_DATA_PREFIX + id)
+
+        // verify the response data matches what was stored (string with ID, not necessarily a DeviceResponse object)
+        val responseBytes = entry.componentLogs[PresentationLogStore.LogComponent.Response]
+        Assert.assertNotNull(responseBytes)
+        Assert.assertEquals(java.lang.String(responseBytes), TestConst.RESPONSE_DATA_PREFIX + id)
+    }
+
+    /**
+     * Verify that we can log 1 entry with only metadata component (without request or response bytes)
+     * if an error was encountered.
+     */
+    @Test
+    fun logOneEntry_Transaction_Error_Component_Metadata() {
+        val id = 10
+        presentationLogStore.newLogEntryWithRequest(byteArrayOf(), null, EngagementTypeDef.NFC_STATIC_HANDOVER)
+        presentationLogStore.persistLogEntryTransactionError(TestGen.getSampleErrorThrowable(id))
+        // get all stored entries
+        val entries = presentationHistoryStore.fetchAllLogEntries()
+
+        // verify there's only 1 log entry stored
+        Assert.assertEquals(entries.size, 1)
+
+        val entry = entries.first()
+
+        // verify stored error matches what was thrown
+        val metadata = entry.getMetadata()
+        Assert.assertNotNull(metadata)
+        Assert.assertEquals(
+            metadata!!.presentationTransactionStatus,
+            PresentationLogMetadata.PresentationTransactionStatus.Error
+        )
+        Assert.assertEquals(metadata.error, TestGen.getSampleErrorText(id))
+
+        // verify there are no request bytes stored in store
+        val requestBytes = entry.componentLogs[PresentationLogStore.LogComponent.Request]
+        Assert.assertNull(requestBytes)
+        // verify there are no response bytes stored
+        val responseBytes = entry.componentLogs[PresentationLogStore.LogComponent.Response]
+        Assert.assertNull(responseBytes)
+    }
+
+    /**
+     * Verify that we can log 3 entries testing for:
+     * - 1, 2 or 3 components being logged per entry
+     * - engagement types are persisted and retrieved correctly: NFC, QR, Unattended
+     * - transaction statuses are persisted and retrieved correctly: Canceled, Disconnected, Error
+     *
+     * where:
+     *
+     * - first entry has all 3 components (request, response, metadata), NFC engagement, Disconnected status
+     * - second entry has 2 components (request, metadata) due to di, QR engagement, Canceled status
+     * - third entry has 1 component (metadata) due to , UNATTENDED engagement, Error status
+     */
+    @Test
+    fun logOneEntry_Transaction_Error_Component_Request_Metadata() {
+        // define first log entry
+        val firstId = 10
+        val firstEngagement = EngagementTypeDef.NFC_STATIC_HANDOVER
+        val firstStatus = PresentationLogMetadata.PresentationTransactionStatus.Disconnected
+
+        // insert first log entry
+        presentationLogStore.newLogEntryWithRequest(
+            TestGen.getSampleRequestBytes(firstId),
+            null,
+            firstEngagement
+        )
+        presentationLogStore.logResponseData(TestGen.getSampleResponseBytes(firstId))
+        presentationLogStore.persistLogEntryTransactionDisconnected() // mark as disconnected (and persist this entry)
+
+        // define second log entry
+        val secondId = 20
+        val secondEngagement = EngagementTypeDef.QR_CODE
+        val secondStatus = PresentationLogMetadata.PresentationTransactionStatus.Canceled
+
+        // insert second log entry
+        presentationLogStore.newLogEntryWithRequest(
+            TestGen.getSampleRequestBytes(secondId),
+            null,
+            secondEngagement
+        )
+        presentationLogStore.persistLogEntryTransactionCanceled() // mark as canceled (and persist)
+
+
+        // define third log entry
+        val thirdId = 30
+        val thirdEngagement = EngagementTypeDef.UNATTENDED
+        val thirdStatus = PresentationLogMetadata.PresentationTransactionStatus.Error
+
+        // insert third log entry
+        presentationLogStore.newLogEntryWithRequest(byteArrayOf(), null, thirdEngagement)
+        presentationLogStore.persistLogEntryTransactionError(TestGen.getSampleErrorThrowable(thirdId)) // mark as error (and persist)
+
+        ////////////////////////////////////////////
+
+        // get all stored entries, in descending order (last entry is first)
+        val entries = presentationHistoryStore.fetchAllLogEntries()
+
+
+        // verify there's 3 stored entries
+        Assert.assertEquals(entries.size, 3)
+
+        // verify third entry components
+        val thirdEntry = entries[0]
+        val thirdMetadata = thirdEntry.getMetadata()
+        Assert.assertNotNull(thirdMetadata)
+        Assert.assertEquals(thirdMetadata!!.presentationTransactionStatus, thirdStatus)
+        Assert.assertEquals(thirdMetadata.error, TestGen.getSampleErrorText(thirdId))
+        Assert.assertEquals(thirdMetadata.engagementType, thirdEngagement)
+        // verify third entry request
+        val thirdRequestBytes = thirdEntry.componentLogs[PresentationLogStore.LogComponent.Request]
+        Assert.assertNull(thirdRequestBytes)
+        // verify third entry response
+        val thirdResponseBytes =
+            thirdEntry.componentLogs[PresentationLogStore.LogComponent.Response]
+        Assert.assertNull(thirdResponseBytes)
+
+        // verify second entry components
+        val secondEntry = entries[1]
+        val secondMetadata = secondEntry.getMetadata()
+        Assert.assertNotNull(secondMetadata)
+        Assert.assertEquals(secondMetadata!!.presentationTransactionStatus, secondStatus)
+        Assert.assertEquals(secondMetadata.engagementType, secondEngagement)
+        // verify second entry request
+        val secondRequestBytes =
+            secondEntry.componentLogs[PresentationLogStore.LogComponent.Request]
+        Assert.assertNotNull(secondRequestBytes)
+        Assert.assertEquals(String(secondRequestBytes!!), TestGen.getSampleRequestText(secondId))
+        // verify second entry response
+        val secondResponseBytes =
+            secondEntry.componentLogs[PresentationLogStore.LogComponent.Response]
+        Assert.assertNull(secondResponseBytes)
+
+        // verify first entry components
+        val firstEntry = entries[2]
+        val firstMetadata = firstEntry.getMetadata()
+        Assert.assertNotNull(firstMetadata)
+        Assert.assertEquals(firstMetadata!!.presentationTransactionStatus, firstStatus)
+        Assert.assertEquals(firstMetadata.engagementType, firstEngagement)
+        // verify first entry request
+        val firstRequestBytes = firstEntry.componentLogs[PresentationLogStore.LogComponent.Request]
+        Assert.assertNotNull(firstRequestBytes)
+        Assert.assertEquals(String(firstRequestBytes!!), TestGen.getSampleRequestText(firstId))
+        // verify first entry response
+        val firstResponseBytes =
+            firstEntry.componentLogs[PresentationLogStore.LogComponent.Response]
+        Assert.assertNotNull(firstResponseBytes)
+        Assert.assertEquals(String(firstResponseBytes!!), TestGen.getSampleResponseText(firstId))
+    }
+
+    /**
+     * Verify that deleting a single entry from 3 works without affecting other entries.
+     */
+    @Test
+    fun log3Entries_delete1Entry() {
+        // insert 3 entries
+        for (i in 1..3) {
+            val entryBuilder = presentationLogStore.newLogEntryWithRequest(
+                TestGen.getSampleRequestBytes(i),
+                null,
+                EngagementTypeDef.NFC_STATIC_HANDOVER
+            )
+
+            entryBuilder.metadataBuilder.transactionStartTimestamp(i * 1L)
+            entryBuilder.metadataBuilder.transactionEndTimestamp(i * (10L + i))
+
+            presentationLogStore.logResponseData(TestGen.getSampleResponseBytes(i))
+            presentationLogStore.persistLogEntryTransactionComplete()
+        }
+
+        // get entries in ascending order, delete the first (oldest entry, smallest timestamp)
+        val entries = presentationHistoryStore.fetchAllLogEntries().sortedBy { it.id }
+        Assert.assertEquals(entries.size, 3)
+
+        val oldest = entries[0]
+        val mid = entries[1]
+        val youngest = entries[2]
+
+        // delete first entry
+        presentationHistoryStore.deleteLogEntry(oldest.id)
+
+        // get new entries, verify count is 2
+        val newEntries = presentationHistoryStore.fetchAllLogEntries().sortedBy { it.id }
+        Assert.assertEquals(newEntries.size, 2)
+
+        // verify the entries that remain are not the oldest entry
+        Assert.assertEquals(newEntries[0].id, mid.id)
+        Assert.assertEquals(newEntries[1].id, youngest.id)
+    }
+
+    /**
+     * Add 3 entries, delete 2 youngest entries, verify the oldest entry remains
+     */
+    @Test
+    fun log3Entries_delete2Entries() {
+        // insert 3 entries
+        for (i in 1..3) {
+            val entryBuilder = presentationLogStore.newLogEntryWithRequest(
+                TestGen.getSampleRequestBytes(i),
+                null,
+                EngagementTypeDef.NFC_STATIC_HANDOVER
+            )
+
+            entryBuilder.metadataBuilder.transactionStartTimestamp(i * 1L)
+            entryBuilder.metadataBuilder.transactionEndTimestamp(i * (10L + i))
+
+            presentationLogStore.logResponseData(TestGen.getSampleResponseBytes(i))
+            presentationLogStore.persistLogEntryTransactionComplete()
+        }
+
+        // get entries in ascending order, delete the first (oldest entry, smallest timestamp)
+        val entries = presentationHistoryStore.fetchAllLogEntries().sortedBy { it.id }
+        Assert.assertEquals(entries.size, 3)
+
+        val oldest = entries[0]
+        val mid = entries[1]
+        val youngest = entries[2]
+
+        // delete 2 oldest entries
+        presentationHistoryStore.deleteLogEntry(oldest.id)
+        presentationHistoryStore.deleteLogEntry(mid.id)
+
+        // get new entries, verify count is 1
+        val newEntries = presentationHistoryStore.fetchAllLogEntries().sortedBy { it.id }
+        Assert.assertEquals(newEntries.size, 1)
+
+        // verify the only remaining entry is the oldest entry
+        Assert.assertEquals(newEntries[0].id, youngest.id)
+    }
+
+    /**
+     * Test PresentationHistoryStore by deleting all log entries after adding 20 entries.
+     */
+    @Test
+    fun log20Entries_deleteAllEntries() {
+        // insert 20 entries
+        for (i in 1..20) {
+            presentationLogStore.newLogEntryWithRequest(
+                TestGen.getSampleRequestBytes(i),
+                null,
+                EngagementTypeDef.NFC_STATIC_HANDOVER
+            )
+            presentationLogStore.logResponseData(TestGen.getSampleResponseBytes(i))
+            presentationLogStore.persistLogEntryTransactionComplete()
+        }
+
+        // get entries in ascending order, delete the first (oldest entry, smallest timestamp)
+        val entries = presentationHistoryStore.fetchAllLogEntries()
+        Assert.assertEquals(entries.size, 20)
+
+        // delete all logs
+        presentationHistoryStore.deleteAllLogs()
+
+        // get new list of logs
+        val newEntries = presentationHistoryStore.fetchAllLogEntries()
+
+        // confirm there are no presentation logs persisted in StorageEngine
+        Assert.assertEquals(newEntries.size, 0)
+    }
+
+    /**
+     * Test enforcement of MAX_ENTRIES_COUNT by adding MAX_ENTRIES_COUNT entries and verifying the
+     * count of stored entries matches MAX_ENTRIES_COUNT, then add 1 more entry and confirm the count
+     * of stored entries continues to match MAX_ENTRIES_COUNT.l
+     */
+    @Test
+    fun maxEntriesEnforcement() {
+        // add as many entries as defined in PresentationLogStore.StoreConst.MAX_ENTRIES
+        for (i in 1..PresentationLogStore.StoreConst.MAX_ENTRIES_COUNT) {
+            presentationLogStore.newLogEntryWithRequest(
+                TestGen.getSampleRequestBytes(i),
+                null,
+                EngagementTypeDef.NFC_STATIC_HANDOVER
+            )
+            presentationLogStore.logResponseData(TestGen.getSampleResponseBytes(i))
+            presentationLogStore.persistLogEntryTransactionComplete()
+        }
+
+        // confirm there are MAX_ENTRIES_COUNT in StorageEngine
+        val entries = presentationHistoryStore.fetchAllLogEntries()
+        Assert.assertEquals(entries.size, PresentationLogStore.StoreConst.MAX_ENTRIES_COUNT)
+
+        // add 1 more entry
+        presentationLogStore.newLogEntryWithRequest(
+            TestGen.getSampleRequestBytes(200),
+            null,
+            EngagementTypeDef.NFC_STATIC_HANDOVER
+        )
+        presentationLogStore.logResponseData(TestGen.getSampleResponseBytes(200))
+        presentationLogStore.persistLogEntryTransactionComplete()
+
+        // verify that we still have at most MAX_ENTRIES_COUNT entries in StorageEngine
+        val newEntries = presentationHistoryStore.fetchAllLogEntries()
+        Assert.assertEquals(newEntries.size, PresentationLogStore.StoreConst.MAX_ENTRIES_COUNT)
+    }
+}

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.java
@@ -16,6 +16,11 @@
 
 package com.android.identity.android.mdoc.deviceretrieval;
 
+import static com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_NFC_NEGOTIATED_HANDOVER;
+import static com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_NFC_STATIC_HANDOVER;
+import static com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_NOT_ENGAGED;
+import static com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_QR_CODE;
+import static com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_REVERSE;
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 import android.content.Context;
@@ -44,7 +49,6 @@ import com.android.identity.mdoc.engagement.EngagementGenerator;
 import com.android.identity.mdoc.engagement.EngagementParser;
 import com.android.identity.mdoc.request.DeviceRequestGenerator;
 import com.android.identity.mdoc.response.DeviceResponseParser;
-import com.android.identity.securearea.SecureArea;
 import com.android.identity.util.Constants;
 import com.android.identity.util.Logger;
 import com.android.identity.internal.Util;
@@ -81,14 +85,7 @@ import co.nstant.in.cbor.model.SimpleValue;
 // cleaned up at object finalization time.
 @SuppressWarnings("NotCloseable")
 public class VerificationHelper {
-
     private static final String TAG = "VerificationHelper";
-
-    public static final int ENGAGEMENT_METHOD_NOT_ENGAGED = 0;
-    public static final int ENGAGEMENT_METHOD_QR_CODE = 1;
-    public static final int ENGAGEMENT_METHOD_NFC_STATIC_HANDOVER = 2;
-    public static final int ENGAGEMENT_METHOD_NFC_NEGOTIATED_HANDOVER = 3;
-    public static final int ENGAGEMENT_METHOD_REVERSE = 4;
 
     @Retention(RetentionPolicy.SOURCE)
     @IntDef(flag = false,

--- a/identity/src/main/java/com/android/identity/mdoc/request/DeviceRequestParser.java
+++ b/identity/src/main/java/com/android/identity/mdoc/request/DeviceRequestParser.java
@@ -16,6 +16,8 @@
 
 package com.android.identity.mdoc.request;
 
+import static java.rmi.server.LogStream.log;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -242,6 +244,7 @@ public final class DeviceRequestParser {
                             requestInfo.put(key, encodedValue);
                         }
                     }
+
 
                     String docType = Util.cborMapExtractString(itemsRequest, "docType");
                     DocumentRequest.Builder builder = new DocumentRequest.Builder(docType,

--- a/identity/src/main/java/com/android/identity/presentationlog/PresentationLogEntry.kt
+++ b/identity/src/main/java/com/android/identity/presentationlog/PresentationLogEntry.kt
@@ -1,0 +1,124 @@
+package com.android.identity.presentationlog
+
+import androidx.annotation.VisibleForTesting
+import com.android.identity.mdoc.request.DeviceRequestParser
+import com.android.identity.mdoc.response.DeviceResponseParser
+import com.android.identity.util.Timestamp
+
+/**
+ * PresentationLogEntry is a log entry captures logs from all PresentationLogComponent components through a Builder
+ * which populates
+ */
+class PresentationLogEntry private constructor(
+    val id: Long,
+    @get:VisibleForTesting
+    val componentLogs: MutableMap<PresentationLogStore.LogComponent, ByteArray>,
+) {
+    // simple ephemeral cache for optimizing composable calls
+    private var requestCached: DeviceRequestParser.DeviceRequest? = null
+    private var responseCached: DeviceResponseParser.DeviceResponse? = null
+    private var metadataCached: PresentationLogMetadata? = null
+
+    /**
+     * Return the DeviceRequest object extracted from the passed-in bytes.
+     */
+    fun getRequest(): DeviceRequestParser.DeviceRequest? {
+        val requestBytes = getLogComponentBytes(LogComponent.Request)
+        val metadata = getMetadata()
+        if (requestBytes.isEmpty() || metadata == null) return null
+
+        if (requestCached == null) {
+            val requestParser = DeviceRequestParser()
+            requestParser.setSessionTranscript(metadata.sessionTranscript)
+            requestParser.setDeviceRequest(requestBytes)
+            requestCached = requestParser.parse()
+        }
+
+        return requestCached
+    }
+
+    /**
+     * Return the DeviceResponse object extracted from the passed-in bytes.
+     */
+    fun getResponse(): DeviceResponseParser.DeviceResponse? {
+        val responseBytes = getLogComponentBytes(LogComponent.Response)
+        val metadata = getMetadata()
+        if (responseBytes.isEmpty() || metadata == null) return null
+        if (responseCached == null) {
+            val responseParser = DeviceResponseParser()
+            responseParser.setDeviceResponse(responseBytes)
+            responseParser.setSessionTranscript(metadata.sessionTranscript)
+            responseCached = responseParser.parse()
+        }
+        return responseCached
+    }
+
+    /**
+     * Return the PresentationLogMetadata object extracted from the passed-in bytes.
+     */
+    fun getMetadata(): PresentationLogMetadata? {
+        if (metadataCached == null) {
+            val metadataBytes = getLogComponentBytes(LogComponent.Metadata)
+            if (metadataBytes.isEmpty()) return null
+            metadataCached = PresentationLogMetadata.fromCborBytes(metadataBytes)
+        }
+
+        return metadataCached
+    }
+
+    /**
+     * Return the (CBOR encoded) bytes of the specified PresentationLogComponent
+     */
+    fun getLogComponentBytes(logComponent: LogComponent) =
+        componentLogs[logComponent] ?: byteArrayOf()
+
+    /**
+     * Builder of PresentationLogEntry - which is comprised of bytes for every PresentationLogComponent.
+     * The ID of each log entry is the timestamp in milliseconds of when the Builder() was instantiated.
+     */
+    data class Builder(
+        private val _id: Long = Timestamp.now().toEpochMilli(),
+        private val componentLogs: MutableMap<LogComponent, ByteArray> = mutableMapOf(),
+        private var wasBuilt: Boolean = false,
+        // internal instance with public getter
+        private val _metadataBuilder: PresentationLogMetadata.Builder =
+            PresentationLogMetadata.Builder(transactionStartTime = _id)
+    ) {
+        val id: Long
+            get() = _id
+        val metadataBuilder: PresentationLogMetadata.Builder
+            get() = _metadataBuilder
+
+        /**
+         * Add a LogComponent to the log entry
+         */
+        fun addComponentLogBytes(logComponent: LogComponent, data: ByteArray) = apply {
+            componentLogs[logComponent] = data
+        }
+
+        fun wasNotBuilt() = !wasBuilt
+
+        fun build(): PresentationLogEntry {
+            // mark as was/being built
+            wasBuilt = true
+
+            // either use bytes read from StorageEngine or extract from metadata builder
+            ensureMetadataIsLogged()
+
+            // return a new instance of PresentationLogEntry
+            return PresentationLogEntry(id, componentLogs)
+        }
+
+        /**
+         * Ensure the correct metadata bytes are populated in the new instance of PresentationLogEntry
+         */
+        private fun ensureMetadataIsLogged() {
+            // if we don't already have the bytes of metadata, extract from current metadata builder
+            if (componentLogs[PresentationLogStore.LogComponent.Metadata] == null) {
+                // add metadata component to componentLogs
+                componentLogs[PresentationLogStore.LogComponent.Metadata] =
+                    _metadataBuilder.build().cborDataBytes
+            }
+        }
+    }
+}

--- a/identity/src/main/java/com/android/identity/presentationlog/PresentationLogMetadata.kt
+++ b/identity/src/main/java/com/android/identity/presentationlog/PresentationLogMetadata.kt
@@ -1,0 +1,166 @@
+package com.android.identity.presentationlog
+
+import androidx.annotation.VisibleForTesting
+import co.nstant.`in`.cbor.CborBuilder
+import co.nstant.`in`.cbor.CborEncoder
+import com.android.identity.internal.Util
+import com.android.identity.util.EngagementTypeDef
+import com.android.identity.util.Timestamp
+import java.io.ByteArrayOutputStream
+
+class PresentationLogMetadata private constructor(
+    val presentationTransactionStatus: PresentationTransactionStatus,
+    val engagementType: EngagementTypeDef,
+    val error: String = "",
+    val transactionStartTime: Long,
+    val transactionEndTime: Long,
+    val sessionTranscript: ByteArray,
+    val locationLatitude: Double = 0.0,
+    val locationLongitude: Double = 0.0
+) {
+
+    // return instance data in CBOR encoded format
+    val cborDataBytes: ByteArray
+        get() = ByteArrayOutputStream().apply {
+            CborEncoder(this).encode(
+                CborBuilder().addMap()
+                    .put("transaction_status", presentationTransactionStatus.code)
+                    .put("engagement_type", engagementType.name)
+                    .put("error", error)
+                    .put("transaction_start", transactionStartTime)
+                    .put("transaction_end", transactionEndTime)
+                    .put("session_transcript", sessionTranscript)
+                    .put("location_latitude", locationLatitude.toString())
+                    .put("location_longitude", locationLongitude.toString())
+                    .end()
+                    .build()
+            )
+        }.toByteArray()
+
+    companion object {
+        /**
+         * Return a new instance of PresentationLogMetadata extracted from the passed-in CBOR encoded bytes
+         */
+        fun fromCborBytes(cborData: ByteArray): PresentationLogMetadata {
+            val metadataItem = Util.cborDecode(cborData)
+            return PresentationLogMetadata(
+                PresentationTransactionStatus.fromNumber(
+                    Util.cborMapExtractNumber(metadataItem, "transaction_status"),
+                ),
+                EngagementTypeDef.fromString(
+                    Util.cborMapExtractString(metadataItem, "engagement_type")
+                ),
+                Util.cborMapExtractString(metadataItem, "error"),
+                Util.cborMapExtractNumber(metadataItem, "transaction_start"),
+                Util.cborMapExtractNumber(metadataItem, "transaction_end"),
+                Util.cborMapExtractByteString(metadataItem, "session_transcript"),
+                Util.cborMapExtractString(metadataItem, "location_latitude").toDouble(),
+                Util.cborMapExtractString(metadataItem, "location_longitude").toDouble(),
+            )
+        }
+    }
+
+    /**
+     * Defines the different types of statuses the end result of an mDL Presentation can be in
+     */
+    enum class PresentationTransactionStatus(val code: Long) {
+        Complete(10), // everything went to plan
+
+        Canceled(100), // user invoked cancellation
+
+        Disconnected(200), // abrupt disconnection
+
+        Error(300), // there was an error completing th presentation
+
+        None(0) // default, uninitialized/unused
+        ;
+
+        companion object {
+            /**
+             * Given a status code integer, return the corresponding matching enum, or return None
+             * if the specified code doesn't match any of the existing status codes
+             */
+            fun fromNumber(code: Long) =
+                PresentationTransactionStatus.values().firstOrNull {
+                    it.code == code
+                } ?: None
+        }
+    }
+
+    data class Builder(
+        // provided from new instance of PresentationLogEntry.Builder
+        private var transactionStartTime: Long,
+        private var engagementType: EngagementTypeDef = EngagementTypeDef.NOT_ENGAGED,
+        private var presentationTransactionStatus: PresentationTransactionStatus = PresentationTransactionStatus.None,
+        private var error: Throwable? = null,
+        private var transactionEndTime: Long = 0L,
+        private var sessionTranscript: ByteArray = byteArrayOf(),
+        private var locationLatitude: Double = 0.0,
+        private var locationLongitude: Double = 0.0
+    ) {
+        /**
+         * This function should not be accessible publicly since it's set when a PresentationLogEntry is instantiated
+         */
+        @VisibleForTesting
+        fun transactionStartTimestamp(startMillis: Long) = apply {
+            transactionStartTime = startMillis
+        }
+
+        fun engagementType(engagementType: EngagementTypeDef) = apply {
+            this.engagementType = engagementType
+        }
+
+        fun transactionStatus(status: PresentationTransactionStatus) = apply {
+            this.presentationTransactionStatus = status
+        }
+
+        fun transactionEndTimestamp(endMillis: Long? = null) = apply {
+            if (transactionEndTime == 0L) { // if it's been previously set, don't change it
+                transactionEndTime = endMillis ?: Timestamp.now().toEpochMilli()
+            }
+        }
+
+        fun transactionComplete() = apply {
+            transactionStatus(PresentationTransactionStatus.Complete)
+            transactionEndTimestamp()
+        }
+
+        fun transactionCanceled() = apply {
+            transactionStatus(PresentationTransactionStatus.Canceled)
+            transactionEndTimestamp()
+        }
+
+        fun transactionDisconnected() = apply {
+            transactionStatus(PresentationTransactionStatus.Disconnected)
+            transactionEndTimestamp()
+        }
+
+        fun transactionError(throwable: Throwable? = null) = apply {
+            transactionStatus(PresentationTransactionStatus.Error)
+            throwable?.let {
+                error = throwable
+            }
+        }
+
+        fun sessionTranscript(byteArray: ByteArray) = apply {
+            sessionTranscript = byteArray
+        }
+
+        fun location(latitude: Double, longitude: Double) = apply {
+            locationLatitude = latitude
+            locationLongitude = longitude
+        }
+
+        fun build() =
+            PresentationLogMetadata(
+                engagementType = engagementType,
+                presentationTransactionStatus = presentationTransactionStatus,
+                error = error?.message ?: "",
+                transactionStartTime = transactionStartTime,
+                transactionEndTime = transactionEndTime,
+                sessionTranscript = sessionTranscript,
+                locationLatitude = locationLatitude,
+                locationLongitude = locationLongitude
+            )
+    }
+}

--- a/identity/src/main/java/com/android/identity/presentationlog/PresentationLogStore.kt
+++ b/identity/src/main/java/com/android/identity/presentationlog/PresentationLogStore.kt
@@ -1,0 +1,309 @@
+package com.android.identity.presentationlog
+
+import androidx.annotation.VisibleForTesting
+import com.android.identity.storage.StorageEngine
+import com.android.identity.util.EngagementTypeDef
+
+typealias LogComponent = PresentationLogStore.LogComponent
+
+/**
+ * A Log Store that is used to form and persist all components of a PresentationLogEntry.
+ * It also provides a History Store for obtaining previously persisted log entries (list of PresentationLogEntry)
+ */
+class PresentationLogStore(
+    private val storageEngine: StorageEngine,
+) {
+    // public access of the history store
+    val presentationHistoryStore = PresentationHistoryStore(storageEngine)
+
+    // last known location lat/long
+    var locationLatitude: Double = 0.0
+    var locationLongitude: Double = 0.0
+
+    /**
+     * Defines the different components that can be logged as part of a log entry.
+     * Every component has its own record/entry in [StorageEngine] belonging to a common log entry id.
+     */
+    enum class LogComponent {
+        Request,
+        Response,
+        Metadata,
+        ;
+
+        /**
+         * Const object to differentiate from enum names.
+         * i.e. if we added const vals to the companion object then LogComponent.COMPONENT_PREFIX
+         * would give the illusion of being an enum, which is not.
+         */
+        object Const {
+            const val COMPONENT_PREFIX = "_CMPNT_"
+        }
+
+        /**
+         * Return the store key for storing/retrieving bytes of a LogComponent in [StorageEngine].
+         */
+        fun getStoreKey(logEntryId: Long) = StoreConst.LOG_PREFIX +
+                logEntryId +
+                Const.COMPONENT_PREFIX +
+                name
+    }
+
+    /**
+     * Const object (rather than companion) dedicated to providing constants
+     */
+    @VisibleForTesting
+    object StoreConst {
+        // used for identifying entries belonging to PresentationLogStore when persisting logs in the StorageEngine
+        const val LOG_PREFIX = "IC_Log_"
+
+        // whether or not to enforce a limit to the number of log entries that are persisted to [StorageEngine]
+        const val MAX_ENTRIES_ENFORCEMENT = true
+
+        // retain a history of the last MAX_ENTRIES number of log entries
+        const val MAX_ENTRIES_COUNT = 100
+    }
+
+    // async instances of PresentationLogEntry.Builder that get deleted once they're persisted to StorageEngine
+    private val currentEntries = mutableListOf<PresentationLogEntry.Builder>()
+
+    /**
+     * Return a new or existing [PresentationLogEntry.Builder] instance according to which instances
+     * are lingering around in [currentEntries]
+     */
+    private fun getCurrentLogEntryBuilder(
+        newInstance: Boolean = false,
+        havingId: Long? = null
+    ): PresentationLogEntry.Builder {
+        // immediately create a new PresentationLogEntry.Builder instance and return it
+        if (newInstance) {
+            val newEntryBuilder = PresentationLogEntry.Builder()
+            currentEntries.add(newEntryBuilder)
+            return newEntryBuilder
+        }
+
+        // iterate through all log entry builder instances
+        currentEntries.forEach { currentEntryBuilder ->
+            // return the entry instance that has not been persisted yet
+            if (currentEntryBuilder.id == havingId // and matches specified ID
+                // or entry has not been built (is actively being populated)
+                || currentEntryBuilder.wasNotBuilt()
+            ) {
+                return currentEntryBuilder
+            }
+        }
+
+        // reaching here means we were asked to get instance with specified ID but were unable to find it
+        if (havingId != null) {
+            throw IllegalArgumentException("Could not find PresentationLogEntry instance with specified id $havingId")
+        }
+
+        // reaching here means either all log entry instances are actively being persisted or
+        // there are is no log active/new entry being populated
+        val newEntryBuilder = PresentationLogEntry.Builder() // new entry (builder)
+        currentEntries.add(newEntryBuilder)
+        return newEntryBuilder
+    }
+
+    /**
+     * Delete the passed instance of the log entry Builder from ephemeral storage.
+     */
+    private fun deleteLogEntryBuilderInstance(entryBuilder: PresentationLogEntry.Builder) {
+        currentEntries.remove(entryBuilder)
+    }
+
+    /**
+     * Create a new PresentationLogEntry.Builder instance and add the request data bytes, session transcript
+     * bytes and engagement type. This instance will be populated with other log components and
+     * persisted whenever finishing the log entry.
+     *
+     * Returns the new Builder instance.
+     */
+    fun newLogEntryWithRequest(
+        data: ByteArray,
+        sessionTranscript: ByteArray?,
+        engagementType: EngagementTypeDef
+    ): PresentationLogEntry.Builder {
+        val entryBuilder = getCurrentLogEntryBuilder(newInstance = true)
+
+        if (data.isNotEmpty()) {
+            entryBuilder.addComponentLogBytes(LogComponent.Request, data)
+        }
+
+        entryBuilder.metadataBuilder
+            .engagementType(engagementType)
+            .sessionTranscript(sessionTranscript ?: byteArrayOf())
+
+        return entryBuilder
+    }
+
+    /**
+     * Set the data bytes for LogComponent.Response
+     */
+    fun logResponseData(data: ByteArray, currentEntryId: Long? = null) {
+        val entryBuilder = getCurrentLogEntryBuilder(havingId = currentEntryId)
+        if (data.isNotEmpty()) {
+            entryBuilder.addComponentLogBytes(LogComponent.Response, data)
+        }
+    }
+
+    /**
+     * Persist log entry to StorageEngine after transaction was marked as complete.
+     */
+    fun persistLogEntryTransactionComplete(currentEntryId: Long? = null) {
+        val entryBuilder = getCurrentLogEntryBuilder(havingId = currentEntryId)
+        entryBuilder.metadataBuilder.transactionComplete()
+        persistLogEntry(entryBuilder)
+    }
+
+    /**
+     * Persist the log entry after user invoked cancellation of transaction.
+     */
+    fun persistLogEntryTransactionCanceled(currentEntryId: Long? = null) {
+        val entryBuilder = getCurrentLogEntryBuilder(havingId = currentEntryId)
+        entryBuilder.metadataBuilder.transactionCanceled()
+        persistLogEntry(entryBuilder)
+    }
+
+    /**
+     * Persist the log entry after there's a disconnect between sender and receiver.
+     */
+    fun persistLogEntryTransactionDisconnected(currentEntryId: Long? = null) {
+        val entryBuilder = getCurrentLogEntryBuilder(havingId = currentEntryId)
+        entryBuilder.metadataBuilder.transactionDisconnected()
+        persistLogEntry(entryBuilder)
+    }
+
+    /**
+     * Persist the log entry with the specified error that occurred during presentation.
+     */
+    fun persistLogEntryTransactionError(throwable: Throwable, currentEntryId: Long? = null) {
+        val entryBuilder = getCurrentLogEntryBuilder(havingId = currentEntryId)
+        entryBuilder.metadataBuilder.transactionError(throwable)
+        persistLogEntry(entryBuilder)
+    }
+
+    /**
+     * Persist all the data of log components that built the passed in PresentationLogEntry.Builder instance.
+     */
+    private fun persistLogEntry(entryBuilder: PresentationLogEntry.Builder) {
+        // add last known location
+        entryBuilder.metadataBuilder.location(locationLatitude, locationLongitude)
+
+        // create a PresentationLogEntry instance containing bytes for each LogComponent
+        val logEntry = entryBuilder.build()
+
+            // iterate through all possible LogComponents
+        LogComponent.values().forEach { logComponent ->
+            // generate the key to use for storing the byte array of every log component
+            val storeKey = logComponent.getStoreKey(logEntry.id)
+            // get the bytes of the log component (if any were passed)
+            val storeValue = logEntry.getLogComponentBytes(logComponent)
+            if (storeValue.isNotEmpty()) { // don't persist empty data of a log component
+                // create a new entry record in secure persistent storage for every (non-empty) log component's bytes in PresentationLogEntry
+                storageEngine.put(storeKey, storeValue)
+            }
+        }
+
+        // remove entryBuilder instance
+        deleteLogEntryBuilderInstance(entryBuilder)
+
+        // enforce max entries
+        if (StoreConst.MAX_ENTRIES_ENFORCEMENT) {
+            // if we stored 1 more log entry than the defined MAX_ENTRIES, remove the oldest entry
+            enforceMaxLogEntries()
+        }
+    }
+
+    /**
+     * Ensure there are no more than SoreConst.MAX_ENTRIES entries saved in [StorageEngine], else,
+     * delete as many oldest entries as necessary to satisfy requirement.
+     *
+     * This function is always called after every persisting of PresentationLogEntry and only
+     * if MAX_ENTRIES_ENFORCEMENT = true.
+     */
+    private fun enforceMaxLogEntries() {
+        val allLogEntryIds = presentationHistoryStore.fetchAllLogEntryIds().sorted()
+        var difference = StoreConst.MAX_ENTRIES_COUNT - allLogEntryIds.size
+        var oldestIndex = 0
+        while (difference < 0) { // there's at least 1 more entry over the defined MAX_ENTRIES
+            // delete the oldest entries to bring count to MAX_ENTRIES
+            val oldestId = allLogEntryIds[oldestIndex]
+            presentationHistoryStore.deleteLogEntry(oldestId)
+            difference++ // 1 entry was purged
+            oldestIndex++ // go to next oldest entry
+        }
+    }
+
+    /**
+     * Provides a Public/External History Log Store that can fetch previous log entries,
+     * delete a single entry, and delete all entries.
+     */
+    class PresentationHistoryStore(
+        private val storageEngine: StorageEngine,
+    ) {
+        /**
+         * Retrieve the bytes of all persisted log entries and return a list of PresentationLogEntry of those entries.
+         */
+        fun fetchAllLogEntries(): List<PresentationLogEntry> {
+            // list to populate with all persisted PresentationLogEntry objects
+            val persistedLogEntries = mutableListOf<PresentationLogEntry>()
+            // get all the unique IDs that are embedded in the store key of every component tied to a PresentationLogEntry
+            fetchAllLogEntryIds().forEach { logEntryId ->
+                // Creating a new PresentationLogEntry for every encountered ID
+                val presentationLogEntry = PresentationLogEntry.Builder(logEntryId)
+                // try get saved bytes of every log component to build the PresentationLogEntry with bytes of every found component
+                LogComponent.values().forEach { logComponent ->
+                    // look for bytes of a component (for every entry ID) at this key
+                    val componentStoreKey = logComponent.getStoreKey(logEntryId)
+                    val componentValueBytes = storageEngine[componentStoreKey]
+                    // add components that have data persisted
+                    if (componentValueBytes != null) {
+                        presentationLogEntry.addComponentLogBytes(
+                            logComponent,
+                            componentValueBytes
+                        )
+                    }
+                }
+                // build the entry now that we've extracted all possible bytes of every log component for a given entry ID
+                persistedLogEntries.add(presentationLogEntry.build())
+            }
+            return persistedLogEntries
+        }
+
+        /**
+         * Enumerate all persisted entries of [StorageEngine] and filter for (Presentation) log entries,
+         * return only unique log entry IDs - where each log entry ID can have 1 or more key/value pairs
+         * stored in the secure persistent storage table.
+         */
+        fun fetchAllLogEntryIds(): List<Long> = storageEngine.enumerate()
+            .filter { it.startsWith(StoreConst.LOG_PREFIX) }
+            .map { extractLogEntryId(it) }
+            .distinct()
+            .sortedDescending() // last entry shows up first
+
+        /**
+         * Given a key found in [StorageEngine], extract the ID of the log entry that was stored.
+         */
+        private fun extractLogEntryId(storeKey: String) =
+            storeKey
+                .split(StoreConst.LOG_PREFIX)[1]
+                .split(LogComponent.Const.COMPONENT_PREFIX)[0]
+                .toLong()
+
+
+        /**
+         * Delete all saved records (log components) from [StorageEngine] associated with the specified entryID.
+         */
+        fun deleteLogEntry(entryId: Long) =
+            LogComponent.values().forEach { logComponent ->
+                storageEngine.delete(logComponent.getStoreKey(entryId))
+            }
+
+        /**
+         * Delete all logs - iterate through all persisted unique entry IDs and delete all log components
+         * tied for each entry ID.
+         */
+        fun deleteAllLogs() =
+            fetchAllLogEntryIds().forEach { logEntryId -> deleteLogEntry(logEntryId) }
+    }
+}

--- a/identity/src/main/java/com/android/identity/util/EngagementTypeDef.kt
+++ b/identity/src/main/java/com/android/identity/util/EngagementTypeDef.kt
@@ -1,0 +1,48 @@
+package com.android.identity.util
+
+import com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_NFC_NEGOTIATED_HANDOVER
+import com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_NFC_STATIC_HANDOVER
+import com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_NOT_ENGAGED
+import com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_QR_CODE
+import com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_REVERSE
+import com.android.identity.util.EngagementTypeDef.TypeDef.ENGAGEMENT_METHOD_UNATTENDED
+
+/**
+ * Engagement Type Definitions
+ */
+enum class EngagementTypeDef(val engagementValue: Int) {
+    NOT_ENGAGED(ENGAGEMENT_METHOD_NOT_ENGAGED), // default, uninitialized variable (not a valid engagement type)
+    QR_CODE(ENGAGEMENT_METHOD_QR_CODE),
+    NFC_STATIC_HANDOVER(ENGAGEMENT_METHOD_NFC_STATIC_HANDOVER),
+    NFC_NEGOTIATED_HANDOVER(ENGAGEMENT_METHOD_NFC_NEGOTIATED_HANDOVER),
+    REVERSE(ENGAGEMENT_METHOD_REVERSE),
+    UNATTENDED(ENGAGEMENT_METHOD_UNATTENDED),
+    ;
+
+    /**
+     * Int definitions for all the engagement method types.
+     *
+     * These used to live in com.android.identity.android.mdoc.deviceretrieval.VerificationHelper
+     */
+    object TypeDef {
+        const val ENGAGEMENT_METHOD_NOT_ENGAGED = 0
+        const val ENGAGEMENT_METHOD_QR_CODE = 1
+        const val ENGAGEMENT_METHOD_NFC_STATIC_HANDOVER = 2
+        const val ENGAGEMENT_METHOD_NFC_NEGOTIATED_HANDOVER = 3
+        const val ENGAGEMENT_METHOD_REVERSE = 4
+        const val ENGAGEMENT_METHOD_UNATTENDED = 5
+    }
+
+    companion object {
+        /**
+         * Return an EngagementTypeDef according to name
+         */
+        fun fromString(name: String) = values().firstOrNull { it.name == name } ?: NOT_ENGAGED
+
+        /**
+         * Return an EngagementTypeDef according to engagement value
+         */
+        fun fromValue(value: Int?) =
+            values().firstOrNull { it.engagementValue == value } ?: NOT_ENGAGED
+    }
+}


### PR DESCRIPTION
Fixes #315 

PresentationLogStore, PresentationLogEntry and PresentationLogMetadata live in the -identity- module so it can be referenced from the -identity-android-, -appholder-, and -appverifier- modules.

PresentationLogStore is used to return a newly initiated PresentationLogEntry to be populated with bytes of every LogComponent (request + response bytes and PresentationLogMetadata).

Both Appholder and Appverifier now have their own History fragments (drawer menu — History) rendering compose views that show previous mDL Presentations.

Persisting a log entry also records the last known lat/long of the device.

Synchronization support for multiple logging events. Once an entry is persisted it is removed from -currentEntries-.

Tests cases can be found in PresentationLogStoreTest that lives in the -identity-android- module and verifies the correctness of the presentation log + presentation history store (persisted entries, components, deletion, etc..)

EngagementType contains all ENGAGEMENT_METHOD ints that were defined in VerificationHelper (and are now referenced from VerificationHelper)

Signed-off-by: Dritan Xhabija <dritan@google.com>