### PR TITLE
Fixes: #462: Fix race condition in method sendResponse in com.android.identity.wallet.transfer.Communication

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/fragment/TransferDocumentFragment.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/fragment/TransferDocumentFragment.kt
@@ -163,13 +163,13 @@ class TransferDocumentFragment : Fragment() {
     private fun onTransferDisconnected() {
         log("Disconnected")
         hideButtons()
-        TransferManager.getInstance(requireContext()).disconnect()
+        TransferManager.getInstance(requireContext()).disconnect(true)
     }
 
     private fun onTransferError() {
         Toast.makeText(requireContext(), "An error occurred.", Toast.LENGTH_SHORT).show()
         hideButtons()
-        TransferManager.getInstance(requireContext()).disconnect()
+        TransferManager.getInstance(requireContext()).disconnect(true)
     }
 
     private fun hideButtons() {

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/Communication.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/Communication.kt
@@ -45,21 +45,16 @@ class Communication private constructor(
             if (progress == max) {
                 log("Completed...")
             }
+            if (progress == max && closeAfterSending) {
+                deviceRetrievalHelper?.disconnect()
+            }
         }
-        if (closeAfterSending) {
-            deviceRetrievalHelper?.sendDeviceResponse(
-                deviceResponse,
-                OptionalLong.of(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION),
-                progressListener,
-                context.mainExecutor())
-            deviceRetrievalHelper?.disconnect()
-        } else {
-            deviceRetrievalHelper?.sendDeviceResponse(
-                deviceResponse,
-                OptionalLong.empty(),
-                progressListener,
-                context.mainExecutor())
-        }
+
+        deviceRetrievalHelper?.sendDeviceResponse(
+            deviceResponse,
+            OptionalLong.of(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION),
+            progressListener,
+            context.mainExecutor())
     }
 
     fun stopPresentation(

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
@@ -264,7 +264,9 @@ class TransferManager private constructor(private val context: Context) {
 
     fun sendResponse(deviceResponse: ByteArray, closeAfterSending: Boolean) {
         communication.sendResponse(deviceResponse, closeAfterSending)
-        disconnect(!closeAfterSending)
+        if (closeAfterSending) {
+            disconnect(false)
+        }
     }
 
     fun readDocumentEntries(documentName: String): DocumentElements {

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/TransferManager.kt
@@ -244,11 +244,13 @@ class TransferManager private constructor(private val context: Context) {
             sendSessionTerminationMessage,
             useTransportSpecificSessionTermination
         )
-        disconnect()
+        disconnect(true)
     }
 
-    fun disconnect() {
-        communication.disconnect()
+    fun disconnect(disconnectCommunication: Boolean) {
+        if (disconnectCommunication) {
+            communication.disconnect()
+        }
         qrCommunicationSetup?.close()
         transferStatusLd = MutableLiveData<TransferStatus>()
         destroy()
@@ -262,9 +264,7 @@ class TransferManager private constructor(private val context: Context) {
 
     fun sendResponse(deviceResponse: ByteArray, closeAfterSending: Boolean) {
         communication.sendResponse(deviceResponse, closeAfterSending)
-        if (closeAfterSending) {
-            disconnect()
-        }
+        disconnect(!closeAfterSending)
     }
 
     fun readDocumentEntries(documentName: String): DocumentElements {


### PR DESCRIPTION
Fixes #462

This PR changes the method `sendResponse` in class `Communication` to only close the underlying `mTransport` after the `deviceResponse` has been fully sent. 