### PR TITLE
Presentation Activity in Wallet

### DIFF
--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <uses-feature
+        android:name="android.hardware.bluetooth_le"
+        android:required="true" />
+    <uses-feature
+        android:name="android.hardware.nfc"
+        android:required="true" />
+
+    <uses-permission android:name="android.permission.VIBRATE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_SCAN"
+        android:usesPermissionFlags="neverForLocation" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
+    <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <uses-permission android:name="android.permission.NFC" />
 
     <uses-permission android:name="android.permission.NFC"/>
     <uses-feature android:name="android.hardware.nfc" android:required="true"/>
@@ -27,6 +42,28 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
+        <activity
+            android:name=".PresentationActivity"
+            android:exported="true"
+            android:label="@string/app_name_presentation"
+            android:theme="@style/Theme.IdentityCredential">
+        </activity>
+
+        <service
+            android:name=".NfcEngagementHandler"
+            android:exported="true"
+            android:label="@string/nfc_engagement_service_desc"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/nfc_engagement_apdu_service" />
+        </service>
+
     </application>
 
 </manifest>

--- a/wallet/src/main/java/com/android/identity_credential/wallet/CredentialInformationViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/CredentialInformationViewModel.kt
@@ -5,12 +5,10 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.identity.credential.Credential
 import com.android.identity.issuance.CredentialExtensions.housekeeping
