### PR TITLE
Kotlinize Identity Android Updates to PR #507 

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/transfer/ReverseQrCommunicationSetup.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/ReverseQrCommunicationSetup.kt
@@ -11,10 +11,11 @@ import com.android.identity.mdoc.engagement.EngagementParser
 import com.android.identity.mdoc.origininfo.OriginInfo
 import com.android.identity.wallet.util.PreferencesHelper
 import com.android.identity.wallet.util.log
-import com.android.identity.wallet.util.mainExecutor
+import kotlinx.coroutines.CoroutineScope
 
 class ReverseQrCommunicationSetup(
     private val context: Context,
+    private val scope: CoroutineScope?,
     private val onPresentationReady: (presentation: DeviceRetrievalHelper) -> Unit,
     private val onNewRequest: (request: ByteArray) -> Unit,
     private val onDisconnected: () -> Unit,
@@ -75,14 +76,15 @@ class ReverseQrCommunicationSetup(
             connectionSetup.getConnectionOptions()
         )
 
-        val builder = DeviceRetrievalHelper.Builder(
-            context,
-            presentationListener,
-            context.mainExecutor(),
-            eDeviceKey
-        )
-        builder.useReverseEngagement(transport, encodedReaderEngagement, origins)
-        presentation = builder.build()
+        presentation = DeviceRetrievalHelper.Builder(
+            context = context,
+            scope = scope,
+            listener = presentationListener,
+            eDeviceKey = eDeviceKey,
+            transport = transport
+        ).apply {
+            useReverseEngagement(encodedReaderEngagement, origins)
+        }.build()
         onPresentationReady(requireNotNull(presentation))
     }
 }

--- a/appholder/src/main/java/com/android/identity/wallet/util/NfcDataTransferHandler.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/NfcDataTransferHandler.kt
@@ -16,12 +16,12 @@
 
 package com.android.identity.wallet.util
 
-import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
 import com.android.identity.android.mdoc.transport.DataTransportNfc
+import com.android.identity.android.util.HostApduServiceScoped
 import com.android.identity.wallet.transfer.TransferManager
 
