### PR TITLE
Biometric Prompt in Wallet

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/BiometricUserAuthPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/BiometricUserAuthPrompt.kt
@@ -1,0 +1,158 @@
+package com.android.identity_credential.wallet
+
+import android.os.Handler
+import android.os.Looper
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.biometric.BiometricPrompt.PromptInfo
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import com.android.identity.android.securearea.UserAuthenticationType
+
+/**
+ * Prompts user for authentication, and calls the provided functions when authentication is
+ * complete. Biometric authentication will be offered first if both [UserAuthenticationType.LSKF]
+ * and [UserAuthenticationType.BIOMETRIC] are allowed.
+ *
+ * @param activity the activity hosting the authentication prompt
+ * @param title the title for the authentication prompt
+ * @param cryptoObject a crypto object to be associated with this authentication
+ * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
+ *                                least one element
+ * @param requireConfirmation option to require explicit user confirmation after a passive biometric
+ * @param onSuccess the function which will be called when the user successfully authenticates
+ * @param onCanceled the function which will be called when the user cancels
+ * @param onError the function which will be called when there is an unexpected error in the user
+ *                authentication process - a throwable will be passed into this function
+ */
+fun showBiometricPrompt(
+    activity: FragmentActivity,
+    title: String,
+    cryptoObject: BiometricPrompt.CryptoObject?,
+    userAuthenticationTypes: Set<UserAuthenticationType>,
+    requireConfirmation: Boolean,
+    onSuccess: () -> Unit,
+    onCanceled: () -> Unit,
+    onError: (Throwable) -> Unit,
+) {
+    if (userAuthenticationTypes.isEmpty()) {
+        onError.invoke(
+            IllegalStateException(
+                "userAuthenticationTypes must contain at least one authentication type"
+            )
+        )
+    }
+
+    BiometricUserAuthPrompt(
+        activity = activity,
+        title = title,
+        cryptoObject = cryptoObject,
+        userAuthenticationTypes = userAuthenticationTypes,
+        requireConfirmation = requireConfirmation,
+        onSuccess = onSuccess,
+        onCanceled = onCanceled,
+        onError = onError
+    ).authenticate()
+}
+
+private class BiometricUserAuthPrompt(
+    private val activity: FragmentActivity,
+    private val title: String,
+    private val cryptoObject: BiometricPrompt.CryptoObject?,
+    private val userAuthenticationTypes: Set<UserAuthenticationType>,
+    private val requireConfirmation: Boolean,
+    private val onSuccess: () -> Unit,
+    private val onCanceled: () -> Unit,
+    private val onError: (Throwable) -> Unit,
+) {
+    companion object {
+        private const val TAG = "BiometricPromptViewModel"
+    }
+
+    private var lskfOnNegativeBtn: Boolean = false
+
+    private var biometricAuthCallback = object : BiometricPrompt.AuthenticationCallback() {
+        override fun onAuthenticationError(
+            errorCode: Int,
+            errorString: CharSequence
+        ) {
+            super.onAuthenticationError(errorCode, errorString)
+            if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON && lskfOnNegativeBtn) {
+                // if no delay is injected, then biometric prompt's auth callbacks would not be called
+                Handler(Looper.getMainLooper()).postDelayed({
+                    authenticateLskf()
+                }, 100)
+            } else if (errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
+                onCanceled.invoke()
+            } else {
+                onError.invoke(IllegalStateException(errorString.toString()))
+            }
+        }
+
+        override fun onAuthenticationSucceeded(
+            result: BiometricPrompt.AuthenticationResult
+        ) {
+            super.onAuthenticationSucceeded(result)
+            onSuccess()
+        }
+
+        override fun onAuthenticationFailed() {
+            super.onAuthenticationFailed()
+            onCanceled.invoke()
+        }
+    }
+
+    private var biometricPrompt = BiometricPrompt(
+        activity,
+        ContextCompat.getMainExecutor(activity),
+        biometricAuthCallback
+    )
+
+    fun authenticate() {
+        lskfOnNegativeBtn = userAuthenticationTypes.contains(UserAuthenticationType.LSKF)
+
+        if (userAuthenticationTypes.contains(UserAuthenticationType.BIOMETRIC)) {
+            authenticateBiometric()
+        } else {
+            authenticateLskf()
+        }
+    }
+
+    private fun authenticateBiometric() {
+        val negativeTxt =
+            if (lskfOnNegativeBtn) resourceString(R.string.biometric_prompt_negative_btn_lskf)
+            else resourceString(R.string.biometric_prompt_negative_btn_no_lskf)
+
+        val biometricPromptInfo = PromptInfo.Builder()
+            .setTitle(title)
+            .setNegativeButtonText(negativeTxt)
+            .setConfirmationRequired(requireConfirmation)
+            .build()
+
+        if (cryptoObject != null) {
+            biometricPrompt.authenticate(biometricPromptInfo, cryptoObject!!)
+        } else {
+            biometricPrompt.authenticate(biometricPromptInfo)
+        }
+    }
+
+    private fun authenticateLskf() {
+        lskfOnNegativeBtn = false
+
+        val lskfPromptInfo = PromptInfo.Builder()
+            .setTitle(title)
+            .setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+            .setConfirmationRequired(requireConfirmation)
+            .build()
+
+        if (cryptoObject != null) {
+            biometricPrompt.authenticate(lskfPromptInfo, cryptoObject!!)
+        } else {
+            biometricPrompt.authenticate(lskfPromptInfo)
+        }
+    }
+
+    private fun resourceString(id: Int, vararg text: String): String {
+        return activity.applicationContext.resources.getString(id, *text)
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-@file:OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
-
 package com.android.identity_credential.wallet
 
 import android.Manifest
@@ -24,9 +22,7 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.viewModels
-import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -80,6 +80,10 @@
     <string name="provisioning_error">Error provisioning: %1$s</string>
     <string name="provisioning_unexpected">Unexpected state: %1$s</string>
 
+    <!-- Presentation screen -->
+    <string name="presentation_authkey_usage_warning">Using previously used Auth Key</string>
+    <string name="presentation_biometric_prompt_title">Authentication Required</string>
+
     <!-- QR screen -->
     <string name="qr_title">QR Code</string>
     <string name="qr_error_generating">Error generating QR code</string>
@@ -164,6 +168,10 @@
     <string name="consent_prompt_title">The following information is being requested from \"%1$s\"</string>
     <string name="consent_prompt_title_verifier">%1$s is requesting information from \"%2$s\"</string>
     <string name="consent_prompt_icon_description">Verifier Icon</string>
+
+    <!-- Biometric Prompt -->
+    <string name="biometric_prompt_negative_btn_lskf">Use PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Cancel</string>
 
     <!-- Asset name (for localized assets -->
     <string name="asset_about_md">about.md</string>


### PR DESCRIPTION
Adds BiometricUserAuthPrompt and integrates into PresentationActivity such that any KeyLocked exceptions thrown during presentation can be caught and handled. BiometricUserAuthPrompt can support both LSKF and biometric unlocking - while it prefer biometric when both are available, LSKF is integrated into the prompt behavior as a fallback. Additionally, authkeys for credentials in AndroidSecureArea now require user authentication with timeout 0sec by default.

Tested manually with authkeys which require user authentication with allowed auth types of (LSKF + Biometric), (LSKF only), and (Biometric only) respectively. Also tested the cancellation + LSKF fallback cases.