-import com.android.identity.issuance.CredentialExtensions.refreshState
-import com.android.identity.util.Logger
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 
-class CredentialInformationViewModel  : ViewModel() {
+class CredentialInformationViewModel : ViewModel() {
 
     companion object {
         private const val TAG = "CredentialInformationViewModel"
@@ -27,7 +25,7 @@ class CredentialInformationViewModel  : ViewModel() {
                 3,
                 30*24*3600,
                 application.androidKeystoreSecureArea,
-                "mdoc/MSO")
+                WalletApplication.AUTH_KEY_DOMAIN)
             lastHousekeepingAt.value = System.currentTimeMillis()
         }
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/NfcEngagementHandler.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/NfcEngagementHandler.kt
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity_credential.wallet
+
+import android.content.Context
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import android.os.Handler
+import android.os.Looper
+import android.os.Vibrator
+import androidx.core.content.ContextCompat
+import com.android.identity.android.mdoc.engagement.NfcEngagementHelper
+import com.android.identity.android.mdoc.transport.DataTransport
+import com.android.identity.android.mdoc.transport.DataTransportOptions
+import com.android.identity.internal.Util
+import com.android.identity.securearea.SecureArea
+import com.android.identity.util.Logger
+
+class NfcEngagementHandler : HostApduService() {
+    companion object {
+        private val TAG = "NfcEngagementHandler"
+    }
+
+    private var engagementHelper: NfcEngagementHelper? = null
+
+    private val eDeviceKeyCurve = SecureArea.EC_CURVE_P256
+    private val eDeviceKeyPair by lazy {
+        Util.createEphemeralKeyPair(eDeviceKeyCurve)
+    }
+    private val nfcEngagementListener = object : NfcEngagementHelper.Listener {
+
+        override fun onTwoWayEngagementDetected() {
+            Logger.i(TAG, "onTwoWayEngagementDetected")
+        }
+
+        override fun onHandoverSelectMessageSent() {
+            Logger.i(TAG, "onHandoverSelectMessageSent")
+            // This is invoked _just_ before the NFC tag reader will do a READ_BINARY
+            // for the Handover Select message. Vibrate the device to indicate to the
+            // user they can start removing the device from the reader.
+            val vibrator = getSystemService(Context.VIBRATOR_SERVICE) as Vibrator
+            val vibrationPattern = longArrayOf(0, 500, 50, 300)
+            val indexInPatternToRepeat = -1
+            vibrator.vibrate(vibrationPattern, indexInPatternToRepeat)
+        }
+
+        override fun onDeviceConnecting() {
+            Logger.i(TAG, "onDeviceConnecting")
+        }
+
+        override fun onDeviceConnected(transport: DataTransport) {
+            Logger.i(TAG, "onDeviceConnected")
+
+            PresentationActivity.startPresentation(applicationContext, transport,
+                engagementHelper!!.handover, eDeviceKeyCurve, eDeviceKeyPair,
+                engagementHelper!!.deviceEngagement)
+
+            engagementHelper?.close()
+            engagementHelper = null
+        }
+
+        override fun onError(error: Throwable) {
+            Logger.i(TAG, "Engagement Listener: onError -> ${error.message}")
+            engagementHelper?.close()
+            engagementHelper = null
+        }
+    }
+
+    override fun onCreate() {
+        super.onCreate()
+        Logger.i(TAG, "onCreate")
+
+        val application: WalletApplication = application as WalletApplication
+
+        if (application.credentialStore.listCredentials().size > 0
+            && !PresentationActivity.isPresentationActive()) {
+
+            val options = DataTransportOptions.Builder().build()
+            val builder = NfcEngagementHelper.Builder(
+                applicationContext,
+                eDeviceKeyPair.public,
+                eDeviceKeyCurve,
+                options,
+                nfcEngagementListener,
+                ContextCompat.getMainExecutor(applicationContext)
+            )
+            builder.useNegotiatedHandover()
+            engagementHelper = builder.build()
+        }
+    }
+
+    override fun processCommandApdu(commandApdu: ByteArray, extras: Bundle?): ByteArray? {
+        Logger.dHex(TAG, "processCommandApdu", commandApdu)
+        return engagementHelper?.nfcProcessCommandApdu(commandApdu)
+    }
+
+    override fun onDeactivated(reason: Int) {
+        Logger.i(TAG, "onDeactivated: reason-> $reason ")
+        engagementHelper?.nfcOnDeactivated(reason)
+
+        // We need to close the NfcEngagementHelper but if we're doing it as the reader moves
+        // out of the field, it's too soon as it may take a couple of seconds to establish
+        // the connection, triggering onDeviceConnected() callback above.
+        //
+        // In fact, the reader _could_ actually take a while to establish the connection...
+        // for example the UI in the mdoc doc reader might have the operator pick the
+        // transport if more than one is offered. In fact this is exactly what we do in
+        // our mdoc reader.
+        //
+        // So we give the reader 15 seconds to do this...
+        //
+        val timeoutSeconds = 15
+        Handler(Looper.getMainLooper()).postDelayed({
+            if (engagementHelper != null) {
+                Logger.w(TAG, "Reader didn't connect inside $timeoutSeconds seconds, closing")
+                engagementHelper!!.close()
+            }
+        }, timeoutSeconds * 1000L)
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PermissionTracker.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PermissionTracker.kt
@@ -3,6 +3,7 @@ package com.android.identity_credential.wallet
 import android.content.pm.PackageManager
 import androidx.activity.ComponentActivity
 import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material3.Button
 import androidx.compose.material3.Text
@@ -60,19 +61,29 @@ class PermissionTracker(private val activity: ComponentActivity, private val per
      */
     @Composable
     fun PermissionCheck(permissions: Iterable<String>, content: @Composable () -> Unit) {
-
         var allGranted = true
-        for (permission in permissions) {
-            if (!mState[permission]!!.observeAsState().value!!) {
-                allGranted = false
-                Text(this.permissions[permission]!!, modifier = Modifier.fillMaxWidth())
-                Button(onClick = {requestPermission(permission)}) {
-                    Text("Request")
+        Column {
+            for (permission in permissions) {
+                if (!mState[permission]!!.observeAsState().value!!) {
+                    allGranted = false
+                    SinglePermissionRequest(permission = permission)
                 }
             }
         }
+
         if (allGranted) {
             content()
+        }
+    }
+
+    @Composable
+    private fun SinglePermissionRequest(permission: String){
+        val reasoningTxt: String = this.permissions[permission]!!
+        Column {
+            Text(text = reasoningTxt, modifier = Modifier.fillMaxWidth())
+            Button(onClick = {requestPermission(permission)}) {
+                Text("I understand")
+            }
         }
     }
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -1,0 +1,366 @@
+/*
+ * Copyright (C) 2024 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.identity_credential.wallet
+
+import android.content.Context
+import android.content.Intent
+import android.content.SharedPreferences
+import android.os.Bundle
+import android.preference.PreferenceManager
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MutableLiveData
+import com.android.identity.android.mdoc.deviceretrieval.DeviceRetrievalHelper
+import com.android.identity.android.mdoc.transport.DataTransport
+import com.android.identity.credential.Credential
+import com.android.identity.credential.NameSpacedData
+import com.android.identity.internal.Util
+import com.android.identity.issuance.CredentialExtensions.credentialConfiguration
+import com.android.identity.issuance.CredentialExtensions.issuingAuthorityIdentifier
+import com.android.identity.issuance.CredentialPresentationFormat
+import com.android.identity.mdoc.mso.MobileSecurityObjectParser
+import com.android.identity.mdoc.mso.StaticAuthDataParser
+import com.android.identity.mdoc.request.DeviceRequestParser
+import com.android.identity.mdoc.response.DeviceResponseGenerator
+import com.android.identity.mdoc.response.DocumentGenerator
+import com.android.identity.mdoc.util.MdocUtil
+import com.android.identity.securearea.SecureArea
+import com.android.identity.util.Constants
+import com.android.identity.util.Logger
+import com.android.identity.util.Timestamp
+import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
+import java.lang.Exception
+import java.lang.IllegalArgumentException
+import java.security.KeyPair
+import java.security.PublicKey
+import java.util.OptionalLong
+
+class PresentationActivity : ComponentActivity() {
+    companion object {
+        private const val TAG = "PresentationActivity"
+        private var mTransport: DataTransport?
+        private var mHandover: ByteArray?
+        private var mEDeviceKeyCurve: Int? = null
+        private var mEDeviceKeyPair: KeyPair?
+        private var mDeviceEngagement: ByteArray?
+        private var state = MutableLiveData<State>()
+
+        init {
+            state.value = State.NOT_CONNECTED
+            mTransport = null
+            mHandover = null
+            mEDeviceKeyCurve = null
+            mEDeviceKeyPair = null
+            mDeviceEngagement = null
+        }
+
+        fun startPresentation(context: Context, transport: DataTransport, handover: ByteArray,
+                              eDeviceKeyCurve: Int, eDeviceKeyPair: KeyPair, deviceEngagement: ByteArray) {
+            mTransport = transport
+            mHandover = handover
+            mEDeviceKeyCurve = eDeviceKeyCurve
+            mEDeviceKeyPair = eDeviceKeyPair
+            mDeviceEngagement = deviceEngagement
+            Logger.i(TAG, "engagement info set")
+
+            val launchAppIntent = Intent(context, PresentationActivity::class.java)
+            launchAppIntent.addFlags(
+                Intent.FLAG_ACTIVITY_NEW_TASK or
+                    Intent.FLAG_ACTIVITY_NO_HISTORY or
+                    Intent.FLAG_ACTIVITY_EXCLUDE_FROM_RECENTS)
+            context.startActivity(launchAppIntent)
+            state.value = State.CONNECTED
+        }
+
+        fun isPresentationActive(): Boolean {
+            return state.value != State.NOT_CONNECTED
+        }
+    }
+
+    enum class State {
+        NOT_CONNECTED,
+        CONNECTED,
+        REQUEST_AVAILABLE,
+        RESPONSE_SENT,
+    }
+
+    private var deviceRequest: ByteArray? = null
+    private var deviceRetrievalHelper: DeviceRetrievalHelper? = null
+    private lateinit var sharedPreferences: SharedPreferences
+
+    override fun onDestroy() {
+        Logger.i(TAG, "onDestroy")
+        disconnect()
+        super.onDestroy()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        Logger.i(TAG, "onCreate")
+        super.onCreate(savedInstanceState)
+
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(applicationContext)
+
+        setContent {
+            IdentityCredentialTheme {
+
+                val stateDisplay = remember { mutableStateOf("Idle") }
+
+                state.observe(this as LifecycleOwner) { state ->
+                    when (state) {
+                        State.NOT_CONNECTED -> {
+                            stateDisplay.value = "Not Connected"
+                            Logger.i(TAG, "State: Not Connected")
+                        }
+                        State.CONNECTED -> {
+                            makeDeviceRetrievalHelper()
+                            stateDisplay.value = "Connected"
+                            Logger.i(TAG, "State: Connected")
+                        }
+                        State.REQUEST_AVAILABLE -> {
+                            stateDisplay.value = "Request Available"
+                            Logger.i(TAG, "State: Request Available")
+                            processRequest()
+                        }
+                        State.RESPONSE_SENT -> {
+                            stateDisplay.value = "Response Sent"
+                            Logger.i(TAG, "State: Response Sent")
+                        }
+                        else -> {}
+                    }
+                }
+
+                ScreenWithAppBar(title = "Presenting", navigationIcon = { }) {
+                    Column(
+                        modifier = Modifier
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "Sending mDL to reader.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            text = "TODO: finalize UI",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Divider()
+                        Text(
+                            text = "State: ${stateDisplay.value}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Divider()
+                        Button(onClick = { finish() }) {
+                            Text("Close")
+                        }
+                    }
+                }
+            }
+        }
+
+    }
+
+    private fun makeDeviceRetrievalHelper() {
+        Logger.i(TAG, "making DeviceRetrievalHelper")
+        deviceRetrievalHelper = DeviceRetrievalHelper.Builder(
+            applicationContext,
+            object : DeviceRetrievalHelper.Listener {
+                override fun onEReaderKeyReceived(eReaderKey: PublicKey) {
+                    Logger.i(TAG, "onEReaderKeyReceived")
+                }
+
+                override fun onDeviceRequest(deviceRequestBytes: ByteArray) {
+                    Logger.i(TAG, "onDeviceRequest")
+                    deviceRequest = deviceRequestBytes
+                    state.value = State.REQUEST_AVAILABLE
+                }
+
+                override fun onDeviceDisconnected(transportSpecificTermination: Boolean) {
+                    Logger.i(TAG, "onDeviceDisconnected $transportSpecificTermination")
+                    deviceRetrievalHelper?.disconnect()
+                    deviceRetrievalHelper = null
+                    state.value = State.NOT_CONNECTED
+                }
+
+                override fun onError(error: Throwable) {
+                    Logger.i(TAG, "onError", error)
+                    deviceRetrievalHelper?.disconnect()
+                    deviceRetrievalHelper = null
+                    state.value = State.NOT_CONNECTED
+                }
+
+            },
+            ContextCompat.getMainExecutor(applicationContext),
+            mEDeviceKeyPair!!,
+            mEDeviceKeyCurve!!)
+            .useForwardEngagement(mTransport!!, mDeviceEngagement!!, mHandover!!)
+            .build()
+    }
+
+    private fun disconnect() {
+        Logger.i(TAG, "disconnect")
+        if (deviceRetrievalHelper == null) {
+            Logger.i(TAG, "already closed")
+            return
+        }
+        if (state.value == State.REQUEST_AVAILABLE) {
+            val deviceResponseGenerator = DeviceResponseGenerator(Constants.DEVICE_RESPONSE_STATUS_GENERAL_ERROR)
+            sendResponse(deviceResponseGenerator.generate())
+        }
+        deviceRetrievalHelper?.disconnect()
+        deviceRetrievalHelper = null
+        mTransport = null
+        mHandover = null
+        state.value = State.NOT_CONNECTED
+    }
+
+    private fun error(msg: String) {
+        Toast.makeText(applicationContext, msg, Toast.LENGTH_SHORT).show()
+        this.onDestroy()
+    }
+
+    private fun getDeviceRequest(): ByteArray {
+        check(state.value == State.REQUEST_AVAILABLE) { "Not in REQUEST_AVAILABLE state"}
+        check(deviceRequest != null) { "No request available "}
+        return deviceRequest as ByteArray
+    }
+
+    private fun sendResponse(deviceResponseBytes: ByteArray) {
+        check(state.value == State.REQUEST_AVAILABLE) { "Not in REQUEST_AVAILABLE state"}
+        deviceRetrievalHelper!!.sendDeviceResponse(deviceResponseBytes, OptionalLong.of(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION))
+        state.value = State.RESPONSE_SENT
+    }
+
+    private fun processRequest() {
+        // TODO support more formats
+        val credentialPresentationFormat: CredentialPresentationFormat = CredentialPresentationFormat.MDOC_MSO
+
+        // TODO when selecting a matching credential of the MDOC_MSO format, also use docRequest.docType
+        //     to select a credential of the right doctype
+        val credentialId: String? = firstMatchingCredentialID(credentialPresentationFormat)
+        if (credentialId == null) {
+            error("No matching credentials in wallet")
+            return
+        }
+
+        val request = DeviceRequestParser()
+            .setDeviceRequest(getDeviceRequest())
+            .setSessionTranscript(deviceRetrievalHelper!!.sessionTranscript)
+            .parse()
+        val docRequest = request.documentRequests[0]
+        val requestedDocType: String = docRequest.docType
+        val encodedDeviceResponse: ByteArray
+
+        if (requestedDocType == SelfSignedMdlIssuingAuthority.MDL_DOCTYPE) {
+            val application: WalletApplication = application as WalletApplication
+            val credential = application.credentialStore.lookupCredential(credentialId)!!
+            val credentialConfiguration = credential.credentialConfiguration
+            val now = Timestamp.now()
+
+            val authKey: Credential.AuthenticationKey
+            try {
+                authKey = credential.findAuthenticationKey(WalletApplication.AUTH_KEY_DOMAIN, now)!!
+            } catch (e: Exception) {
+                error("No valid auth keys, please request more")
+                return
+            }
+
+            val staticAuthData = StaticAuthDataParser(authKey.issuerProvidedData).parse()
+            val encodedMsoBytes = Util.cborDecode(Util.coseSign1GetData(Util.cborDecode(staticAuthData.issuerAuth)))
+            val encodedMso = Util.cborEncode(Util.cborExtractTaggedAndEncodedCbor(encodedMsoBytes))
+            val mso = MobileSecurityObjectParser().setMobileSecurityObject(encodedMso).parse()
+
+            val credentialRequest = MdocUtil.generateCredentialRequest(docRequest!!)
+            val mergedIssuerNamespaces = MdocUtil.mergeIssuerNamesSpaces(
+                credentialRequest,
+                credentialConfiguration.staticData,
+                staticAuthData
+            )
+
+            val deviceResponseGenerator = DeviceResponseGenerator(Constants.DEVICE_RESPONSE_STATUS_OK)
+            deviceResponseGenerator.addDocument(
+                DocumentGenerator(mso.docType,
+                    staticAuthData.issuerAuth, deviceRetrievalHelper!!.sessionTranscript)
+                    .setIssuerNamespaces(mergedIssuerNamespaces)
+                    .setDeviceNamespacesSignature(
+                        NameSpacedData.Builder().build(),
+                        authKey.secureArea,
+                        authKey.alias,
+                        null,
+                        SecureArea.ALGORITHM_ES256
+                    )
+                    .generate()
+            )
+            encodedDeviceResponse = deviceResponseGenerator.generate()
+        } else {
+            error("$requestedDocType not available")
+            return
+        }
+
+        sendResponse(encodedDeviceResponse)
+    }
+
+    private fun firstMatchingCredentialID(
+        credentialPresentationFormat: CredentialPresentationFormat): String? {
+        // prefer the credential which is on-screen if possible
+        val credentialIdFromPager: String? = sharedPreferences.getString(WalletApplication.PREFERENCE_CURRENT_CREDENTIAL_ID, null)
+        if (credentialIdFromPager != null) {
+            if (isCredentialValid(credentialIdFromPager, credentialPresentationFormat)) {
+                return credentialIdFromPager
+            }
+        }
+
+        val application: WalletApplication = application as WalletApplication
+        val credentialIds = application.credentialStore.listCredentials()
+        for (credentialId in credentialIds) {
+            if (isCredentialValid(credentialId, credentialPresentationFormat)) {
+                return credentialIdFromPager
+            }
+        }
+
+        return null
+    }
+
+    private fun isCredentialValid(credentialId: String,
+                                  credentialPresentationFormat: CredentialPresentationFormat): Boolean {
+        val application: WalletApplication = application as WalletApplication
+        val credential = application.credentialStore.lookupCredential(credentialId)!!
+        val issuingAuthorityIdentifier = credential.issuingAuthorityIdentifier
+        val issuer = application.issuingAuthorityRepository.lookupIssuingAuthority(issuingAuthorityIdentifier)
+            ?: throw IllegalArgumentException("No issuer with id $issuingAuthorityIdentifier")
+        val credentialFormats = issuer.configuration.credentialFormats
+        return credentialFormats.contains(credentialPresentationFormat)
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -1,64 +1,23 @@
 package com.android.identity_credential.wallet
 
 import android.app.Application
-import android.graphics.Bitmap
-import android.graphics.BitmapFactory
-import android.graphics.Canvas
-import android.graphics.Paint
-import android.graphics.RadialGradient
-import android.graphics.Rect
-import android.graphics.Shader
 import com.android.identity.android.securearea.AndroidKeystoreSecureArea
 import com.android.identity.android.storage.AndroidStorageEngine
 import com.android.identity.credential.CredentialStore
-import com.android.identity.credential.NameSpacedData
 import com.android.identity.credentialtype.CredentialTypeRepository
 import com.android.identity.credentialtype.knowntypes.DrivingLicense
-import com.android.identity.internal.Util
-import com.android.identity.issuance.CredentialConfiguration
-import com.android.identity.issuance.CredentialPresentationFormat
-import com.android.identity.issuance.evidence.EvidenceResponse
-import com.android.identity.issuance.evidence.EvidenceResponseMessage
-import com.android.identity.issuance.evidence.EvidenceResponseQuestionMultipleChoice
-import com.android.identity.issuance.evidence.EvidenceResponseQuestionString
-import com.android.identity.issuance.evidence.EvidenceType
-import com.android.identity.issuance.IssuingAuthorityConfiguration
 import com.android.identity.issuance.IssuingAuthorityRepository
-import com.android.identity.issuance.evidence.EvidenceRequest
-import com.android.identity.issuance.evidence.EvidenceRequestMessage
-import com.android.identity.issuance.evidence.EvidenceRequestQuestionMultipleChoice
-import com.android.identity.issuance.evidence.EvidenceRequestQuestionString
-import com.android.identity.issuance.simple.SimpleIssuingAuthority
-import com.android.identity.mdoc.mso.MobileSecurityObjectGenerator
-import com.android.identity.mdoc.mso.StaticAuthDataGenerator
-import com.android.identity.mdoc.util.MdocUtil
-import com.android.identity.securearea.SecureArea
 import com.android.identity.securearea.SecureAreaRepository
 import com.android.identity.util.Logger
-import com.android.identity.util.Timestamp
-import org.bouncycastle.asn1.x500.X500Name
-import org.bouncycastle.cert.X509CertificateHolder
-import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter
-import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.operator.ContentSigner
-import org.bouncycastle.operator.jcajce.JcaContentSignerBuilder
-import java.io.ByteArrayOutputStream
 import java.io.File
-import java.math.BigInteger
-import java.security.KeyPair
-import java.security.KeyPairGenerator
-import java.security.PublicKey
-import java.security.SecureRandom
 import java.security.Security
-import java.security.cert.X509Certificate
-import java.security.spec.ECGenParameterSpec
-import java.util.Date
-import kotlin.math.ceil
 
 class WalletApplication : Application() {
     companion object {
         private const val TAG = "WalletApplication"
+        const val AUTH_KEY_DOMAIN = "mdoc/MSO"
+        const val PREFERENCE_CURRENT_CREDENTIAL_ID = "current_credential_id"
     }
 
     lateinit var credentialTypeRepository: CredentialTypeRepository
@@ -91,5 +50,4 @@ class WalletApplication : Application() {
         issuingAuthorityRepository = IssuingAuthorityRepository()
         issuingAuthorityRepository.add(SelfSignedMdlIssuingAuthority(this, storageEngine))
     }
-
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/commonUI.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/commonUI.kt
@@ -1,8 +1,7 @@
-@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@file:OptIn(ExperimentalMaterial3Api::class)
 
 package com.android.identity_credential.wallet
 
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">Wallet</string>
+    <string name="engagement_aid_group_desc">mDL AID Group</string>
+    <string name="nfc_engagement_service_desc">@string/app_name</string>
+    <string name="app_name_presentation">Wallet Presentation</string>
 </resources>

--- a/wallet/src/main/res/xml/nfc_engagement_apdu_service.xml
+++ b/wallet/src/main/res/xml/nfc_engagement_apdu_service.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!--
+  ~ Copyright (C) 2019 Google Inc.
+  ~
+  ~ Licensed under the Apache License, Version 2.0 (the "License");
+  ~ you may not use this file except in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~      http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/nfc_engagement_service_desc"
+    android:requireDeviceUnlock="true">
+
+    <aid-group android:description="@string/engagement_aid_group_desc" android:category="other">
+        <!-- NFC Type 4 Tag -->
+        <aid-filter android:name="D2760000850101"/>
+    </aid-group>
+
+</host-apdu-service>


### PR DESCRIPTION
Adding PresentationActivity to wallet, which will appear on-screen with related presentation UI once the NfcEngagementHandler starts the activity. This addition allows for in-person presentation with NFC engagement.

Tested manually with 0/1/2 active credentials in wallet.