-class NfcDataTransferHandler : HostApduService() {
+class NfcDataTransferHandler : HostApduServiceScoped() {
 
     private lateinit var transferManager: TransferManager
 

--- a/appholder/src/main/java/com/android/identity/wallet/viewmodel/ShareDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/viewmodel/ShareDocumentViewModel.kt
@@ -5,13 +5,15 @@ import android.view.View
 import androidx.databinding.ObservableField
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
+import androidx.lifecycle.viewModelScope
 import com.android.identity.mdoc.origininfo.OriginInfo
 import com.android.identity.wallet.transfer.TransferManager
 import com.android.identity.wallet.util.TransferStatus
 
 class ShareDocumentViewModel(val app: Application) : AndroidViewModel(app) {
 
-    private val transferManager = TransferManager.getInstance(app.applicationContext)
+    private val transferManager =
+        TransferManager.getInstance(app.applicationContext)
     var deviceEngagementQr = ObservableField<View>()
     var message = ObservableField<String>()
     private var hasStarted = false
@@ -23,7 +25,11 @@ class ShareDocumentViewModel(val app: Application) : AndroidViewModel(app) {
         originInfos: List<OriginInfo>
     ) {
         if (!hasStarted) {
-            transferManager.startPresentationReverseEngagement(reverseEngagementUri, originInfos)
+            transferManager.startPresentationReverseEngagement(
+                reverseEngagementUri,
+                originInfos,
+                viewModelScope
+            )
             hasStarted = true
         }
     }
@@ -42,6 +48,6 @@ class ShareDocumentViewModel(val app: Application) : AndroidViewModel(app) {
     }
 
     fun triggerQrEngagement() {
-        transferManager.startQrEngagement()
+        transferManager.startQrEngagement(viewModelScope)
     }
 }

--- a/appholder/src/main/java/com/android/identity/wallet/viewmodel/TransferDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/viewmodel/TransferDocumentViewModel.kt
@@ -31,7 +31,8 @@ import kotlinx.coroutines.withContext
 
 class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
 
-    private val transferManager = TransferManager.getInstance(app.applicationContext)
+    private val transferManager =
+        TransferManager.getInstance(app.applicationContext)
     private val documentManager = DocumentManager.getInstance(app.applicationContext)
     private val signedElements = SignedElementsCollection()
     private val requestedElements = mutableListOf<RequestedDocumentData>()
@@ -132,7 +133,12 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
                     )
                     transferManager.setResponseServed()
                     val documentsCount = elementsToSend.count()
-                    documentsSent.set(app.getString(R.string.txt_documents_sent, documentsCount as Int))
+                    documentsSent.set(
+                        app.getString(
+                            R.string.txt_documents_sent,
+                            documentsCount as Int
+                        )
+                    )
                     cleanUp()
                     onResultReady(result)
                     /*

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/DeviceEngagementFragment.kt
@@ -14,6 +14,7 @@ import android.widget.Toast
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import androidx.navigation.fragment.navArgs
 import com.android.mdl.appreader.R
@@ -62,7 +63,7 @@ class DeviceEngagementFragment : Fragment() {
 
         _binding = FragmentDeviceEngagementBinding.inflate(inflater, container, false)
         transferManager = TransferManager.getInstance(requireContext())
-        transferManager.initVerificationHelper()
+        transferManager.initVerificationHelper(lifecycleScope)
         return binding.root
 
     }

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -18,7 +18,6 @@ import androidx.fragment.app.Fragment
 import androidx.navigation.fragment.findNavController
 import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.DiagnosticOption
-import com.android.identity.cbor.Tagged
 import com.android.identity.credentialtype.CredentialAttributeType
 import com.android.identity.credentialtype.MdocDataElement
 import com.android.identity.crypto.javaPublicKey
@@ -340,7 +339,8 @@ class ShowDocumentFragment : Fragment() {
         namespaceName: String,
         dataElementName: String,
         mdocDataElement: MdocDataElement?,
-        value: ByteArray): String {
+        value: ByteArray
+    ): String {
         return try {
             // TODO: Make DataItem.toString() pretty print data elements and use it here instead
             when (mdocDataElement?.attribute?.type) {
@@ -349,6 +349,7 @@ class ShowDocumentFragment : Fragment() {
                 is CredentialAttributeType.Picture -> {
                     String.format("%d bytes", Cbor.decode(value).asBstr.size)
                 }
+
                 is CredentialAttributeType.Boolean -> Cbor.decode(value).asBoolean.toString()
                 is CredentialAttributeType.ComplexType -> FormatUtil.cborPrettyPrint(value)
                 is CredentialAttributeType.StringOptions -> {
@@ -372,9 +373,11 @@ class ShowDocumentFragment : Fragment() {
                 value,
                 setOf(DiagnosticOption.PRETTY_PRINT, DiagnosticOption.EMBEDDED_CBOR)
             )
-            Logger.w(TAG, "Unexpected exception processing mdoc data element " +
-                "$namespaceName $dataElementName with value $prettyValue and " +
-                    "type ${mdocDataElement?.attribute?.type}", e)
+            Logger.w(
+                TAG, "Unexpected exception processing mdoc data element " +
+                        "$namespaceName $dataElementName with value $prettyValue and " +
+                        "type ${mdocDataElement?.attribute?.type}", e
+            )
             prettyValue
         }
     }

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowQrFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowQrFragment.kt
@@ -11,6 +11,7 @@ import android.view.ViewGroup
 import android.widget.ImageView
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.android.mdl.appreader.R
 import com.android.mdl.appreader.databinding.FragmentShowQrBinding
@@ -40,8 +41,9 @@ class ShowQrFragment : Fragment() {
     ): View {
 
         _binding = FragmentShowQrBinding.inflate(inflater, container, false)
-        transferManager = TransferManager.getInstance(requireContext())
-        transferManager.initVerificationHelperReverseEngagement()
+        transferManager = TransferManager.getInstance(requireContext()).apply {
+            initVerificationHelperReverseEngagement(lifecycleScope)
+        }
         return binding.root
     }
 
@@ -69,9 +71,11 @@ class ShowQrFragment : Fragment() {
         return bitmap
     }
 
-    private fun getViewForReaderEngagementQrCode(readerEngagement : ByteArray): View {
-        val base64Encoded = Base64.encodeToString(readerEngagement,
-            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+    private fun getViewForReaderEngagementQrCode(readerEngagement: ByteArray): View {
+        val base64Encoded = Base64.encodeToString(
+            readerEngagement,
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP
+        )
         val uriEncoded = Uri.Builder()
             .scheme("mdoc://")
             .encodedOpaquePart(base64Encoded)
@@ -101,11 +105,13 @@ class ShowQrFragment : Fragment() {
 
                 TransferStatus.CONNECTED -> {
                     logDebug("Connected")
-                    val requestedDocuments = createRequestViewModel.calculateRequestDocumentList(false)
+                    val requestedDocuments =
+                        createRequestViewModel.calculateRequestDocumentList(false)
                     findNavController().navigate(
                         ShowQrFragmentDirections.actionShowQrToTransfer(requestedDocuments)
                     )
                 }
+
                 else -> {}
             }
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@
     jmrtd-version = "0.7.30"
     mlkit-version = "16.0.0"
     kotlinx-coroutines = "1.8.0-RC2"
+    kotlinx-coroutines-test = "1.8.0"
     kotlinx-io-core = "0.3.1"
     kotlinx-io-bytestring = "0.3.1"
     kotlinx-datetime = "0.5.0"
@@ -64,6 +65,7 @@
     androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "navigation" }
 
     kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref="kotlinx-coroutines" }
+    kotlinx-coroutines-android-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref="kotlinx-coroutines-test" }
     kotlinx-coroutines-guava = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-guava", version.ref="kotlinx-coroutines" }
 
     compose-bom = { module = "androidx.compose:compose-bom", version.ref="compose-bom" }

--- a/identity-android/build.gradle
+++ b/identity-android/build.gradle
@@ -40,14 +40,17 @@ dependencies {
     implementation libs.volley
     implementation libs.kotlinx.datetime
     implementation libs.kotlinx.io.bytestring
+    implementation libs.kotlinx.coroutines.android
 
     testImplementation libs.androidx.test.espresso
     testImplementation libs.androidx.test.ext.junit
     testImplementation libs.bouncy.castle.bcprov
     testImplementation libs.bundles.unit.testing
 
+
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.androidx.test.espresso
+    androidTestImplementation libs.kotlinx.coroutines.android.test
 }
 
 tasks.withType(Test) {

--- a/identity-android/src/androidTest/java/com/android/identity/AndroidAttestationExtensionParser.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/AndroidAttestationExtensionParser.kt
@@ -49,44 +49,41 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
     val teeEnforcedAuthorizationTags: Set<Int>
         get() = teeEnforcedAuthorizations.keys
 
-    fun getSoftwareAuthorizationInteger(tag: Int): Optional<Int> {
-        val entry = findAuthorizationListEntry(softwareEnforcedAuthorizations, tag)
-        return Optional.ofNullable(entry)
-            .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
-    }
+    fun getSoftwareAuthorizationInteger(tag: Int): Optional<Int> =
+        findAuthorizationListEntry(softwareEnforcedAuthorizations, tag).let { entry ->
+            Optional.ofNullable(entry)
+                .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
+        }
 
-    fun getSoftwareAuthorizationLong(tag: Int): Optional<Long> {
-        val entry = findAuthorizationListEntry(softwareEnforcedAuthorizations, tag)
-        return Optional.ofNullable(entry)
-            .map { asn1Value: ASN1Primitive -> getLongFromAsn1(asn1Value) }
-    }
+    fun getSoftwareAuthorizationLong(tag: Int): Optional<Long> =
+        findAuthorizationListEntry(softwareEnforcedAuthorizations, tag).let { entry ->
+            Optional.ofNullable(entry)
+                .map { asn1Value: ASN1Primitive -> getLongFromAsn1(asn1Value) }
+        }
 
-    fun getTeeAuthorizationInteger(tag: Int): Optional<Int> {
-        val entry = findAuthorizationListEntry(teeEnforcedAuthorizations, tag)
-        return Optional.ofNullable(entry)
-            .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
-    }
+    fun getTeeAuthorizationInteger(tag: Int): Optional<Int> =
+        findAuthorizationListEntry(teeEnforcedAuthorizations, tag).let { entry ->
+            Optional.ofNullable(entry)
+                .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
+        }
 
-    fun getSoftwareAuthorizationBoolean(tag: Int): Boolean {
-        val entry = findAuthorizationListEntry(softwareEnforcedAuthorizations, tag)
-        return entry != null
-    }
+    fun getSoftwareAuthorizationBoolean(tag: Int): Boolean =
+        findAuthorizationListEntry(softwareEnforcedAuthorizations, tag) != null
 
-    fun getTeeAuthorizationBoolean(tag: Int): Boolean {
-        val entry = findAuthorizationListEntry(teeEnforcedAuthorizations, tag)
-        return entry != null
-    }
+    fun getTeeAuthorizationBoolean(tag: Int): Boolean =
+        findAuthorizationListEntry(teeEnforcedAuthorizations, tag) != null
 
-    fun getSoftwareAuthorizationByteString(tag: Int): Optional<ByteArray> {
-        val entry =
-            findAuthorizationListEntry(softwareEnforcedAuthorizations, tag) as ASN1OctetString?
-        return Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
-    }
+    fun getSoftwareAuthorizationByteString(tag: Int): Optional<ByteArray> =
+        (findAuthorizationListEntry(softwareEnforcedAuthorizations, tag) as ASN1OctetString?)
+            .let { entry ->
+                Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
+            }
 
-    fun getTeeAuthorizationByteString(tag: Int): Optional<ByteArray> {
-        val entry = findAuthorizationListEntry(teeEnforcedAuthorizations, tag) as ASN1OctetString?
-        return Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
-    }
+    fun getTeeAuthorizationByteString(tag: Int): Optional<ByteArray> =
+        (findAuthorizationListEntry(teeEnforcedAuthorizations, tag) as ASN1OctetString?)
+            .let { entry ->
+                Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
+            }
 
     init {
         val attestationExtensionBytes = cert.getExtensionValue(KEY_DESCRIPTION_OID)
@@ -144,18 +141,17 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
             return authorizationMap.getOrDefault(tag, null)
         }
 
-        private fun getBooleanFromAsn1(asn1Value: ASN1Encodable): Boolean {
-            return if (asn1Value is ASN1Boolean) {
+        private fun getBooleanFromAsn1(asn1Value: ASN1Encodable): Boolean =
+            if (asn1Value is ASN1Boolean) {
                 asn1Value.isTrue
             } else {
                 throw RuntimeException(
                     "Boolean value expected; found " + asn1Value.javaClass.name + " instead."
                 )
             }
-        }
 
-        private fun getIntegerFromAsn1(asn1Value: ASN1Encodable): Int {
-            return if (asn1Value is ASN1Integer) {
+        private fun getIntegerFromAsn1(asn1Value: ASN1Encodable): Int =
+            if (asn1Value is ASN1Integer) {
                 asn1Value.value.toInt()
             } else if (asn1Value is ASN1Enumerated) {
                 asn1Value.value.toInt()
@@ -164,10 +160,9 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
                     "Integer value expected; found " + asn1Value.javaClass.name + " instead."
                 )
             }
-        }
 
-        private fun getLongFromAsn1(asn1Value: ASN1Encodable): Long {
-            return if (asn1Value is ASN1Integer) {
+        private fun getLongFromAsn1(asn1Value: ASN1Encodable): Long =
+            if (asn1Value is ASN1Integer) {
                 asn1Value.value.toLong()
             } else if (asn1Value is ASN1Enumerated) {
                 asn1Value.value.toLong()
@@ -176,26 +171,22 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
                     "Integer value expected; found " + asn1Value.javaClass.name + " instead."
                 )
             }
-        }
 
         private fun getAuthorizationMap(
             authorizationList: Array<ASN1Encodable>
-        ): Map<Int, ASN1Primitive?> {
-            val authorizationMap: MutableMap<Int, ASN1Primitive?> = HashMap()
-            for (entry in authorizationList) {
-                val taggedEntry = entry as ASN1TaggedObject
-                authorizationMap[taggedEntry.tagNo] = taggedEntry.getObject()
+        ): Map<Int, ASN1Primitive?> = mutableMapOf<Int, ASN1Primitive?>().apply {
+            authorizationList.forEach { taggedEntry ->
+                taggedEntry as ASN1TaggedObject
+                this[taggedEntry.tagNo] = taggedEntry.getObject()
             }
-            return authorizationMap
         }
 
-        private fun securityLevelToEnum(securityLevel: Int): SecurityLevel {
-            return when (securityLevel) {
+        private fun securityLevelToEnum(securityLevel: Int): SecurityLevel =
+            when (securityLevel) {
                 KM_SECURITY_LEVEL_SOFTWARE -> SecurityLevel.SOFTWARE
                 KM_SECURITY_LEVEL_TRUSTED_ENVIRONMENT -> SecurityLevel.TRUSTED_ENVIRONMENT
                 KM_SECURITY_LEVEL_STRONG_BOX -> SecurityLevel.STRONG_BOX
                 else -> throw IllegalArgumentException("Invalid security level.")
             }
-        }
     }
 }

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.kt
@@ -32,6 +32,7 @@ import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodWifiAware
 import com.android.identity.mdoc.engagement.EngagementParser
 import com.android.identity.util.toHex
+import kotlinx.coroutines.test.TestScope
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
@@ -40,11 +41,11 @@ import java.security.Security
 import java.util.Arrays
 import java.util.OptionalLong
 import java.util.UUID
-import java.util.concurrent.Executor
-import java.util.concurrent.Executors
 
 @Suppress("deprecation")
 class NfcEnagementHelperTest {
+    val testSCope = TestScope()
+
     @Before
     fun setup() {
         // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
@@ -67,13 +68,12 @@ class NfcEnagementHelperTest {
             override fun onDeviceConnected(transport: DataTransport) {}
             override fun onError(error: Throwable) {}
         }
-        val executor: Executor = Executors.newSingleThreadExecutor()
         val builder = NfcEngagementHelper.Builder(
             context,
+            testSCope,
             eDeviceKey.publicKey,
             DataTransportOptions.Builder().build(),
             listener,
-            executor
         )
 
         // Include all ConnectionMethods that can exist in OOB data
@@ -208,13 +208,12 @@ class NfcEnagementHelperTest {
             override fun onDeviceConnected(transport: DataTransport) {}
             override fun onError(error: Throwable) {}
         }
-        val executor: Executor = Executors.newSingleThreadExecutor()
         val builder = NfcEngagementHelper.Builder(
             context,
+            testSCope,
             eDeviceKey.publicKey,
             DataTransportOptions.Builder().build(),
             listener,
-            executor
         )
 
         // Include all ConnectionMethods that can exist in OOB data

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportTcpTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportTcpTest.kt
@@ -19,6 +19,7 @@ import android.os.ConditionVariable
 import androidx.test.InstrumentationRegistry
 import androidx.test.filters.SmallTest
 import com.android.identity.util.fromHex
+import kotlinx.coroutines.test.TestScope
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.Executor
@@ -26,6 +27,9 @@ import java.util.concurrent.Executors
 
 @Suppress("deprecation")
 class DataTransportTcpTest {
+
+    val testScope = TestScope()
+
     @Test
     @SmallTest
     fun connectAndListen() {
@@ -50,7 +54,7 @@ class DataTransportTcpTest {
         val verifierMessageReceivedCondVar = ConditionVariable()
         val verifierPeerConnectedCondVar = ConditionVariable()
         val executor: Executor = Executors.newSingleThreadExecutor()
-        prover.setListener(object : DataTransport.Listener {
+        prover.setListener(scope = testScope, listener = object : DataTransport.Listener {
             override fun onConnecting() {}
             override fun onConnected() {
                 proverPeerConnectedCondVar.open()
@@ -73,8 +77,8 @@ class DataTransportTcpTest {
                 messageReceivedByProver[0] = data!!.clone()
                 proverMessageReceivedCondVar.open()
             }
-        }, executor)
-        verifier.setListener(object : DataTransport.Listener {
+        })
+        verifier.setListener(scope = testScope, listener = object : DataTransport.Listener {
             override fun onConnecting() {}
             override fun onConnected() {
                 verifierPeerConnectedCondVar.open()
@@ -97,7 +101,7 @@ class DataTransportTcpTest {
                 messageReceivedByVerifier[0] = data!!.clone()
                 verifierMessageReceivedCondVar.open()
             }
-        }, executor)
+        })
         prover.connect()
         verifier.setHostAndPort(prover.host, prover.port)
         verifier.connect()

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
@@ -22,7 +22,8 @@ import android.nfc.NdefRecord
 import android.nfc.Tag
 import android.nfc.tech.IsoDep
 import android.util.Base64
-import com.android.identity.android.mdoc.deviceretrieval.VerificationHelper
+import com.android.identity.android.util.HelperListener
+import com.android.identity.android.util.launchIfAllowed
 import com.android.identity.android.mdoc.transport.DataTransport
 import com.android.identity.android.mdoc.transport.DataTransportBle
 import com.android.identity.android.mdoc.transport.DataTransportBleCentralClientMode
@@ -45,10 +46,10 @@ import com.android.identity.mdoc.sessionencryption.SessionEncryption
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity.util.Timestamp
+import kotlinx.coroutines.CoroutineScope
 import java.io.IOException
 import java.util.Arrays
 import java.util.Locale
-import java.util.concurrent.Executor
 
 /**
  * Helper used for engaging with and receiving documents from a remote mdoc verifier device.
@@ -64,13 +65,17 @@ import java.util.concurrent.Executor
 // cleaned up at object finalization time.
 class VerificationHelper internal constructor(
     private val context: Context,
+    private val scope: CoroutineScope?,
     private val listener: Listener,
-    private val listenerExecutor: Executor
 ) {
     private var negotiatedHandoverConnectionMethods: List<ConnectionMethod>? = null
     private var negotiatedHandoverListeningTransports = mutableListOf<DataTransport>()
 
-    private var dataTransport: DataTransport? = null
+    private var _dataTransport: DataTransport? = null
+    private val dataTransport: DataTransport
+        get() = _dataTransport!!
+
+
     private var ephemeralKey: EcPrivateKey? = null
     private var sessionEncryptionReader: SessionEncryption? = null
     private var deviceEngagement: ByteArray? = null
@@ -99,6 +104,8 @@ class VerificationHelper internal constructor(
     var engagementMethod: EngagementMethod = EngagementMethod.NOT_ENGAGED
         private set
 
+    private val inhibitCallbacks = false
+
     /**
      * The session transcript.
      *
@@ -122,9 +129,11 @@ class VerificationHelper internal constructor(
      * The amount of time from first NFC interaction until Engagement has been received.
      */
     val tapToEngagementDurationMillis: Long
-        get() = if (timestampNfcTap == 0L) {
-            0
-        } else timestampEngagementReceived - timestampNfcTap
+        get() =
+            if (timestampNfcTap == 0L)
+                0
+            else
+                timestampEngagementReceived - timestampNfcTap
 
     /**
      * The amount of time from when Engagement has been received until the request was sent.
@@ -142,9 +151,7 @@ class VerificationHelper internal constructor(
      * The amount of time spent BLE scanning or 0 if no scanning occurred.
      */
     val scanningTimeMillis: Long
-        get() = if (dataTransport is DataTransportBle) {
-            (dataTransport as DataTransportBle).scanningTimeMillis
-        } else 0
+        get() = (dataTransport as? DataTransportBle)?.scanningTimeMillis ?: 0
 
     private fun start() {
         if (reverseEngagementConnectionMethods != null) {
@@ -176,13 +183,14 @@ class VerificationHelper internal constructor(
             reverseEngagementConnectionMethods!!
         )
         for (cm in disambiguatedMethods) {
-            val transport = DataTransport.fromConnectionMethod(
+            DataTransport.fromConnectionMethod(
                 context, cm, DataTransport.Role.MDOC_READER, options!!
-            )
-            reverseEngagementListeningTransports!!.add(transport)
-            // TODO: we may want to have the DataTransport actually give us a ConnectionMethod,
-            //   for example consider the case where a HTTP-based transport uses a cloud-service
-            //   to relay messages.
+            ).let { transport ->
+                // TODO: we may want to have the DataTransport actually give us a ConnectionMethod,
+                //   for example consider the case where a HTTP-based transport uses a cloud-service
+                //   to relay messages.
+                reverseEngagementListeningTransports!!.add(transport)
+            }
         }
 
         // Careful, we're using the user-provided Executor below so these callbacks might happen
@@ -197,7 +205,7 @@ class VerificationHelper internal constructor(
         )
         connectionMethodsForReaderEngagement = mutableListOf()
         for (transport in reverseEngagementListeningTransports!!) {
-            transport.setListener(object : DataTransport.Listener {
+            transport.setListener(scope = scope, listener = object : DataTransport.Listener {
                 override fun onConnecting() {
                     Logger.d(TAG, "onConnecting for $transport")
                     reverseEngagementPeerIsConnecting()
@@ -228,7 +236,7 @@ class VerificationHelper internal constructor(
                     transport.close()
                     reportDeviceDisconnected(true)
                 }
-            }, listenerExecutor)
+            })
             Logger.d(TAG, "Connecting transport $transport")
             transport.connect()
             connectionMethodsForReaderEngagement!!.add(transport.connectionMethodForTransport)
@@ -241,7 +249,7 @@ class VerificationHelper internal constructor(
     }
 
     fun reverseEngagementPeerIsConnecting() {}
-    
+
     fun reverseEngagementPeerHasConnected(transport: DataTransport) {
         // stop listening on other transports
         //
@@ -253,7 +261,7 @@ class VerificationHelper internal constructor(
             }
         }
         reverseEngagementListeningTransports!!.clear()
-        dataTransport = transport
+        _dataTransport = transport
 
         // We're connected to the remote device but we don't want to let the application
         // know this until we've received the first message with DeviceEngagement CBOR...
@@ -307,7 +315,9 @@ class VerificationHelper internal constructor(
                     reportError(e)
                     return
                 }
-                listenerExecutor.execute { connectWithDataTransport(dataTransport, false) }
+                listener.executeIfAllowed(inhibitCallbacks) {
+                    connectWithDataTransport(dataTransport, false)
+                }
             }
         }
         connectThread.start()
@@ -329,7 +339,7 @@ class VerificationHelper internal constructor(
      * @throws IllegalStateException if called after [connect].
      */
     fun setDeviceEngagementFromQrCode(qrDeviceEngagement: String) {
-        check(dataTransport == null) { "Cannot be called after connect()" }
+        check(_dataTransport == null) { "Cannot be called after connect()" }
         val uri = Uri.parse(qrDeviceEngagement)
         if (uri != null && uri.scheme != null && uri.scheme == "mdoc") {
             val encodedDeviceEngagement = Base64.decode(
@@ -364,15 +374,13 @@ class VerificationHelper internal constructor(
     }
 
     private fun readBinary(isoDep: IsoDep, offset: Int, size: Int): ByteArray? {
-        val apdu: ByteArray
-        val ret: ByteArray
-        apdu = NfcUtil.createApduReadBinary(offset, size)
-        ret = transceive(isoDep, apdu)
+        val apdu: ByteArray = NfcUtil.createApduReadBinary(offset, size)
+        val ret: ByteArray = transceive(isoDep, apdu)
         if (ret.size < 2 || ret[ret.size - 2] != 0x90.toByte() || ret[ret.size - 1] != 0x00.toByte()) {
             Logger.eHex(TAG, "Error sending READ_BINARY command, ret", ret)
             return null
         }
-        return Arrays.copyOfRange(ret, 0, ret.size - 2)
+        return ret.copyOfRange(0, ret.size - 2)
     }
 
     private fun ndefReadMessage(isoDep: IsoDep, tWaitMillis: Double, _nWait: Int): ByteArray? {
@@ -384,8 +392,10 @@ class VerificationHelper internal constructor(
             apdu = NfcUtil.createApduReadBinary(0x0000, 2)
             ret = transceive(isoDep, apdu)
             if (ret.size != 4 || ret[2] != 0x90.toByte() || ret[3] != 0x00.toByte()) {
-                Logger.eHex(TAG, "ndefReadMessage: Malformed response for first " +
-                            "READ_BINARY command for length, ret", ret)
+                Logger.eHex(
+                    TAG, "ndefReadMessage: Malformed response for first " +
+                            "READ_BINARY command for length, ret", ret
+                )
                 return null
             }
             replyLen = (ret[0].toInt() and 0xff) * 256 + (ret[1].toInt() and 0xff)
@@ -396,24 +406,34 @@ class VerificationHelper internal constructor(
             // As per [TNEP] 4.1.7 if the tag sends an empty NDEF message it means that
             // it's requesting extra time... honor this if we can.
             if (nWait > 0) {
-                Logger.d(TAG, "ndefReadMessage: NDEF message with length 0 and $nWait time extensions left")
+                Logger.d(
+                    TAG,
+                    "ndefReadMessage: NDEF message with length 0 and $nWait time extensions left"
+                )
                 try {
                     val waitMillis = Math.ceil(tWaitMillis).toLong()
-                    Logger.d(TAG,"ndefReadMessage: Sleeping $waitMillis ms")
+                    Logger.d(TAG, "ndefReadMessage: Sleeping $waitMillis ms")
                     Thread.sleep(waitMillis)
                 } catch (e: InterruptedException) {
                     throw RuntimeException("Unexpected interrupt", e)
                 }
                 nWait--
             } else {
-                Logger.e(TAG, "ndefReadMessage: NDEF message with length 0 but no time extensions left")
+                Logger.e(
+                    TAG,
+                    "ndefReadMessage: NDEF message with length 0 but no time extensions left"
+                )
                 return null
             }
         } while (true)
         apdu = NfcUtil.createApduReadBinary(0x0002, replyLen)
         ret = transceive(isoDep, apdu)
         if (ret.size != replyLen + 2 || ret[replyLen] != 0x90.toByte() || ret[replyLen + 1] != 0x00.toByte()) {
-            Logger.eHex(TAG, "Malformed response for second READ_BINARY command for payload, ret", ret)
+            Logger.eHex(
+                TAG,
+                "Malformed response for second READ_BINARY command for payload, ret",
+                ret
+            )
             return null
         }
         return ret.copyOfRange(0, ret.size - 2)
@@ -560,9 +580,7 @@ class VerificationHelper internal constructor(
 
                     // First see if we should use negotiated handover..
                     val initialNdefMessage = ndefReadMessage(isoDep, 1.0, 0)
-                    if (initialNdefMessage == null) {
-                        throw IllegalStateException("Error reading initial NDEF message")
-                    }
+                        ?: throw IllegalStateException("Error reading initial NDEF message")
                     val handoverServiceRecord =
                         NfcUtil.findServiceParameterRecordWithName(
                             initialNdefMessage,
@@ -570,10 +588,13 @@ class VerificationHelper internal constructor(
                         )
                     if (handoverServiceRecord == null) {
                         val elapsedTime = System.currentTimeMillis() - timeMillisBegin
-                        Logger.i(TAG,"Time spent in NFC static handover: $elapsedTime ms")
-                        Logger.d(TAG, "No urn:nfc:sn:handover record found - assuming NFC static handover")
+                        Logger.i(TAG, "Time spent in NFC static handover: $elapsedTime ms")
+                        Logger.d(
+                            TAG,
+                            "No urn:nfc:sn:handover record found - assuming NFC static handover"
+                        )
                         val hs = NfcUtil.parseHandoverSelectMessage(initialNdefMessage)
-                                ?: throw IllegalStateException("Error parsing Handover Select message")
+                            ?: throw IllegalStateException("Error parsing Handover Select message")
                         check(!hs.connectionMethods.isEmpty()) { "No connection methods in Handover Select" }
                         if (Logger.isDebugEnabled) {
                             for (cm in hs.connectionMethods) {
@@ -594,11 +615,17 @@ class VerificationHelper internal constructor(
                         reportDeviceEngagementReceived(hs.connectionMethods)
                         return
                     }
-                    Logger.d(TAG, "Service Parameter for urn:nfc:sn:handover found - negotiated handover")
+                    Logger.d(
+                        TAG,
+                        "Service Parameter for urn:nfc:sn:handover found - negotiated handover"
+                    )
                     val spr = NfcUtil.parseServiceParameterRecord(handoverServiceRecord)
-                    Logger.d(TAG, String.format(
+                    Logger.d(
+                        TAG, String.format(
                             "tWait is %.1f ms, nWait is %d, maxNdefSize is %d",
-                            spr.tWaitMillis, spr.nWait, spr.maxNdefSize))
+                            spr.tWaitMillis, spr.nWait, spr.maxNdefSize
+                        )
+                    )
 
                     // Select the service, the resulting NDEF message is specified in
                     // in Tag NDEF Exchange Protocol Technical Specification Version 1.0
@@ -649,7 +676,8 @@ class VerificationHelper internal constructor(
                             && Arrays.equals(r.id, "mdoc".toByteArray())
                         ) {
                             encodedDeviceEngagement = r.payload
-                            Logger.dCbor(TAG,
+                            Logger.dCbor(
+                                TAG,
                                 "Device Engagement from NFC negotiated handover",
                                 encodedDeviceEngagement
                             )
@@ -705,28 +733,35 @@ class VerificationHelper internal constructor(
         // Create reader ephemeral key with key to match device ephemeral key's curve... this
         // can take a long time (hundreds of milliseconds) so use the precalculated key
         // to avoid delaying the transaction...
-        ephemeralKey = Crypto.createEcPrivateKey(engagement.eSenderKey.curve)
-        val encodedEReaderKeyPub: ByteArray = Cbor.encode(
-            ephemeralKey!!.publicKey.toCoseKey().toDataItem
-        )
-        encodedSessionTranscript = Cbor.encode(
-            CborArray.builder()
-                .add(Tagged(24, Bstr(this.deviceEngagement!!)))
-                .add(Tagged(24, Bstr(encodedEReaderKeyPub)))
-                .add(handover)
-                .end()
-                .build()
-        )
-        Logger.dCbor(TAG, "SessionTranscript", encodedSessionTranscript!!)
-        sessionEncryptionReader = SessionEncryption(
-            SessionEncryption.Role.MDOC_READER,
-            ephemeralKey!!,
-            eDeviceKey,
-            encodedSessionTranscript!!
-        )
-        if (readerEngagement != null) {
-            // No need to include EReaderKey in first message...
-            sessionEncryptionReader!!.setSendSessionEstablishment(false)
+        Crypto.createEcPrivateKey(engagement.eSenderKey.curve).let { ephemeralKey ->
+            this.ephemeralKey = ephemeralKey
+            Cbor.encode(
+                ephemeralKey.publicKey.toCoseKey().toDataItem
+            ).let { encodedEReaderKeyPub ->
+                Cbor.encode(
+                    CborArray.builder()
+                        .add(Tagged(24, Bstr(this.deviceEngagement!!)))
+                        .add(Tagged(24, Bstr(encodedEReaderKeyPub)))
+                        .add(handover)
+                        .end()
+                        .build()
+                ).let { encodedSessionTranscript ->
+                    this.encodedSessionTranscript = encodedSessionTranscript
+                    Logger.dCbor(TAG, "SessionTranscript", encodedSessionTranscript)
+                    SessionEncryption(
+                        SessionEncryption.Role.MDOC_READER,
+                        ephemeralKey,
+                        eDeviceKey,
+                        encodedSessionTranscript
+                    ).let { sessionEncryption ->
+                        sessionEncryptionReader = sessionEncryption
+                        if (readerEngagement != null) {
+                            // No need to include EReaderKey in first message...
+                            sessionEncryption.setSendSessionEstablishment(false)
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -750,8 +785,10 @@ class VerificationHelper internal constructor(
                     t.close()
                 }
                 negotiatedHandoverListeningTransports.clear()
-                Logger.i(TAG, "Connecting to a warmed-up transport " +
-                        "${warmedUpTransport.connectionMethodForTransport}")
+                Logger.i(
+                    TAG, "Connecting to a warmed-up transport " +
+                            "${warmedUpTransport.connectionMethodForTransport}"
+                )
                 connectWithDataTransport(warmedUpTransport, true)
                 return
             }
@@ -766,7 +803,8 @@ class VerificationHelper internal constructor(
         Logger.i(TAG, "Connecting to transport $connectionMethod")
         connectWithDataTransport(
             DataTransport.fromConnectionMethod(
-                context, connectionMethod, DataTransport.Role.MDOC_READER, options!!),
+                context, connectionMethod, DataTransport.Role.MDOC_READER, options!!
+            ),
             false
         )
     }
@@ -775,7 +813,7 @@ class VerificationHelper internal constructor(
         transport: DataTransport?,
         usingWarmedUpTransport: Boolean
     ) {
-        dataTransport = transport
+        _dataTransport = transport
         if (dataTransport is DataTransportNfc) {
             if (nfcIsoDep == null) {
                 // This can happen if using NFC data transfer with QR code engagement
@@ -783,9 +821,11 @@ class VerificationHelper internal constructor(
                 // weird). In this case we just sit and wait until the tag (reader)
                 // is detected... once detected, this routine can just call connect()
                 // again.
-                Logger.i(TAG,
+                Logger.i(
+                    TAG,
                     "In connect() with NFC data transfer but no ISO dep has been set. " +
-                            "Assuming QR engagement, waiting for mdoc to move into field")
+                            "Assuming QR engagement, waiting for mdoc to move into field"
+                )
                 reportMoveIntoNfcField()
                 return
             }
@@ -793,9 +833,11 @@ class VerificationHelper internal constructor(
         } else if (dataTransport is DataTransportBle) {
             // Helpful warning
             if (options!!.bleClearCache && dataTransport is DataTransportBleCentralClientMode) {
-                Logger.i(TAG,
+                Logger.i(
+                    TAG,
                     "Ignoring bleClearCache flag since it only applies to " +
-                            "BLE mdoc peripheral server mode when acting as a reader")
+                            "BLE mdoc peripheral server mode when acting as a reader"
+                )
             }
         }
 
@@ -818,13 +860,13 @@ class VerificationHelper internal constructor(
 
             override fun onDisconnected() {
                 Logger.d(TAG, "onDisconnected for $dataTransport")
-                dataTransport!!.close()
+                dataTransport.close()
                 reportError(Error("Peer disconnected without proper session termination"))
             }
 
             override fun onError(error: Throwable) {
                 Logger.d(TAG, "onError for $dataTransport: $error")
-                dataTransport!!.close()
+                dataTransport.close()
                 reportError(error)
             }
 
@@ -834,15 +876,15 @@ class VerificationHelper internal constructor(
 
             override fun onTransportSpecificSessionTermination() {
                 Logger.d(TAG, "Received onTransportSpecificSessionTermination")
-                dataTransport!!.close()
+                dataTransport.close()
                 reportDeviceDisconnected(true)
             }
         }
-        dataTransport!!.setListener(listener, listenerExecutor)
+        dataTransport.setListener(listener, scope)
 
         // It's entirely possible the other side already connected to us...
         if (usingWarmedUpTransport) {
-            if (dataTransport!!.isConnected) {
+            if (dataTransport.isConnected) {
                 listener.onConnected()
             }
         } else {
@@ -850,8 +892,8 @@ class VerificationHelper internal constructor(
                 val deviceEngagementDataItem = Cbor.decode(deviceEngagement!!)
                 val security = deviceEngagementDataItem[1]
                 val encodedEDeviceKeyBytes = Cbor.encode(security[1])
-                dataTransport!!.setEDeviceKeyBytes(encodedEDeviceKeyBytes)
-                dataTransport!!.connect()
+                dataTransport.setEDeviceKeyBytes(encodedEDeviceKeyBytes)
+                dataTransport.connect()
             } catch (e: Exception) {
                 reportError(e)
             }
@@ -862,7 +904,7 @@ class VerificationHelper internal constructor(
         Logger.dCbor(TAG, "MessageData", data)
         val map = Cbor.decode(data)
         if (!map.hasKey("deviceEngagementBytes")) {
-            dataTransport!!.close()
+            dataTransport.close()
             reportError(Error("Error extracting DeviceEngagement from MessageData"))
             return
         }
@@ -879,7 +921,7 @@ class VerificationHelper internal constructor(
     }
 
     private fun handleOnMessageReceived() {
-        val data = dataTransport!!.getMessage()
+        val data = dataTransport.getMessage()
         if (data == null) {
             reportError(Error("onMessageReceived but no message"))
             return
@@ -902,7 +944,7 @@ class VerificationHelper internal constructor(
         val decryptedMessage = try {
             sessionEncryptionReader!!.decryptMessage(data)
         } catch (e: Exception) {
-            dataTransport!!.close()
+            dataTransport.close()
             reportError(Error("Error decrypting message from device", e))
             return
         }
@@ -917,7 +959,7 @@ class VerificationHelper internal constructor(
         } else {
             // No data, so status must be set...
             if (decryptedMessage.second == null) {
-                dataTransport!!.close()
+                dataTransport.close()
                 reportError(Error("No data and no status in SessionData"))
                 return
             }
@@ -929,10 +971,10 @@ class VerificationHelper internal constructor(
             val statusCode = decryptedMessage.second
             Logger.d(TAG, "SessionData with status code $statusCode")
             if (statusCode == Constants.SESSION_DATA_STATUS_SESSION_TERMINATION) {
-                dataTransport!!.close()
+                dataTransport.close()
                 reportDeviceDisconnected(false)
             } else {
-                dataTransport!!.close()
+                dataTransport.close()
                 reportError(Error("Expected status code 20, got $statusCode instead"))
             }
         }
@@ -943,31 +985,29 @@ class VerificationHelper internal constructor(
             TAG, "reportDeviceDisconnected: transportSpecificTermination: "
                     + transportSpecificTermination
         )
-        listenerExecutor.execute {
-            listener.onDeviceDisconnected(
-                transportSpecificTermination
-            )
+        listener.executeIfAllowed(inhibitCallbacks) {
+            onDeviceDisconnected(transportSpecificTermination)
         }
     }
 
     fun reportResponseReceived(deviceResponseBytes: ByteArray) {
         Logger.d(TAG, "reportResponseReceived (" + deviceResponseBytes.size + " bytes)")
-        listenerExecutor.execute { listener.onResponseReceived(deviceResponseBytes) }
+        listener.executeIfAllowed(inhibitCallbacks) { onResponseReceived(deviceResponseBytes) }
     }
 
     fun reportMoveIntoNfcField() {
         Logger.d(TAG, "reportMoveIntoNfcField")
-        listenerExecutor.execute { listener.onMoveIntoNfcField() }
+        listener.executeIfAllowed(inhibitCallbacks) { onMoveIntoNfcField() }
     }
 
     fun reportDeviceConnected() {
         Logger.d(TAG, "reportDeviceConnected")
-        listenerExecutor.execute { listener.onDeviceConnected() }
+        listener.executeIfAllowed(inhibitCallbacks) { onDeviceConnected() }
     }
 
     fun reportReaderEngagementReady(readerEngagement: ByteArray) {
         Logger.dCbor(TAG, "reportReaderEngagementReady", readerEngagement)
-        listenerExecutor.execute { listener.onReaderEngagementReady(readerEngagement) }
+        listener.executeIfAllowed(inhibitCallbacks) { onReaderEngagementReady(readerEngagement) }
     }
 
     fun reportDeviceEngagementReceived(connectionMethods: List<ConnectionMethod>) {
@@ -977,13 +1017,13 @@ class VerificationHelper internal constructor(
                 Logger.d(TAG, "  ConnectionMethod: $cm")
             }
         }
-        listenerExecutor.execute { listener.onDeviceEngagementReceived(connectionMethods) }
+        listener.executeIfAllowed(inhibitCallbacks) { onDeviceEngagementReceived(connectionMethods) }
     }
 
     fun reportError(error: Throwable) {
         Logger.d(TAG, "reportError: error: $error")
         error.printStackTrace()
-        listenerExecutor.execute { listener.onError(error) }
+        listener.executeIfAllowed(inhibitCallbacks) { onError(error) }
     }
 
     /**
@@ -1003,7 +1043,7 @@ class VerificationHelper internal constructor(
      * This method is idempotent so it is safe to call multiple times.
      */
     fun disconnect() {
-        for (t in negotiatedHandoverListeningTransports!!) {
+        for (t in negotiatedHandoverListeningTransports) {
             Logger.d(TAG, "Shutting down Negotiated Handover warmed-up transport $t")
             t.close()
         }
@@ -1014,28 +1054,28 @@ class VerificationHelper internal constructor(
             }
             reverseEngagementListeningTransports = null
         }
-        if (dataTransport != null) {
+        if (_dataTransport != null) {
             // Only send session termination message if the session was actually established.
             val sessionEstablished = sessionEncryptionReader!!.numMessagesEncrypted > 0
             if (sendSessionTerminationMessage && sessionEstablished) {
                 if (useTransportSpecificSessionTermination &&
-                    dataTransport!!.supportsTransportSpecificTerminationMessage()
+                    dataTransport.supportsTransportSpecificTerminationMessage()
                 ) {
                     Logger.d(TAG, "Sending transport-specific termination message")
-                    dataTransport!!.sendTransportSpecificTerminationMessage()
+                    dataTransport.sendTransportSpecificTerminationMessage()
                 } else {
                     Logger.d(TAG, "Sending generic session termination message")
                     val sessionTermination = sessionEncryptionReader!!.encryptMessage(
                         null, Constants.SESSION_DATA_STATUS_SESSION_TERMINATION
                     )
-                    dataTransport!!.sendMessage(sessionTermination)
+                    dataTransport.sendMessage(sessionTermination)
                 }
             } else {
                 Logger.d(TAG, "Not sending session termination message")
             }
             Logger.d(TAG, "Shutting down transport")
-            dataTransport!!.close()
-            dataTransport = null
+            dataTransport.close()
+            _dataTransport = null
         }
     }
 
@@ -1057,13 +1097,13 @@ class VerificationHelper internal constructor(
     fun sendRequest(deviceRequestBytes: ByteArray) {
         checkNotNull(deviceEngagement) { "Device engagement is null" }
         checkNotNull(ephemeralKey) { "New object must be created" }
-        checkNotNull(dataTransport) { "Not connected to a remote device" }
+        checkNotNull(_dataTransport) { "Not connected to a remote device" }
         Logger.dCbor(TAG, "DeviceRequest to send", deviceRequestBytes)
         val message = sessionEncryptionReader!!.encryptMessage(
             deviceRequestBytes, null
         )
         Logger.dCbor(TAG, "SessionData to send", message)
-        dataTransport!!.sendMessage(message)
+        dataTransport.sendMessage(message)
         timestampRequestSent = Timestamp.now().toEpochMilli()
     }
 
@@ -1102,9 +1142,9 @@ class VerificationHelper internal constructor(
          * @return `true` if transport specific termination is available, `false`
          * if not or if not connected.
          */
-        get() = if (dataTransport == null) {
+        get() = if (_dataTransport == null) {
             false
-        } else dataTransport!!.supportsTransportSpecificTerminationMessage()
+        } else dataTransport.supportsTransportSpecificTerminationMessage()
 
     /**
      * Sets whether to send session termination message.
@@ -1120,9 +1160,7 @@ class VerificationHelper internal constructor(
      *
      * @param sendSessionTerminationMessage Whether to send session termination message.
      */
-    fun setSendSessionTerminationMessage(
-        sendSessionTerminationMessage: Boolean
-    ) {
+    fun setSendSessionTerminationMessage(sendSessionTerminationMessage: Boolean) {
         this.sendSessionTerminationMessage = sendSessionTerminationMessage
     }
 
@@ -1130,7 +1168,7 @@ class VerificationHelper internal constructor(
     /**
      * Interface for listening to messages from the remote mdoc device.
      */
-    interface Listener {
+    interface Listener : HelperListener {
         /**
          * Called when using reverse engagement and the reader engagement is ready.
          *
@@ -1220,11 +1258,9 @@ class VerificationHelper internal constructor(
      */
     class Builder(
         context: Context,
+        scope: CoroutineScope?,
         listener: Listener,
-        executor: Executor
     ) {
-        private val mHelper: VerificationHelper
-
         /**
          * Creates a new Builder for [VerificationHelper].
          *
@@ -1232,9 +1268,7 @@ class VerificationHelper internal constructor(
          * @param listener listener.
          * @param executor executor.
          */
-        init {
-            mHelper = VerificationHelper(context, listener, executor)
-        }
+        private val mHelper = VerificationHelper(context, scope, listener)
 
         /**
          * Sets the options to use when setting up transports.
@@ -1242,9 +1276,8 @@ class VerificationHelper internal constructor(
          * @param options the options to use.
          * @return the builder.
          */
-        fun setDataTransportOptions(options: DataTransportOptions): Builder {
+        fun setDataTransportOptions(options: DataTransportOptions) = apply {
             mHelper.options = options
-            return this
         }
 
         /**
@@ -1253,15 +1286,14 @@ class VerificationHelper internal constructor(
          * @param connectionMethods a list of connection methods to offer via reverse engagement
          * @return the builder.
          */
-        fun setUseReverseEngagement(connectionMethods: List<ConnectionMethod>): Builder {
+        fun setUseReverseEngagement(connectionMethods: List<ConnectionMethod>) = apply {
             mHelper.reverseEngagementConnectionMethods = connectionMethods
-            return this
         }
 
-        fun setNegotiatedHandoverConnectionMethods(connectionMethods: List<ConnectionMethod>): Builder {
-            mHelper.negotiatedHandoverConnectionMethods = connectionMethods
-            return this
-        }
+        fun setNegotiatedHandoverConnectionMethods(connectionMethods: List<ConnectionMethod>) =
+            apply {
+                mHelper.negotiatedHandoverConnectionMethods = connectionMethods
+            }
 
         /**
          * Builds a [VerificationHelper] with the configuration specified in the builder.
@@ -1288,21 +1320,43 @@ class VerificationHelper internal constructor(
          *
          * @return A [VerificationHelper].
          */
-        fun build(): VerificationHelper {
-            mHelper.start()
-            return mHelper
-        }
+        fun build(): VerificationHelper = mHelper.apply { start() }
     }
 
     companion object {
         private const val TAG = "VerificationHelper"
     }
-    
+
     enum class EngagementMethod {
         NOT_ENGAGED,
         QR_CODE,
         NFC_STATIC_HANDOVER,
         NFC_NEGOTIATED_HANDOVER,
         REVERSE
+    }
+
+    /**
+     * Private extension function localized to [VerificationHelper] that wraps around the extension function
+     * [CoroutineScope?.launchIfAllowed] to simplify and prettify listener callbacks.
+     *
+     * For ex,
+     * scope.launchIfAllowed(inhibitCallbacks, listener) { onMessageReceived() }
+     *
+     * can be reduced/simplified to an easier to understand
+     * listener.executeIfAllowed(inhibitCallbacks) { onMessageReceived() }
+     *
+     * @param inhibitCallbacks whether to prevent the callback from being executed/called
+     * @param callback the block of code using Listener as the function type receiver so
+     * function calls are made on "this" Listener instance directly.
+     */
+    private fun Listener?.executeIfAllowed(
+        inhibitCallbacks: Boolean,
+        callback: Listener.() -> Unit
+    ) {
+        scope.launchIfAllowed(
+            inhibitCallbacks = inhibitCallbacks,
+            listener = this,
+            callback = callback
+        )
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/NfcEngagementHelper.kt
@@ -5,6 +5,8 @@ import android.nfc.FormatException
 import android.nfc.NdefMessage
 import android.nfc.NdefRecord
 import com.android.identity.android.mdoc.engagement.NfcEngagementHelper.Listener
+import com.android.identity.android.util.HelperListener
+import com.android.identity.android.util.launchIfAllowed
 import com.android.identity.android.mdoc.transport.DataTransport
 import com.android.identity.android.mdoc.transport.DataTransport.Companion.fromConnectionMethod
 import com.android.identity.android.mdoc.transport.DataTransportOptions
@@ -20,6 +22,7 @@ import com.android.identity.mdoc.connectionmethod.ConnectionMethod.Companion.com
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod.Companion.disambiguate
 import com.android.identity.mdoc.engagement.EngagementGenerator
 import com.android.identity.util.Logger
+import kotlinx.coroutines.CoroutineScope
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.Arrays
@@ -56,7 +59,7 @@ class NfcEngagementHelper private constructor(
     private val negotiatedHandoverWtInt: Int,
     private val negotiatedHandoverMaxNumWaitingTimeExtensions: Int,
     private val listener: Listener,
-    private val executor: Executor
+    private val scope: CoroutineScope
 ) {
     private var staticHandoverConnectionMethods: List<ConnectionMethod>? = null
     private var inhibitCallbacks = false
@@ -70,7 +73,10 @@ class NfcEngagementHelper private constructor(
      * This returns the bytes of the `DeviceEngagement` CBOR according to
      * ISO/IEC 18013-5:2021 section 8.2.2.1.
      */
-    val deviceEngagement: ByteArray
+    val deviceEngagement: ByteArray = EngagementGenerator(
+        eDeviceKey,
+        EngagementGenerator.ENGAGEMENT_VERSION_1_0
+    ).generate()
 
     /**
      * Gets the bytes of the `Handover` CBOR.
@@ -79,11 +85,11 @@ class NfcEngagementHelper private constructor(
      * ISO/IEC 18013-5:2021 section 9.1.5.1.
      */
     lateinit var handover: ByteArray
-    
+
     private var reportedDeviceConnecting = false
     private var handoverSelectMessage: ByteArray? = null
     private var handoverRequestMessage: ByteArray? = null
-    
+
     private var mUsingNegotiatedHandover = false
 
     private var negotiatedHandoverState = NEGOTIATED_HANDOVER_STATE_NOT_STARTED
@@ -126,7 +132,8 @@ class NfcEngagementHelper private constructor(
         Logger.d(TAG, "Setting up transports")
         val timeStartedSettingUpTransports = System.currentTimeMillis()
         val encodedEDeviceKeyBytes = Cbor.encode(
-            Tagged(24, Bstr(Cbor.encode(eDeviceKey.toCoseKey().toDataItem))))
+            Tagged(24, Bstr(Cbor.encode(eDeviceKey.toCoseKey().toDataItem)))
+        )
 
         // Need to disambiguate the connection methods here to get e.g. two ConnectionMethods
         // if both BLE modes are available at the same time.
@@ -145,7 +152,7 @@ class NfcEngagementHelper private constructor(
         // ThreadPoolExecutor.
         //
         for (transport in transports) {
-            transport.setListener(object : DataTransport.Listener {
+            transport.setListener(scope = scope, listener = object : DataTransport.Listener {
                 override fun onConnecting() {
                     Logger.d(TAG, "onConnecting for $transport")
                     peerIsConnecting(transport)
@@ -174,7 +181,7 @@ class NfcEngagementHelper private constructor(
                     Logger.d(TAG, "Received transport-specific session termination")
                     transport.close()
                 }
-            }, executor)
+            })
             Logger.d(TAG, "Connecting to transport $transport")
             transport.connect()
             setupConnectionMethods.add(transport.connectionMethodForTransport)
@@ -211,8 +218,7 @@ class NfcEngagementHelper private constructor(
         if (Logger.isDebugEnabled) {
             Logger.dHex(TAG, "nfcProcessCommandApdu: apdu", apdu)
         }
-        val commandType = NfcUtil.nfcGetCommandType(apdu)
-        return when (commandType) {
+        return when (val commandType = NfcUtil.nfcGetCommandType(apdu)) {
             NfcUtil.COMMAND_TYPE_SELECT_BY_AID -> handleSelectByAid(apdu)
             NfcUtil.COMMAND_TYPE_SELECT_FILE -> handleSelectFile(apdu)
             NfcUtil.COMMAND_TYPE_READ_BINARY -> handleReadBinary(apdu)
@@ -257,20 +263,22 @@ class NfcEngagementHelper private constructor(
         // contains the NFC Forum Well Known Type (see [RTD]) “Tp”.
         //
         val serviceNameUriUtf8 = "urn:nfc:sn:handover".toByteArray()
-        val baos = ByteArrayOutputStream()
-        try {
-            // The payload of the record is defined in Tag NDEF Exchange Protocol 1.0 section 4.1.2:
-            baos.write(0x10) // TNEP version: 1.0
-            baos.write(serviceNameUriUtf8.size)
-            baos.write(serviceNameUriUtf8)
-            baos.write(0x00) // TNEP Communication Mode: Single Response communication mode
-            baos.write(negotiatedHandoverWtInt) // Minimum Waiting Time
-            baos.write(negotiatedHandoverMaxNumWaitingTimeExtensions) // Maximum Number of Waiting Time Extensions
-            baos.write(0xff) // Maximum NDEF Message Size (upper 8 bits)
-            baos.write(0xff) // Maximum NDEF Message Size (lower 8 bits)
-        } catch (e: IOException) {
-            throw IllegalStateException(e)
+        val baos = ByteArrayOutputStream().apply {
+            try {
+                // The payload of the record is defined in Tag NDEF Exchange Protocol 1.0 section 4.1.2:
+                write(0x10) // TNEP version: 1.0
+                write(serviceNameUriUtf8.size)
+                write(serviceNameUriUtf8)
+                write(0x00) // TNEP Communication Mode: Single Response communication mode
+                write(negotiatedHandoverWtInt) // Minimum Waiting Time
+                write(negotiatedHandoverMaxNumWaitingTimeExtensions) // Maximum Number of Waiting Time Extensions
+                write(0xff) // Maximum NDEF Message Size (upper 8 bits)
+                write(0xff) // Maximum NDEF Message Size (lower 8 bits)
+            } catch (e: IOException) {
+                throw IllegalStateException(e)
+            }
         }
+
         val payload = baos.toByteArray()
         val record = NdefRecord(
             NdefRecord.TNF_WELL_KNOWN,
@@ -329,8 +337,10 @@ class NfcEngagementHelper private constructor(
                 val cmsFromTransports = setupTransports(
                     staticHandoverConnectionMethods!!
                 )
-                Logger.d(TAG, "handleSelectFile: NDEF file selected and using static "
-                    + "handover - calculating handover message")
+                Logger.d(
+                    TAG, "handleSelectFile: NDEF file selected and using static "
+                            + "handover - calculating handover message"
+                )
                 val hsMessage = NfcUtil.createNdefMessageHandoverSelect(
                     cmsFromTransports,
                     deviceEngagement,
@@ -387,30 +397,32 @@ class NfcEngagementHelper private constructor(
             size += apdu[6].toInt() and 0xff
         }
         if (offset >= contents.size) {
-            Logger.w(TAG, "handleReadBinary: starting offset $offset beyond file " +
-                    "end ${contents.size} -> STATUS_WORD_WRONG_PARAMETERS")
+            Logger.w(
+                TAG, "handleReadBinary: starting offset $offset beyond file " +
+                        "end ${contents.size} -> STATUS_WORD_WRONG_PARAMETERS"
+            )
             return NfcUtil.STATUS_WORD_WRONG_PARAMETERS
         }
         if (offset + size > contents.size) {
-            Logger.w(TAG, "handleReadBinary: ending offset ${offset + size} beyond file" +
-                    "end ${contents.size} -> STATUS_WORD_END_OF_FILE_REACHED")
+            Logger.w(
+                TAG, "handleReadBinary: ending offset ${offset + size} beyond file" +
+                        "end ${contents.size} -> STATUS_WORD_END_OF_FILE_REACHED"
+            )
             return NfcUtil.STATUS_WORD_END_OF_FILE_REACHED
         }
         val response = ByteArray(size + NfcUtil.STATUS_WORD_OK.size)
         System.arraycopy(contents, offset, response, 0, size)
         System.arraycopy(NfcUtil.STATUS_WORD_OK, 0, response, size, NfcUtil.STATUS_WORD_OK.size)
-        Logger.d(TAG, "handleReadBinary: returning $size bytes from offset $offset " +
-                "(file size ${contents.size})")
+        Logger.d(
+            TAG, "handleReadBinary: returning $size bytes from offset $offset " +
+                    "(file size ${contents.size})"
+        )
         return response
     }
 
     private var updateBinaryData: ByteArray? = null
 
     init {
-        deviceEngagement = EngagementGenerator(
-            eDeviceKey,
-            EngagementGenerator.ENGAGEMENT_VERSION_1_0
-        ).generate()
         Logger.dCbor(TAG, "NFC DeviceEngagement", deviceEngagement)
         Logger.d(TAG, "Starting")
     }
@@ -457,8 +469,10 @@ class NfcEngagementHelper private constructor(
                         return NfcUtil.STATUS_WORD_FILE_NOT_FOUND
                     }
                     if (length != updateBinaryData!!.size) {
-                        Logger.w(TAG, "Length $length doesn't match received data of " +
-                                "${updateBinaryData!!.size} bytes")
+                        Logger.w(
+                            TAG, "Length $length doesn't match received data of " +
+                                    "${updateBinaryData!!.size} bytes"
+                        )
                         return NfcUtil.STATUS_WORD_FILE_NOT_FOUND
                     }
 
@@ -469,11 +483,13 @@ class NfcEngagementHelper private constructor(
                 }
             } else {
                 if (updateBinaryData != null) {
-                    Logger.w(TAG,"Got data in single UPDATE_BINARY but we are already active")
+                    Logger.w(TAG, "Got data in single UPDATE_BINARY but we are already active")
                     return NfcUtil.STATUS_WORD_FILE_NOT_FOUND
                 }
-                Logger.dHex(TAG, "handleUpdateBinary: single UPDATE_BINARY message " +
-                        "with payload: ", payload)
+                Logger.dHex(
+                    TAG, "handleUpdateBinary: single UPDATE_BINARY message " +
+                            "with payload: ", payload
+                )
                 val ndefMessage = payload.copyOfRange(2, payload.size)
                 handleUpdateBinaryNdefMessage(ndefMessage)
             }
@@ -560,7 +576,7 @@ class NfcEngagementHelper private constructor(
 
     private fun handleHandoverRequest(ndefMessagePayload: ByteArray): ByteArray {
         Logger.dHex(TAG, "handleHandoverRequest: payload", ndefMessagePayload)
-        val  message = try {
+        val message = try {
             NdefMessage(ndefMessagePayload)
         } catch (e: FormatException) {
             Logger.e(TAG, "handleHandoverRequest: Error parsing NdefMessage", e)
@@ -569,7 +585,10 @@ class NfcEngagementHelper private constructor(
         }
         val records = message.records
         if (records.size < 2) {
-            Logger.e(TAG, "handleServiceSelect: Expected at least two NdefRecords, found ${records.size}")
+            Logger.e(
+                TAG,
+                "handleServiceSelect: Expected at least two NdefRecords, found ${records.size}"
+            )
             negotiatedHandoverState = NEGOTIATED_HANDOVER_STATE_NOT_STARTED
             return NfcUtil.STATUS_WORD_WRONG_PARAMETERS
         }
@@ -587,7 +606,11 @@ class NfcEngagementHelper private constructor(
                     var hrEmbMessage = try {
                         NdefMessage(hrEmbMessageData)
                     } catch (e: FormatException) {
-                        Logger.e(TAG, "handleHandoverRequest: Error parsing embedded HR NdefMessage", e)
+                        Logger.e(
+                            TAG,
+                            "handleHandoverRequest: Error parsing embedded HR NdefMessage",
+                            e
+                        )
                         negotiatedHandoverState = NEGOTIATED_HANDOVER_STATE_NOT_STARTED
                         return NfcUtil.STATUS_WORD_WRONG_PARAMETERS
                     }
@@ -694,75 +717,35 @@ class NfcEngagementHelper private constructor(
     }
 
     // Note: The report*() methods are safe to call from any thread.
-    fun reportTwoWayEngagementDetected() {
+    private fun reportTwoWayEngagementDetected() {
         Logger.d(TAG, "reportTwoWayEngagementDetected")
-        val listener = listener
-        val executor = executor
-        if (listener != null && executor != null) {
-            executor.execute {
-                if (!inhibitCallbacks) {
-                    listener.onTwoWayEngagementDetected()
-                }
-            }
-        }
+        listener.executeIfAllowed(inhibitCallbacks) { onTwoWayEngagementDetected() }
     }
 
-    fun reportHandoverSelectMessageSent() {
+    private fun reportHandoverSelectMessageSent() {
         Logger.d(TAG, "onHandoverSelectMessageSent")
-        val listener = listener
-        val executor = executor
-        if (listener != null && executor != null) {
-            executor.execute {
-                if (!inhibitCallbacks) {
-                    listener.onHandoverSelectMessageSent()
-                }
-            }
-        }
+        listener.executeIfAllowed(inhibitCallbacks) { onHandoverSelectMessageSent() }
     }
 
-    fun reportDeviceConnecting() {
+    private fun reportDeviceConnecting() {
         Logger.d(TAG, "reportDeviceConnecting")
-        val listener = listener
-        val executor = executor
-        if (listener != null && executor != null) {
-            executor.execute {
-                if (!inhibitCallbacks) {
-                    listener.onDeviceConnecting()
-                }
-            }
-        }
+        listener.executeIfAllowed(inhibitCallbacks) { onDeviceConnecting() }
     }
 
-    fun reportDeviceConnected(transport: DataTransport) {
+    private fun reportDeviceConnected(transport: DataTransport) {
         Logger.d(TAG, "reportDeviceConnected")
-        val listener = listener
-        val executor = executor
-        if (listener != null && executor != null) {
-            executor.execute {
-                if (!inhibitCallbacks) {
-                    listener.onDeviceConnected(transport)
-                }
-            }
-        }
+        listener.executeIfAllowed(inhibitCallbacks) { onDeviceConnected(transport) }
     }
 
-    fun reportError(error: Throwable) {
+    private fun reportError(error: Throwable) {
         Logger.d(TAG, "reportError: error: ", error)
-        val listener = listener
-        val executor = executor
-        if (listener != null && executor != null) {
-            executor.execute {
-                if (!inhibitCallbacks) {
-                    listener.onError(error)
-                }
-            }
-        }
+        listener.executeIfAllowed(inhibitCallbacks) { onError(error) }
     }
 
     /**
      * Listener for [NfcEngagementHelper].
      */
-    interface Listener {
+    interface Listener : HelperListener {
         /**
          * Called when two-way engagement has been detected.
          *
@@ -820,13 +803,13 @@ class NfcEngagementHelper private constructor(
      * @param options set of options for creating [DataTransport] instances.
      * @param listener the listener.
      * @param executor a [Executor] to use with the listener.
-    */
+     */
     class Builder(
         context: Context,
+        scope: CoroutineScope,
         eDeviceKey: EcPublicKey,
         options: DataTransportOptions,
         listener: Listener,
-        executor: Executor
     ) {
         var helper: NfcEngagementHelper
 
@@ -846,7 +829,7 @@ class NfcEngagementHelper private constructor(
                 negotiatedHandoverWtInt,
                 negotiatedHandoverMaxNumWaitingTimeExtensions,
                 listener,
-                executor
+                scope
             )
         }
 
@@ -882,8 +865,10 @@ class NfcEngagementHelper private constructor(
          * @return the helper, ready to be used.
          */
         fun build(): NfcEngagementHelper {
-            check(!(helper.mUsingNegotiatedHandover &&
-                    helper.staticHandoverConnectionMethods != null)) {
+            check(
+                !(helper.mUsingNegotiatedHandover &&
+                        helper.staticHandoverConnectionMethods != null)
+            ) {
                 "Can't use static and negotiated handover at the same time."
             }
             return helper
@@ -896,5 +881,30 @@ class NfcEngagementHelper private constructor(
         private const val NEGOTIATED_HANDOVER_STATE_EXPECT_SERVICE_SELECT = 1
         private const val NEGOTIATED_HANDOVER_STATE_EXPECT_HANDOVER_REQUEST = 2
         private const val NEGOTIATED_HANDOVER_STATE_EXPECT_HANDOVER_SELECT = 3
+    }
+
+    /**
+     * Private extension function localized to [NfcEngagementHelper] that wraps around the extension function
+     * [CoroutineScope?.launchIfAllowed] to simplify and prettify listener callbacks.
+     *
+     * For ex, run a coroutine to call "onMessageReceived()" on the Listener instance
+     * scope.launchIfAllowed(inhibitCallbacks, listener) { onMessageReceived() }
+     *
+     * can be simplified to something easier to follow
+     * listener.executeIfAllowed(inhibitCallbacks) { onMessageReceived() }
+     *
+     * @param inhibitCallbacks whether to prevent the callback from being executed/called
+     * @param callback the block of code using Listener as the function type receiver so
+     * function calls are made on "this" Listener instance directly.
+     */
+    private fun Listener?.executeIfAllowed(
+        inhibitCallbacks: Boolean,
+        callback: Listener.() -> Unit
+    ) {
+        scope.launchIfAllowed(
+            inhibitCallbacks = inhibitCallbacks,
+            listener = this,
+            callback = callback
+        )
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodUdp.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodUdp.kt
@@ -7,23 +7,25 @@ import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 
 class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() {
 
-    override fun toDeviceEngagement(): ByteArray {
-        val mapBuilder = CborMap.builder()
-        mapBuilder.put(OPTION_KEY_HOST, host)
-        mapBuilder.put(OPTION_KEY_PORT, port.toLong())
-        return Cbor.encode(
+    override fun toDeviceEngagement(): ByteArray =
+        Cbor.encode(
             CborArray.builder()
                 .add(METHOD_TYPE)
                 .add(METHOD_MAX_VERSION)
-                .add(mapBuilder.end().build())
+                .add(
+                    CborMap.builder().apply {
+                        put(OPTION_KEY_HOST, host)
+                        put(OPTION_KEY_PORT, port.toLong())
+                    }
+                        .end()
+                        .build()
+                )
                 .end()
                 .build()
         )
-    }
 
-    override fun toString(): String {
-        return "udp:host=$host:port=$port"
-    }
+
+    override fun toString(): String = "udp:host=$host:port=$port"
 
     companion object {
         // NOTE: 18013-5 only allows positive integers, but our codebase also supports negative
@@ -33,19 +35,21 @@ class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() 
 
         private const val OPTION_KEY_HOST = 0L
         private const val OPTION_KEY_PORT = 1L
+
         @JvmStatic
-        fun fromDeviceEngagementUdp(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethodUdp? {
-            val array = Cbor.decode(encodedDeviceRetrievalMethod).asArray
-            val type = array[0].asNumber
-            val version = array[1].asNumber
-            require(type == METHOD_TYPE)
-            if (version > METHOD_MAX_VERSION) {
-                return null
+        fun fromDeviceEngagementUdp(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethodUdp? =
+            Cbor.decode(encodedDeviceRetrievalMethod).asArray.let { array ->
+                val version = array[1].asNumber
+                if (version > METHOD_MAX_VERSION) {
+                    return null
+                }
+                val type = array[0].asNumber
+                require(type == METHOD_TYPE)
+
+                val map = array[2]
+                val host = map[OPTION_KEY_HOST].asTstr
+                val port = map[OPTION_KEY_PORT].asNumber
+                ConnectionMethodUdp(host, port.toInt())
             }
-            val map = array[2]
-            val host = map[OPTION_KEY_HOST].asTstr
-            val port = map[OPTION_KEY_PORT].asNumber
-            return ConnectionMethodUdp(host, port.toInt())
-        }
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBle.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBle.kt
@@ -58,7 +58,8 @@ abstract class DataTransportBle(
             connectionMethod.centralClientModeUuid
         )
         connectionMethodToReturn.peripheralServerModePsm = connectionMethod.peripheralServerModePsm
-        connectionMethodToReturn.peripheralServerModeMacAddress = connectionMethod.peripheralServerModeMacAddress
+        connectionMethodToReturn.peripheralServerModeMacAddress =
+            connectionMethod.peripheralServerModeMacAddress
     }
 
     override val connectionMethodForTransport: ConnectionMethod
@@ -79,7 +80,7 @@ abstract class DataTransportBle(
             var peripheral = false
             var uuid: UUID? = null
             var gotLeRole = false
-            var gotUuid = false
+            var gotUuid = false // TODO cleanup, never used
             var psm = OptionalInt.empty()
             var macAddress: ByteArray? = null
 
@@ -235,72 +236,77 @@ abstract class DataTransportBle(
             // Looking that up it says it's just a sequence of {length, AD type, AD data} where each
             // AD is defined in the "Bluetooth Supplement to the Core Specification" document.
             //
-            var baos = ByteArrayOutputStream()
-            baos.write(0x02)
-            baos.write(0x1c) // LE Role
-            baos.write(leRole)
-            if (uuid != null) {
-                baos.write(0x11) // Complete List of 128-bit Service UUID’s (0x07)
-                baos.write(0x07)
-                val uuidBuf = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN)
-                uuidBuf.putLong(0, uuid.leastSignificantBits)
-                uuidBuf.putLong(8, uuid.mostSignificantBits)
-                try {
-                    baos.write(uuidBuf.array())
-                } catch (e: IOException) {
-                    throw IllegalStateException(e)
+            val ndefRecordBytes = ByteArrayOutputStream().let { baos ->
+                baos.write(0x02)
+                baos.write(0x1c) // LE Role
+                baos.write(leRole)
+                if (uuid != null) {
+                    baos.write(0x11) // Complete List of 128-bit Service UUID’s (0x07)
+                    baos.write(0x07)
+                    val uuidBuf = ByteBuffer.allocate(16).order(ByteOrder.LITTLE_ENDIAN)
+                    uuidBuf.putLong(0, uuid.leastSignificantBits)
+                    uuidBuf.putLong(8, uuid.mostSignificantBits)
+                    try {
+                        baos.write(uuidBuf.array())
+                    } catch (e: IOException) {
+                        throw IllegalStateException(e)
+                    }
                 }
+                val macAddress = cm.peripheralServerModeMacAddress
+                if (macAddress != null) {
+                    require(macAddress.size == 6) {
+                        "MAC address should be six bytes, found ${macAddress.size}"
+                    }
+                    baos.write(0x07)
+                    baos.write(0x1b) // MAC address
+                    try {
+                        baos.write(macAddress)
+                    } catch (e: IOException) {
+                        throw IllegalStateException(e)
+                    }
+                }
+                val psm = cm.peripheralServerModePsm
+                if (psm.isPresent) {
+                    // TODO: need to actually allocate this number (0x77)
+                    baos.write(0x05) // PSM: 4 bytes
+                    baos.write(0x77)
+                    val psmValue = ByteBuffer.allocate(4)
+                        .order(ByteOrder.LITTLE_ENDIAN)
+                        .putInt(psm.asInt)
+                    try {
+                        baos.write(psmValue.array())
+                    } catch (e: IOException) {
+                        throw IllegalStateException(e)
+                    }
+                }
+
+                baos.toByteArray()
             }
-            val macAddress = cm.peripheralServerModeMacAddress
-            if (macAddress != null) {
-                require(macAddress.size == 6) {
-                    "MAC address should be six bytes, found ${macAddress.size}"
-                }
-                baos.write(0x07)
-                baos.write(0x1b) // MAC address
-                try {
-                    baos.write(macAddress)
-                } catch (e: IOException) {
-                    throw IllegalStateException(e)
-                }
-            }
-            val psm = cm.peripheralServerModePsm
-            if (psm.isPresent) {
-                // TODO: need to actually allocate this number (0x77)
-                baos.write(0x05) // PSM: 4 bytes
-                baos.write(0x77)
-                val psmValue = ByteBuffer.allocate(4)
-                    .order(ByteOrder.LITTLE_ENDIAN)
-                    .putInt(psm.asInt)
-                try {
-                    baos.write(psmValue.array())
-                } catch (e: IOException) {
-                    throw IllegalStateException(e)
-                }
-            }
-            val oobData = baos.toByteArray()
+
             val record = NdefRecord(
                 NdefRecord.TNF_MIME_MEDIA,
                 "application/vnd.bluetooth.le.oob".toByteArray(),
                 "0".toByteArray(),
-                oobData
+                ndefRecordBytes
             )
 
             // From 7.1 Alternative Carrier Record
             //
-            baos = ByteArrayOutputStream()
-            baos.write(0x01) // CPS: active
-            baos.write(0x01) // Length of carrier data reference ("0")
-            baos.write('0'.code) // Carrier data reference
-            baos.write(auxiliaryReferences.size) // Number of auxiliary references
-            for (auxRef in auxiliaryReferences) {
-                // Each auxiliary reference consists of a single byte for the length and then as
-                // many bytes for the reference itself.
-                val auxRefUtf8 = auxRef.toByteArray()
-                baos.write(auxRefUtf8.size)
-                baos.write(auxRefUtf8, 0, auxRefUtf8.size)
+            val acRecordPayload = ByteArrayOutputStream().let { baos ->
+                baos.write(0x01) // CPS: active
+                baos.write(0x01) // Length of carrier data reference ("0")
+                baos.write('0'.code) // Carrier data reference
+                baos.write(auxiliaryReferences.size) // Number of auxiliary references
+                for (auxRef in auxiliaryReferences) {
+                    // Each auxiliary reference consists of a single byte for the length and then as
+                    // many bytes for the reference itself.
+                    val auxRefUtf8 = auxRef.toByteArray()
+                    baos.write(auxRefUtf8.size)
+                    baos.write(auxRefUtf8, 0, auxRefUtf8.size)
+                }
+                baos.toByteArray()
             }
-            val acRecordPayload = baos.toByteArray()
+
             return Pair(record, acRecordPayload)
         }
 

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
@@ -45,8 +45,10 @@ class DataTransportBleCentralClientMode(
     options: DataTransportOptions
 ) : DataTransportBle(context, role, connectionMethod, options) {
     private var characteristicStateUuid = UUID.fromString("00000005-a123-48ce-896b-4c76973373e6")
-    private var characteristicClient2ServerUuid = UUID.fromString("00000006-a123-48ce-896b-4c76973373e6")
-    private var characteristicServer2ClientUuid = UUID.fromString("00000007-a123-48ce-896b-4c76973373e6")
+    private var characteristicClient2ServerUuid =
+        UUID.fromString("00000006-a123-48ce-896b-4c76973373e6")
+    private var characteristicServer2ClientUuid =
+        UUID.fromString("00000007-a123-48ce-896b-4c76973373e6")
     private var characteristicIdentUuid = UUID.fromString("00000008-a123-48ce-896b-4c76973373e6")
 
     /**
@@ -56,13 +58,24 @@ class DataTransportBleCentralClientMode(
      * UUID 0000000B-A123-48CE896B-4C76973373E6 and the GATT client (for the _mdoc_) should
      * connect to that UUID.
      */
-    private var characteristicL2CAPUuidMdocReader = UUID.fromString("0000000b-a123-48ce-896b-4c76973373e6")
+    private var characteristicL2CAPUuidMdocReader =
+        UUID.fromString("0000000b-a123-48ce-896b-4c76973373e6")
     private var bluetoothManager: BluetoothManager? = null
     private var bluetoothLeAdvertiser: BluetoothLeAdvertiser? = null
-    private var gattClient: GattClient? = null
     private var scanner: BluetoothLeScanner? = null
     private var encodedEDeviceKeyBytes: ByteArray? = null
     private var timeScanningStartedMillis: Long = 0
+    private var l2capClient: L2CAPClient? = null
+
+    // GattServer nullable and non-nullable
+    private var _gattServer: GattServer? = null
+    private val gattServer: GattServer
+        get() = _gattServer!!
+
+    // GattClient nullable and non-nullable
+    private var _gattClient: GattClient? = null
+    private val gattClient: GattClient
+        get() = _gattClient!!
 
     // a flag to prevent multiple GattClient connects which cause to multiple
     // new GattClient instances and to crashes
@@ -80,8 +93,10 @@ class DataTransportBleCentralClientMode(
             isConnecting = true
             val device = result.device
             scanningTimeMillis = System.currentTimeMillis() - timeScanningStartedMillis
-            Logger.i(TAG, "Scanned for $scanningTimeMillis milliseconds. "
-                        + "Connecting to device with address ${device.address}")
+            Logger.i(
+                TAG, "Scanned for $scanningTimeMillis milliseconds. "
+                        + "Connecting to device with address ${device.address}"
+            )
             connectToDevice(device)
             if (scanner != null) {
                 Logger.d(TAG, "Stopped scanning for UUID $serviceUuid")
@@ -114,8 +129,26 @@ class DataTransportBleCentralClientMode(
         }
     }
 
-    private var gattServer: GattServer? = null
-    private var l2capClient: L2CAPClient? = null
+    /**
+     * Stop the active GattServer and free memory of its instance.
+     */
+    private fun clearGattServer() =
+        _gattServer?.let {
+            gattServer.listener = null
+            gattServer.stop()
+            _gattServer = null
+        }
+
+    /**
+     * Disconnect the active GattClient and free memory of its instance.
+     */
+    fun clearGattClient() =
+        _gattClient?.let {
+            gattClient.listener = null
+            gattClient.disconnect()
+            _gattClient = null
+        }
+
 
     private fun connectToDevice(device: BluetoothDevice) {
         reportConnecting()
@@ -135,24 +168,24 @@ class DataTransportBleCentralClientMode(
         if (options.bleUseL2CAP) {
             characteristicL2CAPUuid = characteristicL2CAPUuidMdocReader
         }
-        gattClient = GattClient(
-            context,
-            serviceUuid!!, encodedEDeviceKeyBytes,
-            characteristicStateUuid, characteristicClient2ServerUuid,
-            characteristicServer2ClientUuid, characteristicIdentUuid,
-            characteristicL2CAPUuid
+        _gattClient = GattClient(
+            context = context,
+            scope = scope,
+            serviceUuid = serviceUuid!!,
+            encodedEDeviceKeyBytes = encodedEDeviceKeyBytes,
+            characteristicStateUuid = characteristicStateUuid,
+            characteristicClient2ServerUuid = characteristicClient2ServerUuid,
+            characteristicServer2ClientUuid = characteristicServer2ClientUuid,
+            characteristicIdentUuid = characteristicIdentUuid,
+            characteristicL2CAPUuid = characteristicL2CAPUuid
         )
-        gattClient!!.listener = object : GattClient.Listener {
+        gattClient.listener = object : GattClient.Listener {
             override fun onPeerConnected() {
                 reportConnected()
             }
 
             override fun onPeerDisconnected() {
-                if (gattClient != null) {
-                    gattClient!!.listener = null
-                    gattClient!!.disconnect()
-                    gattClient = null
-                }
+                clearGattClient()
                 reportDisconnected()
             }
 
@@ -168,29 +201,31 @@ class DataTransportBleCentralClientMode(
                 reportError(error)
             }
         }
-        gattClient!!.clearCache = options.bleClearCache
-        gattClient!!.connect(device)
+        gattClient.clearCache = options.bleClearCache
+        gattClient.connect(device)
     }
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
     private fun connectL2CAP(device: BluetoothDevice, psm: Int) {
-        l2capClient = L2CAPClient(context, object : L2CAPClient.Listener {
-            override fun onPeerConnected() {
-                reportConnected()
-            }
+        l2capClient = L2CAPClient(context = context,
+            scope = scope,
+            listener = object : L2CAPClient.Listener {
+                override fun onPeerConnected() {
+                    reportConnected()
+                }
 
-            override fun onPeerDisconnected() {
-                reportDisconnected()
-            }
+                override fun onPeerDisconnected() {
+                    reportDisconnected()
+                }
 
-            override fun onMessageReceived(data: ByteArray) {
-                reportMessageReceived(data)
-            }
+                override fun onMessageReceived(data: ByteArray) {
+                    reportMessageReceived(data)
+                }
 
-            override fun onError(error: Throwable) {
-                reportError(error)
-            }
-        })
+                override fun onError(error: Throwable) {
+                    reportError(error)
+                }
+            })
         l2capClient!!.connect(device, psm)
     }
 
@@ -201,7 +236,7 @@ class DataTransportBleCentralClientMode(
     // TODO: Check if BLE is enabled and error out if not so...
     private fun connectAsMdoc() {
         bluetoothManager = context.getSystemService(BluetoothManager::class.java)
-        val bluetoothAdapter = bluetoothManager!!.getAdapter()
+        val bluetoothAdapter = bluetoothManager!!.adapter
         val macAddress = connectionMethod.peripheralServerModeMacAddress
         if (macAddress != null) {
             Logger.i(TAG, "MAC address provided, no scanning needed")
@@ -238,14 +273,19 @@ class DataTransportBleCentralClientMode(
         if (options.bleUseL2CAP) {
             characteristicL2CAPUuid = characteristicL2CAPUuidMdocReader
         }
-        gattServer = GattServer(
-            context, bluetoothManager, serviceUuid!!,
-            encodedEDeviceKeyBytes,
-            characteristicStateUuid, characteristicClient2ServerUuid,
-            characteristicServer2ClientUuid, characteristicIdentUuid,
-            characteristicL2CAPUuid
+        _gattServer = GattServer(
+            context = context,
+            scope = scope,
+            bluetoothManager = bluetoothManager,
+            serviceUuid = serviceUuid!!,
+            encodedEDeviceKeyBytes = encodedEDeviceKeyBytes,
+            characteristicStateUuid = characteristicStateUuid,
+            characteristicClient2ServerUuid = characteristicClient2ServerUuid,
+            characteristicServer2ClientUuid = characteristicServer2ClientUuid,
+            characteristicIdentUuid = characteristicIdentUuid,
+            characteristicL2CAPUuid = characteristicL2CAPUuid
         )
-        gattServer!!.listener = object : GattServer.Listener {
+        gattServer.listener = object : GattServer.Listener {
             override fun onPeerConnected() {
                 Logger.i(TAG, "onPeerConnected")
                 reportConnected()
@@ -279,21 +319,18 @@ class DataTransportBleCentralClientMode(
                 reportError(error)
             }
         }
-        if (!gattServer!!.start()) {
+        if (!gattServer.start()) {
             reportError(Error("Error starting Gatt Server"))
-            gattServer!!.stop()
-            gattServer = null
-            return
+            clearGattServer()
         }
         if (options.experimentalBleL2CAPPsmInEngagement) {
-            connectionMethodToReturn.peripheralServerModePsm = gattServer!!.psm
+            connectionMethodToReturn.peripheralServerModePsm = gattServer.psm
         }
         val bluetoothAdapter = bluetoothManager.adapter
         bluetoothLeAdvertiser = bluetoothAdapter.bluetoothLeAdvertiser
         if (bluetoothLeAdvertiser == null) {
             reportError(Error("Failed to create BLE advertiser"))
-            gattServer!!.stop()
-            gattServer = null
+            clearGattServer()
         } else {
             val settings = AdvertiseSettings.Builder()
                 .setAdvertiseMode(AdvertiseSettings.ADVERTISE_MODE_LOW_LATENCY)
@@ -336,11 +373,7 @@ class DataTransportBleCentralClientMode(
             }
             bluetoothLeAdvertiser = null
         }
-        if (gattServer != null) {
-            gattServer!!.listener = null
-            gattServer!!.stop()
-            gattServer = null
-        }
+        clearGattServer()
         if (scanner != null) {
             Logger.d(TAG, "Stopped scanning for UUID $serviceUuid")
             try {
@@ -350,11 +383,8 @@ class DataTransportBleCentralClientMode(
             }
             scanner = null
         }
-        if (gattClient != null) {
-            gattClient!!.listener = null
-            gattClient!!.disconnect()
-            gattClient = null
-        }
+        clearGattClient()
+
         if (l2capClient != null) {
             l2capClient!!.disconnect()
             l2capClient = null
@@ -362,40 +392,33 @@ class DataTransportBleCentralClientMode(
     }
 
     override fun sendMessage(data: ByteArray) {
-        require(data.size != 0) { "Data to send cannot be empty" }
-        if (l2capClient != null) {
-            l2capClient!!.sendMessage(data)
-        } else if (gattServer != null) {
-            gattServer!!.sendMessage(data)
-        } else if (gattClient != null) {
-            gattClient!!.sendMessage(data)
-        }
+        require(data.isNotEmpty()) { "Data to send cannot be empty" }
+
+        l2capClient?.sendMessage(data)
+            ?: _gattServer?.sendMessage(data)
+            ?: _gattClient?.sendMessage(data)
     }
 
     override fun sendTransportSpecificTerminationMessage() {
         if (l2capClient != null) {
             reportError(Error("Transport-specific termination not available"))
-        } else if (gattServer == null) {
-            if (gattClient == null) {
+        } else if (_gattServer == null) {
+            if (_gattClient == null) {
                 reportError(Error("Transport-specific termination not available"))
                 return
             }
-            gattClient!!.sendTransportSpecificTermination()
+            gattClient.sendTransportSpecificTermination()
             return
         }
-        gattServer!!.sendTransportSpecificTermination()
+        gattServer.sendTransportSpecificTermination()
     }
 
-    override fun supportsTransportSpecificTerminationMessage(): Boolean {
-        if (l2capClient != null) {
-            return false
-        } else if (gattServer != null) {
-            return gattServer!!.supportsTransportSpecificTerminationMessage()
-        } else if (gattClient != null) {
-            return gattClient!!.supportsTransportSpecificTerminationMessage()
-        }
-        return false
-    }
+    override fun supportsTransportSpecificTerminationMessage(): Boolean =
+        if (l2capClient != null) false else
+            _gattServer?.supportsTransportSpecificTerminationMessage()
+                ?: _gattClient?.supportsTransportSpecificTerminationMessage()
+                ?: false
+
 
     companion object {
         private const val TAG = "DataTransportBleCCM" // limit to <= 23 chars

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportOptions.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportOptions.kt
@@ -79,12 +79,11 @@ class DataTransportOptions internal constructor(
          *
          * @return the built [DataTransportOptions] instance.
          */
-        fun build(): DataTransportOptions {
-            return DataTransportOptions(
+        fun build(): DataTransportOptions =
+            DataTransportOptions(
                 bleUseL2CAP,
                 bleClearCache,
                 experimentalBleL2CAPPsmInEngagement
             )
-        }
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportUdp.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportUdp.kt
@@ -84,7 +84,7 @@ class DataTransportUdp(
             }
         }
         socketServerThread.start()
-        if (host == null || host!!.length == 0) {
+        if (host == null || host!!.isEmpty()) {
             host = getWifiIpAddress(context)
         }
         if (this.port == 0) {
@@ -175,7 +175,7 @@ class DataTransportUdp(
                         }
                         // An empty message is used to convey that the writing thread should be
                         // shut down.
-                        if (messageToSend.size == 0) {
+                        if (messageToSend.isEmpty()) {
                             Logger.d(TAG, "Empty message, shutting down writer")
                             break
                         }
@@ -279,19 +279,20 @@ class DataTransportUdp(
 
             // From 7.1 Alternative Carrier Record
             //
-            val baos = ByteArrayOutputStream()
-            baos.write(0x01) // CPS: active
-            baos.write(reference.size)
-            try {
-                baos.write(reference)
-            } catch (e: IOException) {
-                throw IllegalStateException(e)
+            val acRecordPayload = ByteArrayOutputStream().run {
+                write(0x01) // CPS: active
+                write(reference.size)
+                try {
+                    write(reference)
+                } catch (e: IOException) {
+                    throw IllegalStateException(e)
+                }
+                write(0x01) // Number of auxiliary references
+                val auxReference = "mdoc".toByteArray()
+                write(auxReference.size)
+                write(auxReference, 0, auxReference.size)
+                toByteArray()
             }
-            baos.write(0x01) // Number of auxiliary references
-            val auxReference = "mdoc".toByteArray()
-            baos.write(auxReference.size)
-            baos.write(auxReference, 0, auxReference.size)
-            val acRecordPayload = baos.toByteArray()
             return Pair(record, acRecordPayload)
         }
     }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportWifiAware.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportWifiAware.kt
@@ -382,8 +382,7 @@ class DataTransportWifiAware(
 
         // peerIpv6.getHostAddress() returns something like "fe80::75:baff:fedd:ce16%aware_data0",
         // this is how we get rid of it...
-        val strippedAddress: InetAddress
-        strippedAddress = try {
+        val strippedAddress: InetAddress = try {
             InetAddress.getByAddress(peerIpv6!!.address)
         } catch (e: UnknownHostException) {
             reportError(e)
@@ -459,8 +458,7 @@ class DataTransportWifiAware(
     }
 
     fun writeToSocket(isListener: Boolean, socket: Socket?) {
-        val os: OutputStream
-        os = try {
+        val os: OutputStream = try {
             socket!!.getOutputStream()
         } catch (e: IOException) {
             reportError(e)
@@ -635,13 +633,11 @@ Content-Type: application/CBOR
             cm: ConnectionMethodWifiAware,
             role: Role,
             options: DataTransportOptions
-        ): DataTransport {
-            val t = DataTransportWifiAware(context, role, cm, options)
+        ): DataTransport = DataTransportWifiAware(context, role, cm, options).apply {
             if (cm.passphraseInfoPassphrase != null) {
-                t.setPassphrase(cm.passphraseInfoPassphrase!!)
+                setPassphrase(cm.passphraseInfoPassphrase!!)
             }
             // TODO: set mBandInfoSupportedBands, mChannelInfoChannelNumber, mChannelInfoOperatingClass
-            return t
         }
 
         fun toNdefRecord(
@@ -651,70 +647,73 @@ Content-Type: application/CBOR
         ): Pair<NdefRecord, ByteArray>? {
             // The NdefRecord and its OOB data is defined in "Wi-Fi Aware Specification", table 142.
             //
-            var baos = ByteArrayOutputStream()
-            try {
-                // TODO: use mCipherSuites
-                val cipherSuites = Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_128
+            val oobData = ByteArrayOutputStream().run {
+                try {
+                    // TODO: use mCipherSuites
+                    val cipherSuites = Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_128
 
-                // Spec says: The NFC Handover Selector shall include the Cipher Suite Info field
-                // with one or multiple NAN Cipher Suite IDs in the WiFi Aware Carrier Configuration
-                // Record to indicate the supported NAN cipher suite(s)."
-                //
-                var numCipherSuitesSupported = 0
-                if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_128 != 0) {
-                    numCipherSuitesSupported++
-                }
-                if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_256 != 0) {
-                    numCipherSuitesSupported++
-                }
-                baos.write(1 + numCipherSuitesSupported)
-                baos.write(0x01) // Data Type 0x01 - Cipher Suite Info
-                if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_128 != 0) {
-                    baos.write(0x01) // NCS-SK-128
-                }
-                if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_256 != 0) {
-                    baos.write(0x02) // NCS-SK-256
-                }
+                    // Spec says: The NFC Handover Selector shall include the Cipher Suite Info field
+                    // with one or multiple NAN Cipher Suite IDs in the WiFi Aware Carrier Configuration
+                    // Record to indicate the supported NAN cipher suite(s)."
+                    //
+                    var numCipherSuitesSupported = 0
+                    if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_128 != 0) {
+                        numCipherSuitesSupported++
+                    }
+                    if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_256 != 0) {
+                        numCipherSuitesSupported++
+                    }
+                    write(1 + numCipherSuitesSupported)
+                    write(0x01) // Data Type 0x01 - Cipher Suite Info
+                    if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_128 != 0) {
+                        write(0x01) // NCS-SK-128
+                    }
+                    if (cipherSuites and Characteristics.WIFI_AWARE_CIPHER_SUITE_NCS_SK_256 != 0) {
+                        write(0x02) // NCS-SK-256
+                    }
 
-                // Spec says: "If the NFC Handover Selector indicates an NCS-SK cipher suite, it
-                // shall include a Pass-phrase Info field in the Wi-Fi Aware Carrier Configuration Record
-                // to specify the selected pass-phrase for the supported cipher suite."
-                //
-                // Additionally, 18013-5 says: "If NFC is used for device engagement, either the
-                // Pass-phrase Info or the DH Info shall be explicitly transferred from the mdoc to
-                // the mdoc reader during device engagement according to the Wi-Fi Alliance
-                // Neighbor Awareness Networking Specification section 12."
-                //
-                if (cm.passphraseInfoPassphrase != null) {
-                    val encodedPassphrase = cm.passphraseInfoPassphrase!!.toByteArray(
-                        
-                    )
-                    baos.write(1 + encodedPassphrase.size)
-                    baos.write(0x03) // Data Type 0x03 - Pass-phrase Info
-                    baos.write(encodedPassphrase)
-                }
+                    // Spec says: "If the NFC Handover Selector indicates an NCS-SK cipher suite, it
+                    // shall include a Pass-phrase Info field in the Wi-Fi Aware Carrier Configuration Record
+                    // to specify the selected pass-phrase for the supported cipher suite."
+                    //
+                    // Additionally, 18013-5 says: "If NFC is used for device engagement, either the
+                    // Pass-phrase Info or the DH Info shall be explicitly transferred from the mdoc to
+                    // the mdoc reader during device engagement according to the Wi-Fi Alliance
+                    // Neighbor Awareness Networking Specification section 12."
+                    //
+                    if (cm.passphraseInfoPassphrase != null) {
+                        val encodedPassphrase = cm.passphraseInfoPassphrase!!.toByteArray(
 
-                // Spec says: "The NFC Handover Selector shall also include a Band Info field in the
-                // Wi-Fi Aware Configuration Record to indicate the supported NAN operating band
-                // (s)."
-                //
-                if (cm.bandInfoSupportedBands != null) {
-                    baos.write(1 + cm.bandInfoSupportedBands!!.size)
-                    baos.write(0x04) // Data Type 0x04 - Band Info
-                    baos.write(cm.bandInfoSupportedBands)
-                }
+                        )
+                        write(1 + encodedPassphrase.size)
+                        write(0x03) // Data Type 0x03 - Pass-phrase Info
+                        write(encodedPassphrase)
+                    }
 
-                // Spec says: "The Channel Info field serves as a placeholder for future
-                // extension, and
-                // may optionally be included in the Wi-Fi Aware Carrier Configuration Record in the
-                // NFC Handover Select message."
-                //
-                // We don't include this for now.
-                //
-            } catch (e: IOException) {
-                throw IllegalStateException(e)
+                    // Spec says: "The NFC Handover Selector shall also include a Band Info field in the
+                    // Wi-Fi Aware Configuration Record to indicate the supported NAN operating band
+                    // (s)."
+                    //
+                    if (cm.bandInfoSupportedBands != null) {
+                        write(1 + cm.bandInfoSupportedBands!!.size)
+                        write(0x04) // Data Type 0x04 - Band Info
+                        write(cm.bandInfoSupportedBands)
+                    }
+
+                    // Spec says: "The Channel Info field serves as a placeholder for future
+                    // extension, and
+                    // may optionally be included in the Wi-Fi Aware Carrier Configuration Record in the
+                    // NFC Handover Select message."
+                    //
+                    // We don't include this for now.
+                    //
+                } catch (e: IOException) {
+                    throw IllegalStateException(e)
+
+                }
+                toByteArray()
             }
-            val oobData = baos.toByteArray()
+
             val record = NdefRecord(
                 NdefRecord.TNF_MIME_MEDIA,
                 "application/vnd.wfa.nan".toByteArray(),
@@ -724,18 +723,19 @@ Content-Type: application/CBOR
 
             // From 7.1 Alternative Carrier Record
             //
-            baos = ByteArrayOutputStream()
-            baos.write(0x01) // CPS: active
-            baos.write(0x01) // Length of carrier data reference ("0")
-            baos.write('W'.code) // Carrier data reference
-            for (auxRef in auxiliaryReferences) {
-                // Each auxiliary reference consists of a single byte for the length and then as
-                // many bytes for the reference itself.
-                val auxRefUtf8 = auxRef.toByteArray()
-                baos.write(auxRefUtf8.size)
-                baos.write(auxRefUtf8, 0, auxRefUtf8.size)
+            val acRecordPayload = ByteArrayOutputStream().run {
+                write(0x01) // CPS: active
+                write(0x01) // Length of carrier data reference ("0")
+                write('W'.code) // Carrier data reference
+                for (auxRef in auxiliaryReferences) {
+                    // Each auxiliary reference consists of a single byte for the length and then as
+                    // many bytes for the reference itself.
+                    val auxRefUtf8 = auxRef.toByteArray()
+                    write(auxRefUtf8.size)
+                    write(auxRefUtf8, 0, auxRefUtf8.size)
+                }
+                toByteArray()
             }
-            val acRecordPayload = baos.toByteArray()
             return Pair(record, acRecordPayload)
         }
     }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
@@ -28,8 +28,8 @@ import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
 import com.android.identity.util.Logger
 import com.android.identity.util.toHex
+import kotlinx.coroutines.CoroutineScope
 import java.io.ByteArrayOutputStream
-import java.lang.reflect.InvocationTargetException
 import java.nio.ByteBuffer
 import java.util.ArrayDeque
 import java.util.Arrays
@@ -40,6 +40,7 @@ import java.util.UUID
 @SuppressLint("MissingPermission")
 internal class GattClient(
     private val context: Context,
+    private val scope: CoroutineScope?,
     private val serviceUuid: UUID,
     private val encodedEDeviceKeyBytes: ByteArray?,
     var characteristicStateUuid: UUID,
@@ -60,7 +61,8 @@ internal class GattClient(
     private var l2capClient: L2CAPClient? = null
 
     // This is what the 16-bit UUID 0x29 0x02 is encoded like.
-    private var clientCharacteristicConfigUuid = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+    private var clientCharacteristicConfigUuid =
+        UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     private var incomingMessage = ByteArrayOutputStream()
     private var writingQueue: Queue<ByteArray> = ArrayDeque()
     private var writingQueueTotalChunks = 0
@@ -100,22 +102,17 @@ internal class GattClient(
         Logger.d(TAG, "Application requested clearing BLE Service Cache")
         // BluetoothGatt.refresh() is not public API but can be accessed via introspection...
         try {
-            val refreshMethod = gatt.javaClass.getMethod("refresh")
-            var result = false
-            if (refreshMethod != null) {
-                result = refreshMethod.invoke(gatt) as Boolean
+            gatt.javaClass.getMethod("refresh").let { refreshMethod ->
+                val result = refreshMethod.invoke(gatt) as Boolean
+                if (result) {
+                    Logger.d(TAG, "BluetoothGatt.refresh() invoked successfully")
+                } else {
+                    Logger.e(TAG, "BluetoothGatt.refresh() invoked but returned false")
+                }
             }
-            if (result) {
-                Logger.d(TAG, "BluetoothGatt.refresh() invoked successfully")
-            } else {
-                Logger.e(TAG, "BluetoothGatt.refresh() invoked but returned false")
-            }
-        } catch (e: NoSuchMethodException) {
-            Logger.e(TAG, "Getting BluetoothGatt.refresh() failed with NoSuchMethodException", e)
-        } catch (e: IllegalAccessException) {
-            Logger.e(TAG, "Getting BluetoothGatt.refresh() failed with IllegalAccessException", e)
-        } catch (e: InvocationTargetException) {
-            Logger.e(TAG, "Getting BluetoothGatt.refresh() failed with InvocationTargetException", e)
+        } catch (e: Exception) {
+            // could be NoSuchMethodException, IllegalAccessException, InvocationTargetException
+            Logger.e(TAG, "Getting BluetoothGatt.refresh() failed with ", e)
         }
     }
 
@@ -241,7 +238,7 @@ internal class GattClient(
 
     private var mCharacteristicValueSize = 0
     private val characteristicValueSize: Int
-        private get() {
+        get() {
             if (mCharacteristicValueSize > 0) {
                 return mCharacteristicValueSize
             }
@@ -260,58 +257,73 @@ internal class GattClient(
         characteristic: BluetoothGattCharacteristic,
         status: Int
     ) {
-        if (characteristic.uuid == characteristicIdentUuid) {
-            val identValue = characteristic.value
-            if (Logger.isDebugEnabled) {
-                Logger.d(TAG, "Received identValue: ${identValue.toHex}")
+        when (characteristic.uuid) {
+            characteristicIdentUuid -> {
+                val identValue = characteristic.value
+                if (Logger.isDebugEnabled) {
+                    Logger.d(TAG, "Received identValue: ${identValue.toHex}")
+                }
+                // TODO: Don't even request IDENT since it cannot work w/ reverse engagement (there's
+                //   no way the mdoc reader knows EDeviceKeyBytes at this point) and it's also optional.
+                if (!Arrays.equals(identValue, this.identValue)) {
+                    Logger.w(
+                        TAG, "Received ident '${identValue.toHex}' does not match " +
+                                "expected ident '${this.identValue!!.toHex}'"
+                    )
+                }
+                afterIdentObtained(gatt)
             }
-            // TODO: Don't even request IDENT since it cannot work w/ reverse engagement (there's
-            //   no way the mdoc reader knows EDeviceKeyBytes at this point) and it's also optional.
-            if (!Arrays.equals(identValue, this.identValue)) {
-                Logger.w(TAG, "Received ident '${identValue.toHex}' does not match " +
-                            "expected ident '${this.identValue!!.toHex}'")
+
+            characteristicL2CAPUuid -> {
+                if (!usingL2CAP) {
+                    reportError(
+                        Error(
+                            "Unexpected read for L2CAP characteristic "
+                                    + characteristic.uuid + ", L2CAP not supported"
+                        )
+                    )
+                    return
+                }
+                l2capClient = L2CAPClient(
+                    context = context,
+                    scope = scope,
+                    listener = object : L2CAPClient.Listener {
+                        override fun onPeerConnected() {
+                            reportPeerConnected()
+                        }
+
+                        override fun onPeerDisconnected() {
+                            reportPeerDisconnected()
+                        }
+
+                        override fun onMessageReceived(data: ByteArray) {
+                            reportMessageReceived(data)
+                        }
+
+                        override fun onError(error: Throwable) {
+                            reportError(error)
+                        }
+                    })
+                val psmValue = characteristic.value
+                var psmSized = ByteArray(4)
+                if (psmValue.size < 4) {
+                    // Add 00 on left if psm length is lower than 4
+                    System.arraycopy(psmValue, 0, psmSized, 4 - psmValue.size, psmValue.size)
+                } else {
+                    psmSized = psmValue
+                }
+                val psm = ByteBuffer.wrap(psmSized).getInt()
+                l2capClient!!.connect(this.gatt!!.device, psm)
             }
-            afterIdentObtained(gatt)
-        } else if (characteristic.uuid == characteristicL2CAPUuid) {
-            if (!usingL2CAP) {
+
+            else -> {
                 reportError(
                     Error(
-                        "Unexpected read for L2CAP characteristic "
-                                + characteristic.uuid + ", L2CAP not supported"
+                        "Unexpected onCharacteristicRead for characteristic " +
+                                "$characteristic.uuid + expected $characteristicIdentUuid"
                     )
                 )
-                return
             }
-            l2capClient = L2CAPClient(context, object : L2CAPClient.Listener {
-                override fun onPeerConnected() {
-                    reportPeerConnected()
-                }
-
-                override fun onPeerDisconnected() {
-                    reportPeerDisconnected()
-                }
-
-                override fun onMessageReceived(data: ByteArray) {
-                    reportMessageReceived(data)
-                }
-
-                override fun onError(error: Throwable) {
-                    reportError(error)
-                }
-            })
-            val psmValue = characteristic.value
-            var psmSized = ByteArray(4)
-            if (psmValue.size < 4) {
-                // Add 00 on left if psm length is lower than 4
-                System.arraycopy(psmValue, 0, psmSized, 4 - psmValue.size, psmValue.size)
-            } else {
-                psmSized = psmValue
-            }
-            val psm = ByteBuffer.wrap(psmSized).getInt()
-            l2capClient!!.connect(this.gatt!!.device, psm)
-        } else {
-            reportError(Error("Unexpected onCharacteristicRead for characteristic " +
-                    "$characteristic.uuid + expected $characteristicIdentUuid"))
         }
     }
 
@@ -360,9 +372,11 @@ internal class GattClient(
         descriptor: BluetoothGattDescriptor,
         status: Int
     ) {
-        Logger.d(TAG,
+        Logger.d(
+            TAG,
             "onDescriptorWrite: $descriptor.uuid " +
-            "characteristic=${descriptor.characteristic.uuid} status=$status")
+                    "characteristic=${descriptor.characteristic.uuid} status=$status"
+        )
         try {
             val charUuid = descriptor.characteristic.uuid
             if (charUuid == characteristicServer2ClientUuid && descriptor.uuid == clientCharacteristicConfigUuid) {
@@ -393,9 +407,12 @@ internal class GattClient(
                     reportError(Error("Error writing to state characteristic"))
                 }
             } else {
-                reportError(Error(
+                reportError(
+                    Error(
                         "Unexpected onDescriptorWrite for characteristic UUID $charUuid" +
-                                " and descriptor UUID ${descriptor.uuid}"))
+                                " and descriptor UUID ${descriptor.uuid}"
+                    )
+                )
             }
         } catch (e: SecurityException) {
             reportError(e)
@@ -447,9 +464,11 @@ internal class GattClient(
             }
             incomingMessage.write(data, 1, data.size - 1)
             val isLast = (data[0].toInt() == 0x00)
-            Logger.d(TAG,
+            Logger.d(
+                TAG,
                 "Received chunk with ${data.size} bytes (last=$isLast), " +
-                        "incomingMessage.length=${incomingMessage.toByteArray().size}")
+                        "incomingMessage.length=${incomingMessage.toByteArray().size}"
+            )
             if (data[0].toInt() == 0x00) {
                 // Last message.
                 val entireMessage = incomingMessage.toByteArray()
@@ -457,13 +476,18 @@ internal class GattClient(
                 reportMessageReceived(entireMessage)
             } else if (data[0].toInt() == 0x01) {
                 if (data.size != characteristicValueSize) {
-                    Logger.w(TAG,
+                    Logger.w(
+                        TAG,
                         "Server2Client received ${data.size} bytes which is not the " +
-                                "expected $characteristicValueSize bytes")
+                                "expected $characteristicValueSize bytes"
+                    )
                 }
             } else {
-                reportError(Error("Invalid first byte ${data[0]} in Server2Client data chunk, " +
-                        "expected 0 or 1")
+                reportError(
+                    Error(
+                        "Invalid first byte ${data[0]} in Server2Client data chunk, " +
+                                "expected 0 or 1"
+                    )
                 )
             }
         } else if (characteristic.uuid == characteristicStateUuid) {
@@ -486,7 +510,7 @@ internal class GattClient(
             return
         }
         val chunk = writingQueue.poll() ?: return
-        if (chunk.size == 0) {
+        if (chunk.isEmpty()) {
             Logger.d(TAG, "Chunk is length 0, shutting down GattClient")
             try {
                 gatt!!.disconnect()
@@ -498,7 +522,7 @@ internal class GattClient(
             return
         }
         val isLast = chunk[0].toInt() == 0x00
-        Logger.d(TAG,"Sending chunk with ${chunk.size} bytes (last=$isLast)")
+        Logger.d(TAG, "Sending chunk with ${chunk.size} bytes (last=$isLast)")
         characteristicClient2Server!!.setValue(chunk)
         try {
             if (!gatt!!.writeCharacteristic(characteristicClient2Server)) {

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
@@ -27,10 +27,13 @@ import android.bluetooth.BluetoothManager
 import android.bluetooth.BluetoothProfile
 import android.content.Context
 import android.os.Build
+import com.android.identity.android.util.HelperListener
+import com.android.identity.android.util.launchIfAllowed
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
 import com.android.identity.util.Logger
 import com.android.identity.util.toHex
+import kotlinx.coroutines.CoroutineScope
 import java.io.ByteArrayOutputStream
 import java.nio.ByteBuffer
 import java.util.ArrayDeque
@@ -42,6 +45,7 @@ import java.util.UUID
 @SuppressLint("MissingPermission")
 internal class GattServer(
     private val context: Context,
+    private val scope: CoroutineScope?,
     private val bluetoothManager: BluetoothManager,
     private val serviceUuid: UUID,
     private val encodedEDeviceKeyBytes: ByteArray?,
@@ -56,7 +60,8 @@ internal class GattServer(
     var listener: Listener? = null
 
     // This is what the 16-bit UUID 0x29 0x02 is encoded like.
-    private var clientCharacteristicConfigUuid = UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
+    private var clientCharacteristicConfigUuid =
+        UUID.fromString("00002902-0000-1000-8000-00805f9b34fb")
     private var inhibitCallbacks = false
     private var characteristicState: BluetoothGattCharacteristic? = null
     private var characteristicClient2Server: BluetoothGattCharacteristic? = null
@@ -67,12 +72,15 @@ internal class GattServer(
     private var writingQueue: Queue<ByteArray> = ArrayDeque()
     private var writingQueueTotalChunks = 0
     private var writeIsOutstanding = false
-    private var gattServer: BluetoothGattServer? = null
     private var currentConnection: BluetoothDevice? = null
     private var negotiatedMtu = 0
     private var l2capServer: L2CAPServer? = null
     private var identValue: ByteArray? = null
     private var usingL2CAP = false
+
+    private var _gattServer: BluetoothGattServer? = null
+    private val gattServer: BluetoothGattServer
+        get() = _gattServer!!
 
     @SuppressLint("NewApi")
     fun start(): Boolean {
@@ -82,70 +90,69 @@ internal class GattServer(
             val salt = byteArrayOf()
             identValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
         }
-        gattServer = try {
+        _gattServer = try {
             bluetoothManager.openGattServer(context, this)
         } catch (e: SecurityException) {
             reportError(e)
             return false
         }
-        if (gattServer == null) {
+        if (_gattServer == null) {
             return false
         }
         val service = BluetoothGattService(
             serviceUuid,
             BluetoothGattService.SERVICE_TYPE_PRIMARY
         )
-        var c: BluetoothGattCharacteristic
-        var d: BluetoothGattDescriptor
+        var gattCharacteristic: BluetoothGattCharacteristic
 
         // State
-        c = BluetoothGattCharacteristic(
+        gattCharacteristic = BluetoothGattCharacteristic(
             characteristicStateUuid, BluetoothGattCharacteristic.PROPERTY_NOTIFY
                     or BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
             BluetoothGattCharacteristic.PERMISSION_WRITE
         )
-        d = BluetoothGattDescriptor(
+        var gattDescriptor = BluetoothGattDescriptor(
             clientCharacteristicConfigUuid,
             BluetoothGattDescriptor.PERMISSION_WRITE
         )
-        d.setValue(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
-        c.addDescriptor(d)
-        service.addCharacteristic(c)
-        characteristicState = c
+        gattDescriptor.setValue(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
+        gattCharacteristic.addDescriptor(gattDescriptor)
+        service.addCharacteristic(gattCharacteristic)
+        characteristicState = gattCharacteristic
 
         // Client2Server
-        c = BluetoothGattCharacteristic(
+        gattCharacteristic = BluetoothGattCharacteristic(
             characteristicClient2ServerUuid,
             BluetoothGattCharacteristic.PROPERTY_WRITE_NO_RESPONSE,
             BluetoothGattCharacteristic.PERMISSION_WRITE
         )
-        service.addCharacteristic(c)
-        characteristicClient2Server = c
+        service.addCharacteristic(gattCharacteristic)
+        characteristicClient2Server = gattCharacteristic
 
         // Server2Client
-        c = BluetoothGattCharacteristic(
+        gattCharacteristic = BluetoothGattCharacteristic(
             characteristicServer2ClientUuid,
             BluetoothGattCharacteristic.PROPERTY_NOTIFY,
             BluetoothGattCharacteristic.PERMISSION_WRITE
         )
-        d = BluetoothGattDescriptor(
+        gattDescriptor = BluetoothGattDescriptor(
             clientCharacteristicConfigUuid,
             BluetoothGattDescriptor.PERMISSION_WRITE
         )
-        d.setValue(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
-        c.addDescriptor(d)
-        service.addCharacteristic(c)
-        characteristicServer2Client = c
+        gattDescriptor.setValue(BluetoothGattDescriptor.DISABLE_NOTIFICATION_VALUE)
+        gattCharacteristic.addDescriptor(gattDescriptor)
+        service.addCharacteristic(gattCharacteristic)
+        characteristicServer2Client = gattCharacteristic
 
         // Ident
         if (characteristicIdentUuid != null) {
-            c = BluetoothGattCharacteristic(
+            gattCharacteristic = BluetoothGattCharacteristic(
                 characteristicIdentUuid,
                 BluetoothGattCharacteristic.PROPERTY_READ,
                 BluetoothGattCharacteristic.PERMISSION_READ
             )
-            service.addCharacteristic(c)
-            characteristicIdent = c
+            service.addCharacteristic(gattCharacteristic)
+            characteristicIdent = gattCharacteristic
         }
 
         // Offers support to L2CAP when we have UUID characteristic and the OS version support it
@@ -154,23 +161,25 @@ internal class GattServer(
         Logger.i(TAG, "Is L2CAP supported: $usingL2CAP")
         if (usingL2CAP) {
             // Start L2CAP socket server
-            l2capServer = L2CAPServer(object : L2CAPServer.Listener {
-                override fun onPeerConnected() {
-                    reportPeerConnected()
-                }
+            l2capServer = L2CAPServer(
+                scope = scope,
+                listener = object : L2CAPServer.Listener {
+                    override fun onPeerConnected() {
+                        reportPeerConnected()
+                    }
 
-                override fun onPeerDisconnected() {
-                    reportPeerDisconnected()
-                }
+                    override fun onPeerDisconnected() {
+                        reportPeerDisconnected()
+                    }
 
-                override fun onMessageReceived(data: ByteArray) {
-                    reportMessageReceived(data)
-                }
+                    override fun onMessageReceived(data: ByteArray) {
+                        reportMessageReceived(data)
+                    }
 
-                override fun onError(error: Throwable) {
-                    reportError(error)
-                }
-            })
+                    override fun onError(error: Throwable) {
+                        reportError(error)
+                    }
+                })
             psm = l2capServer!!.start(bluetoothManager.adapter)
             if (psm.isEmpty) {
                 Logger.w(TAG, "Error starting L2CAP server")
@@ -178,17 +187,17 @@ internal class GattServer(
                 usingL2CAP = false
             } else {
                 Logger.i(TAG, "Listening on L2CAP with PSM ${psm.asInt}")
-                c = BluetoothGattCharacteristic(
+                gattCharacteristic = BluetoothGattCharacteristic(
                     characteristicL2CAPUuid,
                     BluetoothGattCharacteristic.PROPERTY_READ,
                     BluetoothGattCharacteristic.PERMISSION_READ
                 )
-                service.addCharacteristic(c)
-                characteristicL2CAP = c
+                service.addCharacteristic(gattCharacteristic)
+                characteristicL2CAP = gattCharacteristic
             }
         }
         try {
-            gattServer!!.addService(service)
+            gattServer.addService(service)
         } catch (e: SecurityException) {
             reportError(e)
             return false
@@ -203,7 +212,7 @@ internal class GattServer(
             l2capServer!!.stop()
             l2capServer = null
         }
-        if (gattServer != null) {
+        if (_gattServer != null) {
             // used to convey we want to shutdown once all write are done.
             sendMessage(ByteArray(0))
         }
@@ -212,9 +221,12 @@ internal class GattServer(
     override fun onConnectionStateChange(device: BluetoothDevice, status: Int, newState: Int) {
         Logger.d(TAG, "onConnectionStateChange: ${device.address} $status + $newState")
         if (newState == BluetoothProfile.STATE_DISCONNECTED && currentConnection != null &&
-            device.address == currentConnection!!.address) {
-            Logger.d(TAG, "Device ${currentConnection!!.address} which we're currently " +
-                        "connected to, has disconnected")
+            device.address == currentConnection!!.address
+        ) {
+            Logger.d(
+                TAG, "Device ${currentConnection!!.address} which we're currently " +
+                        "connected to, has disconnected"
+            )
             currentConnection = null
             reportPeerDisconnected()
         }
@@ -225,12 +237,14 @@ internal class GattServer(
         device: BluetoothDevice, requestId: Int, offset: Int,
         characteristic: BluetoothGattCharacteristic
     ) {
-        Logger.d(TAG, "onCharacteristicReadRequest: ${device.address} $requestId " +
-                "$offset ${characteristic.uuid}")
+        Logger.d(
+            TAG, "onCharacteristicReadRequest: ${device.address} $requestId " +
+                    "$offset ${characteristic.uuid}"
+        )
         if (characteristicIdentUuid != null && characteristic.uuid == characteristicIdentUuid) {
             try {
                 val ident = if (identValue != null) identValue!! else ByteArray(0)
-                gattServer!!.sendResponse(
+                gattServer.sendResponse(
                     device,
                     requestId,
                     BluetoothGatt.GATT_SUCCESS,
@@ -248,7 +262,7 @@ internal class GattServer(
             // TODO: it's not clear this is the right way to encode the PSM and 18013-5 doesn't
             //   seem to give enough guidance on it.
             val encodedPsmValue = ByteBuffer.allocate(4).putInt(psm.asInt).array()
-            gattServer!!.sendResponse(
+            gattServer.sendResponse(
                 device,
                 requestId,
                 BluetoothGatt.GATT_SUCCESS,
@@ -275,15 +289,19 @@ internal class GattServer(
         value: ByteArray
     ) {
         val charUuid = characteristic.uuid
-        Logger.d(TAG, "onCharacteristicWriteRequest: ${device.address} $requestId " +
-                "$offset ${characteristic.uuid} ${value.toHex}")
+        Logger.d(
+            TAG, "onCharacteristicWriteRequest: ${device.address} $requestId " +
+                    "$offset ${characteristic.uuid} ${value.toHex}"
+        )
 
         // If we are connected to a device, ignore write from any other device
         if (currentConnection != null &&
             device.address != currentConnection!!.address
         ) {
-            Logger.e(TAG, "Ignoring characteristic write request from ${device.address} " +
-                    "since we're already connected to ${currentConnection!!.address}")
+            Logger.e(
+                TAG, "Ignoring characteristic write request from ${device.address} " +
+                        "since we're already connected to ${currentConnection!!.address}"
+            )
             return
         }
         if (charUuid == characteristicStateUuid && value.size == 1) {
@@ -291,12 +309,16 @@ internal class GattServer(
                 // Close server socket when the connection was done by state characteristic
                 stopL2CAPServer()
                 if (currentConnection != null) {
-                    Logger.e(TAG, "Ignoring connection attempt from ${device.address} " +
-                                "since we're already connected to ${currentConnection!!.address}")
+                    Logger.e(
+                        TAG, "Ignoring connection attempt from ${device.address} " +
+                                "since we're already connected to ${currentConnection!!.address}"
+                    )
                 } else {
                     currentConnection = device
-                    Logger.d(TAG, "Received connection (state 0x01 on State characteristic) "
-                                + "from ${currentConnection!!.address}")
+                    Logger.d(
+                        TAG, "Received connection (state 0x01 on State characteristic) "
+                                + "from ${currentConnection!!.address}"
+                    )
                 }
                 reportPeerConnected()
             } else if (value[0].toInt() == 0x02) {
@@ -305,7 +327,7 @@ internal class GattServer(
                 reportError(Error("Invalid byte ${value[0]} for state characteristic"))
             }
         } else if (charUuid == characteristicClient2ServerUuid) {
-            if (value.size < 1) {
+            if (value.isEmpty()) {
                 reportError(Error("Invalid value with length ${value.size}"))
                 return
             }
@@ -317,8 +339,10 @@ internal class GattServer(
             }
             incomingMessage.write(value, 1, value.size - 1)
             val isLast = (value[0].toInt() == 0x00)
-            Logger.d(TAG, "Received chunk with ${value.size} bytes " +
-                    "(last=$isLast), incomingMessage.length=${incomingMessage.toByteArray().size}")
+            Logger.d(
+                TAG, "Received chunk with ${value.size} bytes " +
+                        "(last=$isLast), incomingMessage.length=${incomingMessage.toByteArray().size}"
+            )
             if (value[0].toInt() == 0x00) {
                 // Last message.
                 val entireMessage = incomingMessage.toByteArray()
@@ -326,20 +350,24 @@ internal class GattServer(
                 reportMessageReceived(entireMessage)
             } else if (value[0].toInt() == 0x01) {
                 if (value.size != characteristicValueSize) {
-                    Logger.w(TAG,
+                    Logger.w(
+                        TAG,
                         "Client2Server received ${value.size} bytes which is not the " +
-                            "expected $characteristicValueSize bytes"
+                                "expected $characteristicValueSize bytes"
                     )
                     return
                 }
             } else {
-                reportError(Error(
-                    "Invalid first byte ${value[0]} in Client2Server data chunk, expected 0 or 1"))
+                reportError(
+                    Error(
+                        "Invalid first byte ${value[0]} in Client2Server data chunk, expected 0 or 1"
+                    )
+                )
                 return
             }
             if (responseNeeded) {
                 try {
-                    gattServer!!.sendResponse(
+                    gattServer.sendResponse(
                         device,
                         requestId,
                         BluetoothGatt.GATT_SUCCESS,
@@ -351,8 +379,10 @@ internal class GattServer(
                 }
             }
         } else {
-            reportError(Error(
-                "Write on unexpected characteristic with UUID ${characteristic.uuid}")
+            reportError(
+                Error(
+                    "Write on unexpected characteristic with UUID ${characteristic.uuid}"
+                )
             )
         }
     }
@@ -370,8 +400,10 @@ internal class GattServer(
         device: BluetoothDevice, requestId: Int, offset: Int,
         descriptor: BluetoothGattDescriptor
     ) {
-        Logger.d(TAG, "onDescriptorReadRequest: ${device.address} " +
-                "${descriptor.characteristic.uuid} ${descriptor.characteristic.uuid} $offset")
+        Logger.d(
+            TAG, "onDescriptorReadRequest: ${device.address} " +
+                    "${descriptor.characteristic.uuid} ${descriptor.characteristic.uuid} $offset"
+        )
         /* Do nothing */
     }
 
@@ -389,7 +421,7 @@ internal class GattServer(
         }
         if (responseNeeded) {
             try {
-                gattServer!!.sendResponse(
+                gattServer.sendResponse(
                     device,
                     requestId,
                     BluetoothGatt.GATT_SUCCESS,
@@ -418,7 +450,8 @@ internal class GattServer(
                 Logger.w(TAG, "MTU not negotiated, defaulting to 23. Performance will suffer.")
                 mtuSize = 23
             }
-            characteristicValueSizeMemoized = DataTransportBle.bleCalculateAttributeValueSize(mtuSize)
+            characteristicValueSizeMemoized =
+                DataTransportBle.bleCalculateAttributeValueSize(mtuSize)
             return characteristicValueSizeMemoized
         }
 
@@ -432,20 +465,20 @@ internal class GattServer(
             Logger.d(TAG, "Chunk is length 0, shutting down GattServer")
             try {
                 if (currentConnection != null) {
-                    gattServer!!.cancelConnection(currentConnection)
+                    gattServer.cancelConnection(currentConnection)
                 }
-                gattServer!!.close()
+                gattServer.close()
             } catch (e: SecurityException) {
                 Logger.e(TAG, "Caught SecurityException while shutting down", e)
             }
-            gattServer = null
+            _gattServer = null
             return
         }
         val isLast = chunk[0].toInt() == 0x00
         Logger.d(TAG, "Sending chunk with ${chunk.size} bytes (last=$isLast)")
         characteristicServer2Client!!.setValue(chunk)
         try {
-            if (!gattServer!!.notifyCharacteristicChanged(
+            if (!gattServer.notifyCharacteristicChanged(
                     currentConnection,
                     characteristicServer2Client, false
                 )
@@ -485,7 +518,7 @@ internal class GattServer(
             l2capServer!!.sendMessage(data)
             return
         }
-        if (data.size == 0) {
+        if (data.isEmpty()) {
             // Data of length 0 is used to signal we should shut down.
             writingQueue.add(data)
         } else {
@@ -510,34 +543,24 @@ internal class GattServer(
         drainWritingQueue()
     }
 
-    fun reportPeerConnected() {
-        if (listener != null && !inhibitCallbacks) {
-            listener!!.onPeerConnected()
-        }
+    private fun reportPeerConnected() {
+        listener.executeIfAllowed(inhibitCallbacks) { onPeerConnected() }
     }
 
-    fun reportPeerDisconnected() {
-        if (listener != null && !inhibitCallbacks) {
-            listener!!.onPeerDisconnected()
-        }
+    private fun reportPeerDisconnected() {
+        listener.executeIfAllowed(inhibitCallbacks) { onPeerDisconnected() }
     }
 
-    fun reportMessageReceived(data: ByteArray) {
-        if (listener != null && !inhibitCallbacks) {
-            listener!!.onMessageReceived(data)
-        }
+    private fun reportMessageReceived(data: ByteArray) {
+        listener.executeIfAllowed(inhibitCallbacks) { onMessageReceived(data) }
     }
 
-    fun reportError(error: Throwable) {
-        if (listener != null && !inhibitCallbacks) {
-            listener!!.onError(error)
-        }
+    private fun reportError(error: Throwable) {
+        listener.executeIfAllowed(inhibitCallbacks) { onError(error) }
     }
 
-    fun reportTransportSpecificSessionTermination() {
-        if (listener != null && !inhibitCallbacks) {
-            listener!!.onTransportSpecificSessionTermination()
-        }
+    private fun reportTransportSpecificSessionTermination() {
+        listener.executeIfAllowed(inhibitCallbacks) { onTransportSpecificSessionTermination() }
     }
 
     // When using L2CAP it doesn't support characteristics notification
@@ -549,7 +572,7 @@ internal class GattServer(
         val terminationCode = byteArrayOf(0x02.toByte())
         characteristicState!!.setValue(terminationCode)
         try {
-            if (!gattServer!!.notifyCharacteristicChanged(
+            if (!gattServer.notifyCharacteristicChanged(
                     currentConnection,
                     characteristicState, false
                 )
@@ -561,7 +584,7 @@ internal class GattServer(
         }
     }
 
-    internal interface Listener {
+    internal interface Listener : HelperListener {
         fun onPeerConnected()
         fun onPeerDisconnected()
         fun onMessageReceived(data: ByteArray)
@@ -571,5 +594,30 @@ internal class GattServer(
 
     companion object {
         private const val TAG = "GattServer"
+    }
+
+    /**
+     * Private extension function localized to [GattServer] that wraps around the extension function
+     * [CoroutineScope?.launchIfAllowed] to simplify and prettify listener function callbacks.
+     *
+     * For ex, run a coroutine to call "onMessageReceived()" on the Listener instance
+     * scope.launchIfAllowed(inhibitCallbacks, listener) { onMessageReceived() }
+     *
+     * can be simplified to something easier to follow
+     * listener.executeIfAllowed(inhibitCallbacks) { onMessageReceived() }
+     *
+     * @param inhibitCallbacks whether to prevent the callback from being executed/called
+     * @param callback the block of code using Listener as the function type receiver so
+     * function calls are made on "this" Listener instance directly.
+     */
+    private fun Listener?.executeIfAllowed(
+        inhibitCallbacks: Boolean,
+        callback: Listener.() -> Unit
+    ) {
+        scope.launchIfAllowed(
+            inhibitCallbacks = inhibitCallbacks,
+            listener = this,
+            callback = callback
+        )
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/util/CommonExtensions.kt
+++ b/identity-android/src/main/java/com/android/identity/android/util/CommonExtensions.kt
@@ -1,0 +1,42 @@
+package com.android.identity.android.util
+
+/**
+ * Extension function to prettify if-true flag evaluation logic, such as
+ *
+ * return if (booleanValue){
+ *      // do work
+ *      } else {
+ *      // do nothing
+ *      }
+ *
+ * to
+ *
+ * return booleanValue.ifTrue {
+ *      // do work
+ * }
+ *
+ * @param block function to run if the boolean value is true
+ */
+fun Boolean.ifTrue(block: () -> Unit) =
+    if (this)
+        block.invoke()
+    else { // do nothing
+    }
+
+/**
+ * Extension function to prettify if-false flag evaluation logic, such as
+ *
+ * return if (!booleanValue){
+ *          // do work
+ *      } else {
+ *          // do nothing
+ *      }
+ *
+ * to
+ *
+ * return booleanValue.ifFalse {
+ *      // do work
+ * }
+ * @param block function to run if the boolean value is false
+ */
+fun Boolean.ifFalse(block: () -> Unit) = (!this).ifTrue(block)

--- a/identity-android/src/main/java/com/android/identity/android/util/HelperListener.kt
+++ b/identity-android/src/main/java/com/android/identity/android/util/HelperListener.kt
@@ -1,0 +1,43 @@
+package com.android.identity.android.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Common interface for all Listeners defined in each _Helper class such as DeviceRetrievalHelper,
+ * VerificationHelper, etc... so we can run an extension function
+ */
+interface HelperListener
+
+
+
+/**
+ * Extension function to simplify calling a Listener's callback functions in a coroutine, so long as
+ * callbacks are not inhibited, otherwise the call will be ignored..
+ *
+ * ex:
+ * scope.launchIfAllowed(inhibitCallbacks, listener) { onDeviceDisconnected(transportSpecificTermination) }
+ *
+ * There is private extension function [executeIfAllowed] inside all Helper classes ([DeviceRetrievalHelper], [VerificationHelper], etc..)
+ * that wraps around this "scope extension" functionality to work for their own Listener interface.
+ *
+ * Sample use
+ * listener.executeIfAllowed(inhibitCallbacks) { onHandoverSelectMessageSent() }
+ *
+ * This makes it very convenient (and straightforward) to call a Listener's function in a coroutine.
+ */
+fun < T : HelperListener> CoroutineScope?.launchIfAllowed(
+    inhibitCallbacks: Boolean,
+    listener: T?,
+    callback: suspend T.() -> Unit
+) {
+    this?.run { // there is a (non-null) coroutine scope available to use
+        listener?.let{// ignore making a callback if not valid
+            inhibitCallbacks.ifFalse {
+                launch {
+                    callback.invoke(it)
+                }
+            }
+        }
+    }
+}

--- a/identity-android/src/main/java/com/android/identity/android/util/HostApduServiceScoped.kt
+++ b/identity-android/src/main/java/com/android/identity/android/util/HostApduServiceScoped.kt
@@ -1,0 +1,32 @@
+package com.android.identity.android.util
+
+import android.nfc.cardemulation.HostApduService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
+
+
+/**
+ * HostApduServiceScoped is a wrapper for the service class HostApduService that provides a
+ * service-bound coroutine scope to run coroutines from its children. It also ensures to cancel any
+ * actively running coroutines when this service's [onDestroy] gets called.
+ *
+ * Extending service classes get access to [serviceScope] to pass to its child objects and never have
+ * to worry about lingering coroutines beyond the Service's lifecycle.
+ */
+abstract class HostApduServiceScoped : HostApduService() {
+    // supervisor job is not affected by raised exceptions of a child coroutines
+    private val serviceJob = SupervisorJob()
+
+    // scope that child objects can use to launch coroutines
+    val serviceScope = CoroutineScope(Dispatchers.IO + serviceJob)
+
+    /**
+     * Ensure we cancel the SupervisorJob so it propagates cancellation to all sub-coroutines.
+     */
+    override fun onDestroy() {
+        super.onDestroy()
+        serviceJob.cancel("Service onDestroy() was called!")
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -161,6 +161,7 @@ class PresentationActivity : FragmentActivity() {
 
         // terminate PresentationActivity since "presentation is complete" (once response is sent)
         finish()
+
     }
 
     private fun onAuthenticationKeyLocked(authKey: AuthenticationKey) {
@@ -329,8 +330,8 @@ class PresentationActivity : FragmentActivity() {
      */
     private fun newDeviceRetrievalHelper() =
         DeviceRetrievalHelper.Builder(
-            applicationContext,
-            object : DeviceRetrievalHelper.Listener {
+            context = applicationContext,
+            listener = object : DeviceRetrievalHelper.Listener {
 
                 override fun onEReaderKeyReceived(eReaderKey: EcPublicKey) {
                     Logger.i(TAG, "onEReaderKeyReceived")
@@ -357,15 +358,16 @@ class PresentationActivity : FragmentActivity() {
                 }
 
             },
-            ContextCompat.getMainExecutor(applicationContext),
-            eDeviceKey!!
-        )
-            .useForwardEngagement(transport!!, deviceEngagement!!, handover!!)
-            .build().apply {
-                // set deviceRetrievalHelper to this newly built instance
-                deviceRetrievalHelper = this
-                // return the instance
-            }
+            scope = lifecycleScope,
+            eDeviceKey = eDeviceKey!!,
+            transport = transport!!
+        ).apply {
+            useForwardEngagement(deviceEngagement!!, handover!!)
+        }.build().apply {
+            // set deviceRetrievalHelper to this newly built instance
+            deviceRetrievalHelper = this
+            // return the instance
+        }
 
 
     private fun disconnect() {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
@@ -90,11 +90,12 @@ class QrEngagementViewModel(val context: Application) : AndroidViewModel(context
                 )
             )
             qrEngagementHelper = QrEngagementHelper.Builder(
-                context,
-                eDeviceKey!!.publicKey,
-                options,
-                qrEngagementListener,
-                ContextCompat.getMainExecutor(context)
+                context = context,
+                scope = viewModelScope,
+                eDeviceKey = eDeviceKey!!.publicKey,
+                options  = options,
+                listener = qrEngagementListener,
+
             ).setConnectionMethods(connectionMethods).build()
             state = State.LISTENING
         }


### PR DESCRIPTION
## This PR is being split into 2: 

###  Kotlin-DSL 
#### - Kotlin-DSL changes have been extracted to https://github.com/openwallet-foundation-labs/identity-credential/pull/549

###  Coroutines

----


**Replacing `Context.getMainExecutor` in Helper classes (to use lifecycle-aware Kotlin coroutines)**
There are Helper classes such as DeviceRetrievalHelper.Listener, VerificationHelper.Listener, NfcEngagementHelper.Listener, QrEngagementHelper.Listener, DataTransport.Listener, etc.. 

A Helper class is can be instantiated from a Service running in the background, or it can also be instantiated from other Helper classes that are instantiated from an Activity, Fragment or ViewModel running on the UI thread. Each Helper class defines their own Listener interface to notify interested parties (encompassing a service, activity, fragment, viewmodel, etc..) of state changes within its operations. 

The previous approach, used an Executor that is obtained from any `context` via `Context.getMainExecutor()` (https://developer.android.com/reference/androidx/core/content/ContextCompat#getMainExecutor(android.content.Context) which is used to enqueue a task (the Listener callback function) to the **Main thread**’s Task Queue associated with the Context. Generally speaking, the use of `Context.getMainExecutor` is very highly reserved thread utility tool for inter-app communication of components such as between 2 activities or services; alternatives are encouraged for more lighter weight tasks, such as callbacks.

In edge cases, this creates a tight coupling with the Main thread where callbacks within 2 components in a Service stop being received if the UI thread was terminated while the Service background thread is still operational. The Handler would never receive the callback from the Helper’s Listener, yielding to an inconsistency of operations. This edge case can be detrimental if the activity crashed while reading a passport and user is providing the pin, the service submits the pin and the response is received from the nfc service but depending on the timing of the activity’s crash, it wouldn’t be able to send the response to the interested party because the Listeners would only execute on the Main thread’s task queue (which is non-existent after the crash). 

A Helper class should notify its interested parties in the same thread that its Listener was instantiated, rather than always add work to the UI thread for work that’s happening in the background Service for example.

It is common practice to use lifecycle-aware mechanisms, such as Kotlin coroutines, which are already integrated into Android Activities, Fragments, ViewModels, etc… Each component provides a scope via ‘lifecycleScope`, `viewLifecycleOwner.lifecycleScope`, `viewModelScope` respectively and we’ll have to make our NFC service do the same. Coroutines are automatically cancelled when the parent task (supervisor job) cancels them when onDestroy(), and we’ll have to do this part manually for our NFC Service.

The `HostApduServiceScoped` (NFC) Service class (that extends `HostApduService` class) defines a Service-level coroutine scope that is passed down to any component that wants to launch a coroutine. If onDestroy() is called then any running coroutines are canceled- this follows the lifecycle of the Service and does not permit having any long running background coroutines if the Service is destroyed, for example, so it can be restarted after an update.

Any classes that extended `HostApduService` now extend `HostApduServiceScoped` and are now empowered with a coroutine scope to pass around!

Helper classes now use coroutines instead of main executor. Since these coroutines will run on the scope that is given, they are guaranteed to be responsive in the same thread as well as lifecycle-aware so you don’t have to worry about cleanup.

All Listener interfaces for each Helper class extend a common interface `HelperListener` which is used through extension functions to issue callbacks on the listener from inside a coroutine that runs in the scope of the caller - Service, Activity, Fragment, ViewModel. 

Almost all of the Helper classes have the `inhibitCallbacks` value and  `listener` can be null.

The previous approach would look something like
```
if (listener != null && executor != null) {
            executor.execute {
                if (!inhibitCallbacks) {
                    listener.onDeviceRequest(deviceRequestBytes)
                }
            }
        }
```

The new approach looks like 

```
listener.executeIfAllowed(inhibitCallbacks) { onDeviceRequest(deviceRequestBytes) }
```
The function `executeIfAllowed` is a private extension function located at the bottom of every Helper class. This function is a wrapper that calls an extension function on `CoroutineScope` that launches the actual coroutine. 

The other extension function that is called is `launchIfAllowed()` that uses the (coroutine) scope to launch a new coroutine to call `onDeviceRequest(deviceRequestBytes)` on `listener` if it is not null and `inhibitCallbacks = false`. This makes it simple to issue callbacks to Listeners from inside coroutines and it’s easier to follow legibly following very closely to the normal way of calling Listeners.

The signature of `launchIfAllowed()` means given a Listener instance as 2nd parameter, it infers the Listener type (that extends HelperListener) and shows autosuggest for function calls in Android Studio in the 3rd parameter.
```
fun < T : HelperListener> CoroutineScope?.launchIfAllowed(
    inhibitCallbacks: Boolean,
    listener: T?,
    callback: suspend T.() -> Unit
) 
```


Example
```
scope.launchIfAllowed(inhibitCallbacks, listener) { onDeviceRequest(deviceRequestBytes) }
```
------

DeviceRetrievalHelper.Builder constructor now takes in the transport parameter at creation instead of always passing it in with forward or reverse engagement; transport is common to both types of engagement calls and it ought to be brought up to the parent class’ constructor, cleaning up the forward and reverse engagement calls.

------

Other Kotlin-esque updates such as using scope functions `let{`, `run{` etc..
