### PR TITLE
Split self-signed issuing authority in two

### DIFF
--- a/wallet/src/main/java/com/android/identity/issuance/simple/SimpleIssuingAuthorityProofingGraph.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/simple/SimpleIssuingAuthorityProofingGraph.kt
@@ -208,7 +208,7 @@ class SimpleIssuingAuthorityProofingGraph {
         override val followUps: Iterable<Node>
             get() = setOf(successfulActiveAuthentication, successfulChipAuthentication, noAuthentication)
 
-        override fun selectFollowUp(response: EvidenceResponse): Node? {
+        override fun selectFollowUp(response: EvidenceResponse): Node {
             val resp = response as EvidenceResponseIcaoNfcTunnelResult
             return when (resp.advancedAuthenticationType) {
                 EvidenceResponseIcaoNfcTunnelResult.AdvancedAuthenticationType.NONE -> noAuthentication

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PassportBasedIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PassportBasedIssuingAuthority.kt
@@ -1,0 +1,178 @@
+package com.android.identity_credential.wallet
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.toDataItemDateTimeString
+import com.android.identity.credential.NameSpacedData
+import com.android.identity.issuance.CredentialConfiguration
+import com.android.identity.issuance.CredentialPresentationFormat
+import com.android.identity.issuance.IssuingAuthorityConfiguration
+import com.android.identity.issuance.evidence.EvidenceResponse
+import com.android.identity.issuance.evidence.EvidenceResponseIcaoNfcTunnelResult
+import com.android.identity.issuance.evidence.EvidenceResponseIcaoPassiveAuthentication
+import com.android.identity.issuance.evidence.EvidenceResponseMessage
+import com.android.identity.issuance.simple.SimpleIcaoNfcTunnelDriver
+import com.android.identity.issuance.simple.SimpleIssuingAuthorityProofingGraph
+import com.android.identity.storage.StorageEngine
+import com.android.identity_credential.mrtd.MrtdNfcData
+import com.android.identity_credential.mrtd.MrtdNfcDataDecoder
+import kotlinx.datetime.Clock
+import java.io.ByteArrayOutputStream
+import kotlin.time.Duration.Companion.days
+
+class PassportBasedIssuingAuthority(
+    application: WalletApplication,
+    storageEngine: StorageEngine
+) : SelfSignedMdlIssuingAuthority(application, storageEngine) {
+
+    override lateinit var configuration: IssuingAuthorityConfiguration
+
+    init {
+        val baos = ByteArrayOutputStream()
+        BitmapFactory.decodeResource(
+            application.applicationContext.resources,
+            R.drawable.img_erika_portrait
+        )
+            .compress(Bitmap.CompressFormat.JPEG, 90, baos)
+        val icon: ByteArray = baos.toByteArray()
+        configuration = IssuingAuthorityConfiguration(
+            "mDL_Utopia",
+            resourceString(R.string.passport_based_authority_name),
+            icon,
+            setOf(CredentialPresentationFormat.MDOC_MSO),
+            createCredentialConfiguration(null)
+        )
+    }
+
+    override fun getProofingGraphRoot(): SimpleIssuingAuthorityProofingGraph.Node {
+        return SimpleIssuingAuthorityProofingGraph.create {
+            message(
+                "tos",
+                resourceString(R.string.passport_based_authority_tos),
+                resourceString(R.string.passport_based_authority_accept),
+                resourceString(R.string.passport_based_authority_reject),
+            )
+            icaoTunnel("tunnel", listOf(1, 2, 7)) {
+                whenChipAuthenticated {
+                    message(
+                        "inform",
+                        resourceString(R.string.passport_based_authority_chip_authentication),
+                        resourceString(R.string.passport_based_authority_continue),
+                        null
+                    )
+                }
+                whenActiveAuthenticated {
+                    message(
+                        "inform",
+                        resourceString(R.string.passport_based_authority_active_authentication),
+                        resourceString(R.string.passport_based_authority_continue),
+                        null
+                    )
+                }
+                whenNotAuthenticated {
+                    message(
+                        "inform",
+                        resourceString(R.string.passport_based_authority_no_authentication),
+                        resourceString(R.string.passport_based_authority_continue),
+                        null
+                    )
+                }
+            }
+            message(
+                "message",
+                resourceString(R.string.passport_based_authority_application_finish),
+                resourceString(R.string.passport_based_authority_continue),
+                null
+            )
+        }
+    }
+
+    override fun createNfcTunnelHandler(): SimpleIcaoNfcTunnelDriver {
+        return NfcTunnelDriver()
+    }
+
+    override fun checkEvidence(collectedEvidence: Map<String, EvidenceResponse>): Boolean {
+        return (collectedEvidence["tos"] as EvidenceResponseMessage).acknowledged
+    }
+
+    override fun generateCredentialConfiguration(collectedEvidence: Map<String, EvidenceResponse>): CredentialConfiguration {
+        return createCredentialConfiguration(collectedEvidence)
+    }
+
+    private fun createCredentialConfiguration(collectedEvidence: Map<String, EvidenceResponse>?): CredentialConfiguration {
+        if (collectedEvidence == null) {
+            return CredentialConfiguration(
+                resourceString(R.string.self_signed_authority_pending_credential_title),
+                createArtwork(
+                    Color.rgb(192, 192, 192),
+                    Color.rgb(96, 96, 96),
+                    null,
+                    resourceString(R.string.self_signed_authority_pending_credential_text),
+                ),
+                NameSpacedData.Builder().build()
+            )
+        }
+
+        val icaoPassiveData = collectedEvidence["passive"]
+        val icaoTunnelData = collectedEvidence["tunnel"]
+        val mrtdData = if (icaoTunnelData is EvidenceResponseIcaoNfcTunnelResult)
+            MrtdNfcData(icaoTunnelData.dataGroups, icaoTunnelData.securityObject)
+        else if (icaoPassiveData is EvidenceResponseIcaoPassiveAuthentication)
+            MrtdNfcData(icaoPassiveData.dataGroups, icaoPassiveData.securityObject)
+        else
+            throw IllegalStateException("Should not happen")
+        val decoder = MrtdNfcDataDecoder(application.cacheDir)
+        val decoded = decoder.decode(mrtdData)
+        val firstName = decoded.firstName
+        val lastName = decoded.lastName
+        val sex = when (decoded.gender) {
+            "MALE" -> 1L
+            "FEMALE" -> 2L
+            else -> 0L
+        }
+        val portrait = bitmapData(decoded.photo, R.drawable.img_erika_portrait)
+        val signatureOrUsualMark = bitmapData(decoded.signature, R.drawable.img_erika_signature)
+
+        val gradientColor = Pair(
+            Color.rgb(255, 255, 64),
+            Color.rgb(96, 96, 0),
+        )
+
+        val now = Clock.System.now()
+        val issueDate = now
+        val expiryDate = now + 5.days * 365
+
+        val staticData = NameSpacedData.Builder()
+            .putEntryString(MDL_NAMESPACE, "given_name", firstName)
+            .putEntryString(MDL_NAMESPACE, "family_name", lastName)
+            .putEntryByteString(MDL_NAMESPACE, "portrait", portrait)
+            .putEntryByteString(MDL_NAMESPACE, "signature_usual_mark", signatureOrUsualMark)
+            .putEntryNumber(MDL_NAMESPACE, "sex", sex)
+            .putEntry(MDL_NAMESPACE, "issue_date", Cbor.encode(issueDate.toDataItemDateTimeString))
+            .putEntry(
+                MDL_NAMESPACE,
+                "expiry_date",
+                Cbor.encode(expiryDate.toDataItemDateTimeString)
+            )
+            .putEntryString(MDL_NAMESPACE, "document_number", "1234567890")
+            .putEntryString(MDL_NAMESPACE, "issuing_authority", "State of Utopia")
+            .putEntryString(AAMVA_NAMESPACE, "DHS_compliance", "F")
+            .putEntryNumber(AAMVA_NAMESPACE, "EDL_credential", 1)
+            .putEntryBoolean(MDL_NAMESPACE, "age_over_18", true)
+            .putEntryBoolean(MDL_NAMESPACE, "age_over_21", true)
+            .build()
+
+        return CredentialConfiguration(
+            resourceString(R.string.self_signed_authority_credential_title, firstName),
+            createArtwork(
+                gradientColor.first,
+                gradientColor.second,
+                portrait,
+                resourceString(R.string.self_signed_authority_credential_text, firstName),
+            ),
+            staticData
+        )
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfCertificationIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfCertificationIssuingAuthority.kt
@@ -1,0 +1,180 @@
+package com.android.identity_credential.wallet
+
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.graphics.Color
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.toDataItemDateTimeString
+import com.android.identity.credential.NameSpacedData
+import com.android.identity.issuance.CredentialConfiguration
+import com.android.identity.issuance.CredentialPresentationFormat
+import com.android.identity.issuance.IssuingAuthorityConfiguration
+import com.android.identity.issuance.evidence.EvidenceResponse
+import com.android.identity.issuance.evidence.EvidenceResponseMessage
+import com.android.identity.issuance.evidence.EvidenceResponseQuestionMultipleChoice
+import com.android.identity.issuance.evidence.EvidenceResponseQuestionString
+import com.android.identity.issuance.simple.SimpleIssuingAuthorityProofingGraph
+import com.android.identity.storage.StorageEngine
+import kotlinx.datetime.Clock
+import java.io.ByteArrayOutputStream
+import kotlin.time.Duration.Companion.days
+
+class SelfCertificationIssuingAuthority(
+    application: WalletApplication, storageEngine: StorageEngine
+) : SelfSignedMdlIssuingAuthority(application, storageEngine) {
+
+    override lateinit var configuration: IssuingAuthorityConfiguration
+
+    init {
+        val baos = ByteArrayOutputStream()
+        BitmapFactory.decodeResource(
+            application.applicationContext.resources, R.drawable.img_erika_portrait
+        ).compress(Bitmap.CompressFormat.JPEG, 90, baos)
+        val icon: ByteArray = baos.toByteArray()
+        configuration = IssuingAuthorityConfiguration(
+            "mDL_Anarchy",
+            resourceString(R.string.self_certification_authority_name),
+            icon,
+            setOf(CredentialPresentationFormat.MDOC_MSO),
+            createCredentialConfiguration(null)
+        )
+    }
+
+    override fun getProofingGraphRoot(): SimpleIssuingAuthorityProofingGraph.Node {
+        return SimpleIssuingAuthorityProofingGraph.create {
+            message(
+                "tos",
+                resourceString(R.string.self_certification_authority_tos),
+                resourceString(R.string.self_certification_authority_accept),
+                resourceString(R.string.self_certification_authority_reject),
+            )
+            question(
+                "firstName",
+                resourceString(R.string.self_certification_authority_question_first_name),
+                "Erika",
+                resourceString(R.string.self_certification_authority_continue)
+            )
+
+            question(
+                "lastName",
+                resourceString(R.string.self_certification_authority_question_last_name),
+                "Mustermann",
+                resourceString(R.string.self_certification_authority_continue)
+            )
+
+            choice(
+                "art",
+                resourceString(R.string.self_certification_authority_card_art),
+                resourceString(R.string.self_certification_authority_continue)
+            ) {
+                on("green", resourceString(R.string.self_certification_authority_card_art_green)) {}
+                on("blue", resourceString(R.string.self_certification_authority_card_art_blue)) {}
+                on("red", resourceString(R.string.self_certification_authority_card_art_red)) {}
+            }
+            message(
+                "message",
+                resourceString(R.string.self_certification_authority_application_finish),
+                resourceString(R.string.self_certification_authority_continue),
+                null
+            )
+        }
+    }
+
+    override fun checkEvidence(collectedEvidence: Map<String, EvidenceResponse>): Boolean {
+        return (collectedEvidence["tos"] as EvidenceResponseMessage).acknowledged
+    }
+
+    override fun generateCredentialConfiguration(collectedEvidence: Map<String, EvidenceResponse>): CredentialConfiguration {
+        return createCredentialConfiguration(collectedEvidence)
+    }
+
+    private fun createCredentialConfiguration(collectedEvidence: Map<String, EvidenceResponse>?): CredentialConfiguration {
+        if (collectedEvidence == null) {
+            return CredentialConfiguration(
+                resourceString(R.string.self_signed_authority_pending_credential_title),
+                createArtwork(
+                    Color.rgb(192, 192, 192),
+                    Color.rgb(96, 96, 96),
+                    null,
+                    resourceString(R.string.self_signed_authority_pending_credential_text),
+                ),
+                NameSpacedData.Builder().build()
+            )
+        }
+
+        val evidenceWithFirstName = collectedEvidence["firstName"]
+        val evidenceWithLastName = collectedEvidence["lastName"]
+        val firstName = (evidenceWithFirstName as EvidenceResponseQuestionString).answer
+        val lastName = (evidenceWithLastName as EvidenceResponseQuestionString).answer
+        val sex = 2L
+        val portrait = bitmapData(null, R.drawable.img_erika_portrait)
+        val signatureOrUsualMark = bitmapData(null, R.drawable.img_erika_signature)
+
+
+        val cardArtColor =
+            (collectedEvidence["art"] as EvidenceResponseQuestionMultipleChoice).answerId
+        val gradientColor = when (cardArtColor) {
+            "green" -> {
+                Pair(
+                    Color.rgb(64, 255, 64),
+                    Color.rgb(0, 96, 0),
+                )
+            }
+
+            "blue" -> {
+                Pair(
+                    Color.rgb(64, 64, 255),
+                    Color.rgb(0, 0, 96),
+                )
+            }
+
+            "red" -> {
+                Pair(
+                    Color.rgb(255, 64, 64),
+                    Color.rgb(96, 0, 0),
+                )
+            }
+
+            else -> {
+                Pair(
+                    Color.rgb(255, 255, 64),
+                    Color.rgb(96, 96, 0),
+                )
+            }
+        }
+
+
+        val now = Clock.System.now()
+        val issueDate = now
+        val expiryDate = now + 5.days * 365
+
+        val staticData =
+            NameSpacedData.Builder().putEntryString(MDL_NAMESPACE, "given_name", firstName)
+                .putEntryString(MDL_NAMESPACE, "family_name", lastName)
+                .putEntryByteString(MDL_NAMESPACE, "portrait", portrait)
+                .putEntryByteString(MDL_NAMESPACE, "signature_usual_mark", signatureOrUsualMark)
+                .putEntryNumber(MDL_NAMESPACE, "sex", sex).putEntry(
+                    MDL_NAMESPACE,
+                    "issue_date",
+                    Cbor.encode(issueDate.toDataItemDateTimeString)
+                ).putEntry(
+                    MDL_NAMESPACE, "expiry_date", Cbor.encode(expiryDate.toDataItemDateTimeString)
+                ).putEntryString(MDL_NAMESPACE, "document_number", "1234567890")
+                .putEntryString(MDL_NAMESPACE, "issuing_authority", "State of Utopia")
+                .putEntryString(AAMVA_NAMESPACE, "DHS_compliance", "F")
+                .putEntryNumber(AAMVA_NAMESPACE, "EDL_credential", 1)
+                .putEntryBoolean(MDL_NAMESPACE, "age_over_18", true)
+                .putEntryBoolean(MDL_NAMESPACE, "age_over_21", true).build()
+
+        return CredentialConfiguration(
+            resourceString(R.string.self_signed_authority_credential_title, firstName),
+            createArtwork(
+                gradientColor.first,
+                gradientColor.second,
+                portrait,
+                resourceString(R.string.self_signed_authority_credential_text, firstName),
+            ),
+            staticData
+        )
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdlIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdlIssuingAuthority.kt
@@ -54,7 +54,7 @@ import kotlin.random.Random
 import kotlin.time.Duration.Companion.days
 
 
-class SelfSignedMdlIssuingAuthority(
+abstract class SelfSignedMdlIssuingAuthority(
     val application: WalletApplication,
     storageEngine: StorageEngine
 ): SimpleIssuingAuthority(
@@ -66,25 +66,6 @@ class SelfSignedMdlIssuingAuthority(
         val MDL_DOCTYPE = "org.iso.18013.5.1.mDL"
         val MDL_NAMESPACE = "org.iso.18013.5.1"
         val AAMVA_NAMESPACE = "org.iso.18013.5.1.aamva"
-    }
-
-    override lateinit var configuration: IssuingAuthorityConfiguration
-
-    init {
-        val baos = ByteArrayOutputStream()
-        BitmapFactory.decodeResource(
-            application.applicationContext.resources,
-            R.drawable.img_erika_portrait
-        )
-            .compress(Bitmap.CompressFormat.JPEG, 90, baos)
-        val icon: ByteArray = baos.toByteArray()
-        configuration = IssuingAuthorityConfiguration(
-            "mDL_Utopia",
-            resourceString(R.string.self_signed_authority_name),
-            icon,
-            setOf(CredentialPresentationFormat.MDOC_MSO),
-            createCredentialConfiguration(null)
-        )
     }
 
     override fun createPresentationData(presentationFormat: CredentialPresentationFormat,
@@ -196,197 +177,7 @@ class SelfSignedMdlIssuingAuthority(
 
     }
 
-    override fun createNfcTunnelHandler(): SimpleIcaoNfcTunnelDriver {
-        return NfcTunnelDriver()
-    }
-
-
-    override fun getProofingGraphRoot(): SimpleIssuingAuthorityProofingGraph.Node {
-        return SimpleIssuingAuthorityProofingGraph.create {
-            message(
-                "tos",
-                resourceString(R.string.self_signed_authority_tos),
-                resourceString(R.string.self_signed_authority_accept),
-                resourceString(R.string.self_signed_authority_reject),
-            )
-            choice("path",
-                resourceString(R.string.self_signed_authority_authentication_choice),
-                resourceString(R.string.self_signed_authority_continue)) {
-                on("icaoPassive",
-                    resourceString(R.string.self_signed_authority_scan_passport)) {
-                    icaoPassiveAuthentication("passive", listOf(1, 2, 7))
-                }
-                on("icaoTunnel",
-                    resourceString(R.string.self_signed_authority_scan_passport_auth)) {
-                    icaoTunnel("tunnel", listOf(1, 2, 7)) {
-                        whenChipAuthenticated {
-                            message("inform",
-                                resourceString(R.string.self_signed_authority_chip_authentication),
-                                resourceString(R.string.self_signed_authority_continue),
-                                null
-                            )
-                        }
-                        whenActiveAuthenticated {
-                            message("inform",
-                                resourceString(R.string.self_signed_authority_active_authentication),
-                                resourceString(R.string.self_signed_authority_continue),
-                                null
-                            )
-                        }
-                        whenNotAuthenticated {
-                            message("inform",
-                                resourceString(R.string.self_signed_authority_no_authentication),
-                                resourceString(R.string.self_signed_authority_continue),
-                                null
-                            )
-                        }
-                    }
-                }
-                on("questions",
-                    resourceString(R.string.self_signed_authority_answer_questions)) {
-                    question(
-                        "firstName",
-                        resourceString(R.string.self_signed_authority_question_first_name),
-                        "Erika",
-                        resourceString(R.string.self_signed_authority_continue)
-                    )
-                }
-            }
-            choice("art",
-                resourceString(R.string.self_signed_authority_card_art),
-                resourceString(R.string.self_signed_authority_continue)) {
-                on("green", resourceString(R.string.self_signed_authority_card_art_green)) {}
-                on("blue", resourceString(R.string.self_signed_authority_card_art_blue)) {}
-                on("red", resourceString(R.string.self_signed_authority_card_art_red)) {}
-            }
-            message("message",
-                resourceString(R.string.self_signed_authority_application_finish),
-                resourceString(R.string.self_signed_authority_continue),
-                null
-            )
-        }
-    }
-
-    override fun checkEvidence(collectedEvidence: Map<String, EvidenceResponse>): Boolean {
-        return (collectedEvidence["tos"] as EvidenceResponseMessage).acknowledged
-    }
-
-    override fun generateCredentialConfiguration(collectedEvidence: Map<String, EvidenceResponse>): CredentialConfiguration {
-        return createCredentialConfiguration(collectedEvidence)
-    }
-
-    private fun createCredentialConfiguration(collectedEvidence: Map<String, EvidenceResponse>?): CredentialConfiguration {
-        if (collectedEvidence == null) {
-            return CredentialConfiguration(
-                resourceString(R.string.self_signed_authority_pending_credential_title),
-                createArtwork(
-                    Color.rgb(192, 192, 192),
-                    Color.rgb(96, 96, 96),
-                    null,
-                    resourceString(R.string.self_signed_authority_pending_credential_text),
-                ),
-                NameSpacedData.Builder().build()
-            )
-        }
-
-        val icaoPassiveData = collectedEvidence["passive"]
-        val icaoTunnelData = collectedEvidence["tunnel"]
-        val firstName: String
-        val lastName: String
-        val portrait: ByteArray
-        val signatureOrUsualMark: ByteArray
-        val sex: Long
-        if (icaoPassiveData is EvidenceResponseIcaoPassiveAuthentication ||
-            icaoTunnelData is EvidenceResponseIcaoNfcTunnelResult) {
-            val mrtdData = if (icaoTunnelData is EvidenceResponseIcaoNfcTunnelResult)
-                    MrtdNfcData(icaoTunnelData.dataGroups, icaoTunnelData.securityObject)
-                else if (icaoPassiveData is EvidenceResponseIcaoPassiveAuthentication)
-                    MrtdNfcData(icaoPassiveData.dataGroups, icaoPassiveData.securityObject)
-                else
-                    throw IllegalStateException("Should not happen")
-            val decoder = MrtdNfcDataDecoder(application.cacheDir)
-            val decoded = decoder.decode(mrtdData)
-            firstName = decoded.firstName
-            lastName = decoded.lastName
-            sex = when (decoded.gender) {
-                "MALE" -> 1
-                "FEMALE" -> 2
-                else -> 0
-            }
-            portrait = bitmapData(decoded.photo, R.drawable.img_erika_portrait)
-            signatureOrUsualMark = bitmapData(decoded.signature, R.drawable.img_erika_signature)
-        } else {
-            val evidenceWithName = collectedEvidence["firstName"]
-            firstName = (evidenceWithName as EvidenceResponseQuestionString).answer
-            lastName = "Mustermann"
-            sex = 2
-            portrait = bitmapData(null, R.drawable.img_erika_portrait)
-            signatureOrUsualMark = bitmapData(null, R.drawable.img_erika_signature)
-        }
-
-
-        val cardArtColor = (collectedEvidence["art"] as EvidenceResponseQuestionMultipleChoice).answerId
-        val gradientColor = when (cardArtColor) {
-            "green" -> {
-                Pair(
-                    android.graphics.Color.rgb(64, 255, 64),
-                    android.graphics.Color.rgb(0, 96, 0),
-                )
-            }
-            "blue" -> {
-                Pair(
-                    android.graphics.Color.rgb(64, 64, 255),
-                    android.graphics.Color.rgb(0, 0, 96),
-                )
-            }
-            "red" -> {
-                Pair(
-                    android.graphics.Color.rgb(255, 64, 64),
-                    android.graphics.Color.rgb(96, 0, 0),
-                )
-            }
-            else -> {
-                Pair(
-                    android.graphics.Color.rgb(255, 255, 64),
-                    android.graphics.Color.rgb(96, 96, 0),
-                )
-            }
-        }
-
-
-        val now = Clock.System.now()
-        val issueDate = now
-        val expiryDate = now + 5.days*365
-
-        val staticData = NameSpacedData.Builder()
-            .putEntryString(MDL_NAMESPACE, "given_name", firstName)
-            .putEntryString(MDL_NAMESPACE, "family_name", lastName)
-            .putEntryByteString(MDL_NAMESPACE, "portrait", portrait)
-            .putEntryByteString(MDL_NAMESPACE, "signature_usual_mark", signatureOrUsualMark)
-            .putEntryNumber(MDL_NAMESPACE, "sex", sex)
-            .putEntry(MDL_NAMESPACE, "issue_date", Cbor.encode(issueDate.toDataItemDateTimeString))
-            .putEntry(MDL_NAMESPACE, "expiry_date", Cbor.encode(expiryDate.toDataItemDateTimeString))
-            .putEntryString(MDL_NAMESPACE, "document_number", "1234567890")
-            .putEntryString(MDL_NAMESPACE, "issuing_authority", "State of Utopia")
-            .putEntryString(AAMVA_NAMESPACE, "DHS_compliance", "F")
-            .putEntryNumber(AAMVA_NAMESPACE, "EDL_credential", 1)
-            .putEntryBoolean(MDL_NAMESPACE, "age_over_18", true)
-            .putEntryBoolean(MDL_NAMESPACE, "age_over_21", true)
-            .build()
-
-        return CredentialConfiguration(
-            resourceString(R.string.self_signed_authority_credential_title, firstName),
-            createArtwork(
-                gradientColor.first,
-                gradientColor.second,
-                portrait,
-                resourceString(R.string.self_signed_authority_credential_text, firstName),
-            ),
-            staticData
-        )
-    }
-
-    private fun bitmapData(bitmap: Bitmap?, defaultResourceId: Int): ByteArray {
+    protected fun bitmapData(bitmap: Bitmap?, defaultResourceId: Int): ByteArray {
         val baos = ByteArrayOutputStream()
         (bitmap
             ?: BitmapFactory.decodeResource(
@@ -396,7 +187,7 @@ class SelfSignedMdlIssuingAuthority(
         return baos.toByteArray()
     }
 
-    private fun createArtwork(color1: Int,
+    protected fun createArtwork(color1: Int,
                               color2: Int,
                               portrait: ByteArray?,
                               artworkText: String): ByteArray {
@@ -446,7 +237,7 @@ class SelfSignedMdlIssuingAuthority(
         return baos.toByteArray()
     }
 
-    private fun resourceString(id: Int, vararg text: String): String {
+    protected fun resourceString(id: Int, vararg text: String): String {
         return application.applicationContext.resources.getString(id, *text)
     }
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -60,6 +60,7 @@ class WalletApplication : Application() {
         credentialStore = CredentialStore(storageEngine, secureAreaRepository)
 
         issuingAuthorityRepository = IssuingAuthorityRepository()
-        issuingAuthorityRepository.add(SelfSignedMdlIssuingAuthority(this, storageEngine))
+        issuingAuthorityRepository.add(SelfCertificationIssuingAuthority(this, storageEngine))
+        issuingAuthorityRepository.add(PassportBasedIssuingAuthority(this, storageEngine))
     }
 }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -95,31 +95,26 @@
     <string name="accessibility_signature">Signature or Usual Mark of Holder</string>
     <string name="accessibility_qr_code">QR code</string>
 
-    <!-- SelfSignedMdlIssuingAuthority -->
-    <string name="self_signed_authority_name">Utopia mDL</string>
-    <string name="self_signed_authority_tos">
-        Here\'s a long string with TOS. Lorem ipsum dolor sit amet, consectetur
-        adipiscing elit. Vivamus dictum vel metus non mattis. Ut mattis,
-        ipsum vel hendrerit consectetur, mauris purus ultricies nulla, sit amet
-        pulvinar odio lorem sed justo. Aliquam erat volutpat.
-        Nulla facilisi.
+    <!-- SelfCertificationIssuingAuthority -->
+    <string name="self_certification_authority_name">Anarchist mDL</string>
+    <string name="self_certification_authority_tos">
+        Authority assumes numerous shapes and disguises, and it will take a long period of
+        development under freedom to get rid of all. To do this two things are wanted, to rid
+        ourselves of all superstition and to root out the stronghold of all authority, the State.
+        We shall be asked what we intend to put in place of the State. We reply, “Nothing whatever!”
+        The State is simply an obstacle to progress; this obstacle once removed we do not want
+        to erect a fresh obstruction.
     </string>
-    <string name="self_signed_authority_accept">Accept</string>
-    <string name="self_signed_authority_reject">Do Not Accept</string>
-    <string name="self_signed_authority_authentication_choice">How do you want to authenticate</string>
-    <string name="self_signed_authority_continue">Continue</string>
-    <string name="self_signed_authority_scan_passport">Scan passport</string>
-    <string name="self_signed_authority_scan_passport_auth">Scan passport with authentication</string>
-    <string name="self_signed_authority_answer_questions">Answer questions</string>
-    <string name="self_signed_authority_chip_authentication">Excellent! You passport supports chip authentication.</string>
-    <string name="self_signed_authority_active_authentication">Nice! You passport supports active authentication.</string>
-    <string name="self_signed_authority_no_authentication">Your passport only supports passive authentication. Who knows, maybe it is a clone? There is no protection.</string>
-    <string name="self_signed_authority_question_first_name">What first name should be used for the mDL?</string>
-    <string name="self_signed_authority_card_art">Select the card art for the credential</string>
-    <string name="self_signed_authority_card_art_green">Green</string>
-    <string name="self_signed_authority_card_art_blue">Blue</string>
-    <string name="self_signed_authority_card_art_red">Red</string>
-    <string name="self_signed_authority_application_finish">
+    <string name="self_certification_authority_accept">Accept</string>
+    <string name="self_certification_authority_reject">Do Not Accept</string>
+    <string name="self_certification_authority_question_first_name">What first name should be used for the mDL?</string>
+    <string name="self_certification_authority_question_last_name">What last name should be used for the mDL?</string>
+    <string name="self_certification_authority_continue">Continue</string>
+    <string name="self_certification_authority_card_art">Select the card art for the credential</string>
+    <string name="self_certification_authority_card_art_green">Green</string>
+    <string name="self_certification_authority_card_art_blue">Blue</string>
+    <string name="self_certification_authority_card_art_red">Red</string>
+    <string name="self_certification_authority_application_finish">
         Your application is about to be sent the ID issuer for verification. You will get notified
         when the application is approved.
     </string>
@@ -127,4 +122,25 @@
     <string name="self_signed_authority_pending_credential_text">mDL (Pending)</string>
     <string name="self_signed_authority_credential_title">%1$s\'s mDL</string>
     <string name="self_signed_authority_credential_text">%1$s\'s mDL</string>
+
+    <!-- PassportBasedIssuingAuthority -->
+    <string name="passport_based_authority_name">Utopia mDL</string>
+    <string name="passport_based_authority_tos">
+        When people are suspicious with you, you start being suspicious with them.
+    </string>
+    <string name="passport_based_authority_accept">Accept</string>
+    <string name="passport_based_authority_reject">Do Not Accept</string>
+    <string name="passport_based_authority_continue">Continue</string>
+    <string name="passport_based_authority_chip_authentication">Excellent! You passport supports chip authentication.</string>
+    <string name="passport_based_authority_active_authentication">Nice! You passport supports active authentication.</string>
+    <string name="passport_based_authority_no_authentication">Your passport only supports passive authentication. Who knows, maybe it is a clone? There is no protection.</string>
+    <string name="passport_based_authority_application_finish">
+        Your application is about to be sent the ID issuer for verification. You will get notified
+        when the application is approved.
+    </string>
+    <string name="passport_based_authority_pending_credential_title">Utopia mDL (pending)</string>
+    <string name="passport_based_authority_authority_pending_credential_text">mDL (Pending)</string>
+    <string name="passport_based_authority_credential_title">%1$s\'s mDL</string>
+    <string name="passport_based_authority_credential_text">%1$s\'s mDL</string>
+
 </resources>


### PR DESCRIPTION
Split passport-based and self-certifying issuers apart. Also only use tunnel-based workflow to read MRTD (so that we can do chip/active authentication). This simplifies the evidence-gathering workflow.

Still to do: wordsmith the messages (and localize them if wanted?)
 