### PR TITLE
Introduce HexUtil.

### DIFF
--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportHttpTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportHttpTest.kt
@@ -17,8 +17,8 @@ package com.android.identity.android.mdoc.transport
 
 import android.os.ConditionVariable
 import androidx.test.InstrumentationRegistry
-import com.android.identity.internal.Util
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodHttp
+import com.android.identity.util.fromHex
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.Executor
@@ -84,8 +84,8 @@ class DataTransportHttpTest {
             null,
             DataTransportOptions.Builder().build()
         )
-        val messageSentByVerifier = Util.fromHex("010203")
-        val messageSentByProver = Util.fromHex("0405")
+        val messageSentByVerifier = "010203".fromHex
+        val messageSentByProver = "0405".fromHex
         val messageReceivedByProver = arrayOf<ByteArray?>(null)
         val messageReceivedByVerifier = arrayOf<ByteArray?>(null)
         val proverMessageReceivedCondVar = ConditionVariable()

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportTcpTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportTcpTest.kt
@@ -18,7 +18,7 @@ package com.android.identity.android.mdoc.transport
 import android.os.ConditionVariable
 import androidx.test.InstrumentationRegistry
 import androidx.test.filters.SmallTest
-import com.android.identity.internal.Util.fromHex
+import com.android.identity.util.fromHex
 import org.junit.Assert
 import org.junit.Test
 import java.util.concurrent.Executor
@@ -40,8 +40,8 @@ class DataTransportTcpTest {
             DataTransport.Role.MDOC,
             DataTransportOptions.Builder().build()
         )
-        val messageSentByVerifier = fromHex("010203")
-        val messageSentByProver = fromHex("0405")
+        val messageSentByVerifier = "010203".fromHex
+        val messageSentByProver = "0405".fromHex
         val messageReceivedByProver = arrayOf<ByteArray?>(null)
         val messageReceivedByVerifier = arrayOf<ByteArray?>(null)
         val proverMessageReceivedCondVar = ConditionVariable()

--- a/identity-android/src/androidTest/java/com/android/identity/mdoc/connectionmethod/ConnectionMethodNdefTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/mdoc/connectionmethod/ConnectionMethodNdefTest.kt
@@ -26,6 +26,8 @@ import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.DiagnosticOption
 import com.android.identity.internal.Util
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod.Companion.fromDeviceEngagement
+import com.android.identity.util.fromHex
+import com.android.identity.util.toHex
 import org.junit.Assert
 import org.junit.Test
 import java.util.UUID
@@ -108,12 +110,11 @@ class ConnectionMethodNdefTest {
         Assert.assertEquals(uuidBoth, decoded.centralClientModeUuid)
         Assert.assertEquals(
             "da2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c03110702000000000000000000000000000000",
-            Util.toHex(pair.first.toByteArray())
+            pair.first.toByteArray().toHex
         )
         Assert.assertEquals(
-            "01013001046d646f63", Util.toHex(
-                pair.second
-            )
+            "01013001046d646f63",
+            pair.second.toHex
         )
         val hrPair = NfcUtil.toNdefRecord(cm, listOf(""), false)
         Assert.assertArrayEquals(pair.first.toByteArray(), hrPair!!.first.toByteArray())
@@ -161,12 +162,11 @@ class ConnectionMethodNdefTest {
         Assert.assertEquals(uuid, decoded.centralClientModeUuid)
         Assert.assertEquals(
             "da2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c011107b168de3a0000000015cd5b0700000000",
-            Util.toHex(pair.first.toByteArray())
+            pair.first.toByteArray().toHex
         )
         Assert.assertEquals(
-            "01013001046d646f63", Util.toHex(
-                pair.second!!
-            )
+            "01013001046d646f63",
+            pair.second!!.toHex
         )
         pair = NfcUtil.toNdefRecord(cm, emptyList(), false)
         decoded = fromNdefRecord(pair!!.first, false)
@@ -177,9 +177,9 @@ class ConnectionMethodNdefTest {
         Assert.assertEquals(uuid, decoded.centralClientModeUuid)
         Assert.assertEquals(
             "da2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c001107b168de3a0000000015cd5b0700000000",
-            Util.toHex(pair.first.toByteArray())
+            pair.first.toByteArray().toHex
         )
-        Assert.assertEquals("01013000", Util.toHex(pair.second!!))
+        Assert.assertEquals("01013000", pair.second!!.toHex)
     }
 
     @Test
@@ -224,12 +224,11 @@ class ConnectionMethodNdefTest {
         Assert.assertNull(decoded.centralClientModeUuid)
         Assert.assertEquals(
             "da2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c00110701000000000000000000000000000000",
-            Util.toHex(pair.first.toByteArray())
+            pair.first.toByteArray().toHex
         )
         Assert.assertEquals(
-            "01013001046d646f63", Util.toHex(
-                pair.second!!
-            )
+            "01013001046d646f63",
+            pair.second!!.toHex
         )
         pair = NfcUtil.toNdefRecord(cm, emptyList(), false)
         decoded = fromNdefRecord(pair!!.first, false)
@@ -240,9 +239,9 @@ class ConnectionMethodNdefTest {
         Assert.assertNull(decoded.centralClientModeUuid)
         Assert.assertEquals(
             "da2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c01110701000000000000000000000000000000",
-            Util.toHex(pair.first.toByteArray())
+            pair.first.toByteArray().toHex
         )
-        Assert.assertEquals("01013000", Util.toHex(pair.second!!))
+        Assert.assertEquals("01013000", pair.second!!.toHex)
     }
 
     @Test
@@ -275,7 +274,7 @@ class ConnectionMethodNdefTest {
     @Throws(FormatException::class)
     fun testConnectionMethodVector() {
         val ndefHsMessage =
-            NdefMessage(Util.fromHex("91020f487315d10209616301013001046d646f631a2003016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c015c1e580469736f2e6f72673a31383031333a646576696365656e676167656d656e746d646f63a20063312e30018201d818584ba401022001215820e778fcb1513fad715c755462cb4d3ee3c1de2f618d10e07788a35eda2da58b982258205e6ee59512414cdb11ee330db2590ab6d1b5a78ede4a0ecac02e3af65cafbcd9"))
+            NdefMessage("91020f487315d10209616301013001046d646f631a2003016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c015c1e580469736f2e6f72673a31383031333a646576696365656e676167656d656e746d646f63a20063312e30018201d818584ba401022001215820e778fcb1513fad715c755462cb4d3ee3c1de2f618d10e07788a35eda2da58b982258205e6ee59512414cdb11ee330db2590ab6d1b5a78ede4a0ecac02e3af65cafbcd9".fromHex)
         Assert.assertNotNull(ndefHsMessage)
         var cm: ConnectionMethodBle? = null
         for (r in ndefHsMessage.records) {

--- a/identity-android/src/main/java/com/android/identity/android/util/NfcUtil.kt
+++ b/identity-android/src/main/java/com/android/identity/android/util/NfcUtil.kt
@@ -14,12 +14,13 @@ import com.android.identity.android.mdoc.transport.DataTransportTcp
 import com.android.identity.android.mdoc.transport.DataTransportUdp
 import com.android.identity.android.mdoc.transport.DataTransportWifiAware
 import com.android.identity.cbor.Cbor
-import com.android.identity.internal.Util
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodWifiAware
 import com.android.identity.util.Logger
+import com.android.identity.util.fromHex
+import com.android.identity.util.toHex
 import java.io.ByteArrayOutputStream
 import java.io.IOException
 import java.util.Arrays
@@ -29,10 +30,10 @@ object NfcUtil {
 
     // Defined by NFC Forum
     @JvmField
-    val AID_FOR_TYPE_4_TAG_NDEF_APPLICATION = Util.fromHex("D2760000850101")
+    val AID_FOR_TYPE_4_TAG_NDEF_APPLICATION = "D2760000850101".fromHex
 
     // Defined by 18013-5 Section 8.3.3.1.2 Data retrieval using near field communication (NFC)
-    val AID_FOR_MDL_DATA_TRANSFER = Util.fromHex("A0000002480400")
+    val AID_FOR_MDL_DATA_TRANSFER = "A0000002480400".fromHex
 
     const val COMMAND_TYPE_OTHER = 0
     const val COMMAND_TYPE_SELECT_BY_AID = 1
@@ -215,8 +216,8 @@ object NfcUtil {
                 if (Logger.isDebugEnabled) {
                     Logger.d(
                         TAG, "ConnectionMethod $cm: alternativeCarrierRecord: "
-                                + "${Util.toHex(records.second)} carrierConfigurationRecord: "
-                                + "${Util.toHex(records.first.payload)}"
+                                + "${records.second.toHex} carrierConfigurationRecord: "
+                                + "${records.first.payload.toHex}"
                     )
                 }
                 alternativeCarrierRecords.add(records.second)

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/engagement/EngagementParserTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/engagement/EngagementParserTest.kt
@@ -15,16 +15,17 @@
  */
 package com.android.identity.mdoc.engagement
 
-import com.android.identity.internal.Util
 import com.android.identity.mdoc.TestVectors
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
+import com.android.identity.util.fromHex
+import com.android.identity.util.toHex
 import org.junit.Assert
 import org.junit.Test
 
 class EngagementParserTest {
     @Test
     fun testDeviceRequestEngagementWithVectors() {
-        val deviceEngagement = Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_ENGAGEMENT)
+        val deviceEngagement = TestVectors.ISO_18013_5_ANNEX_D_DEVICE_ENGAGEMENT.fromHex
         val parser = EngagementParser(deviceEngagement)
         val engagement = parser.parse()
         Assert.assertEquals("1.0", engagement.version)
@@ -42,7 +43,7 @@ class EngagementParserTest {
         val eDeviceKeyBytes = engagement.eSenderKeyBytes
         Assert.assertEquals(
             TestVectors.ISO_18013_5_ANNEX_D_E_DEVICE_KEY_BYTES,
-            Util.toHex(eDeviceKeyBytes)
+            eDeviceKeyBytes.toHex
         )
     }
 }

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/mso/MobileSecurityObjectGeneratorTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/mso/MobileSecurityObjectGeneratorTest.kt
@@ -19,9 +19,10 @@ import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
 import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
-import com.android.identity.internal.Util
 import com.android.identity.mdoc.TestVectors
 import com.android.identity.util.Timestamp
+import com.android.identity.util.fromHex
+import com.android.identity.util.toHex
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
@@ -156,8 +157,8 @@ class MobileSecurityObjectGeneratorTest {
     fun testFullMSO(digestAlgorithm: String) {
         val deviceKeyFromVector = EcPublicKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y.fromHex
         )
         val signedTimestamp = Timestamp.ofEpochMilli(1601559002000L)
         val validFromTimestamp = Timestamp.ofEpochMilli(1601559002000L)
@@ -167,7 +168,7 @@ class MobileSecurityObjectGeneratorTest {
         deviceKeyAuthorizedDataElements["a"] = listOf("1", "2", "f")
         deviceKeyAuthorizedDataElements["b"] = listOf("4", "5", "k")
         val keyInfo: MutableMap<Long, ByteArray> = HashMap()
-        keyInfo[10L] = Util.fromHex("C985")
+        keyInfo[10L] = "C985".fromHex
         val encodedMSO = MobileSecurityObjectGenerator(
             digestAlgorithm,
             "org.iso.18013.5.1.mDL", deviceKeyFromVector
@@ -202,8 +203,8 @@ class MobileSecurityObjectGeneratorTest {
         Assert.assertEquals(deviceKeyAuthorizedDataElements, mso.deviceKeyAuthorizedDataElements)
         Assert.assertEquals(keyInfo.keys, mso.deviceKeyInfo!!.keys)
         Assert.assertEquals(
-            Util.toHex(keyInfo[10L]!!),
-            Util.toHex(mso.deviceKeyInfo!![10L]!!)
+            keyInfo[10L]!!.toHex,
+            mso.deviceKeyInfo!![10L]!!.toHex
         )
         Assert.assertEquals(signedTimestamp, mso.signed)
         Assert.assertEquals(validFromTimestamp, mso.validFrom)
@@ -215,8 +216,8 @@ class MobileSecurityObjectGeneratorTest {
     fun testBasicMSO() {
         val deviceKeyFromVector = EcPublicKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y.fromHex
         )
         val signedTimestamp = Timestamp.ofEpochMilli(1601559002000L)
         val validFromTimestamp = Timestamp.ofEpochMilli(1601559002000L)
@@ -270,8 +271,8 @@ class MobileSecurityObjectGeneratorTest {
     fun testMSOExceptions() {
         val deviceKeyFromVector = EcPublicKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y.fromHex
         )
         Assert.assertThrows(
             "expect exception for illegal digestAlgorithm",

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/mso/MobileSecurityObjectParserTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/mso/MobileSecurityObjectParserTest.kt
@@ -21,6 +21,8 @@ import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
 import com.android.identity.internal.Util
 import com.android.identity.mdoc.TestVectors
 import com.android.identity.util.Timestamp
+import com.android.identity.util.fromHex
+import com.android.identity.util.toHex
 import org.junit.Assert
 import org.junit.Test
 
@@ -28,7 +30,7 @@ class MobileSecurityObjectParserTest {
     @Test
     fun testMSOParserWithVectors() {
         val deviceResponse =
-            Cbor.decode(Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE))
+            Cbor.decode(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex)
         val documentDataItem = deviceResponse["documents"][0]
         val issuerSigned = documentDataItem["issuerSigned"]
         val issuerAuthDataItem = issuerSigned["issuerAuth"]
@@ -54,78 +56,78 @@ class MobileSecurityObjectParserTest {
         )
         Assert.assertEquals(
             "75167333b47b6c2bfb86eccc1f438cf57af055371ac55e1e359e20f254adcebf",
-            Util.toHex(isoDigestIDs[0L]!!)
+            isoDigestIDs[0L]!!.toHex
         )
         Assert.assertEquals(
             "67e539d6139ebd131aef441b445645dd831b2b375b390ca5ef6279b205ed4571",
-            Util.toHex(isoDigestIDs[1L]!!)
+            isoDigestIDs[1L]!!.toHex
         )
         Assert.assertEquals(
             "3394372ddb78053f36d5d869780e61eda313d44a392092ad8e0527a2fbfe55ae",
-            Util.toHex(isoDigestIDs[2L]!!)
+            isoDigestIDs[2L]!!.toHex
         )
         Assert.assertEquals(
             "2e35ad3c4e514bb67b1a9db51ce74e4cb9b7146e41ac52dac9ce86b8613db555",
-            Util.toHex(isoDigestIDs[3L]!!)
+            isoDigestIDs[3L]!!.toHex
         )
         Assert.assertEquals(
             "ea5c3304bb7c4a8dcb51c4c13b65264f845541341342093cca786e058fac2d59",
-            Util.toHex(isoDigestIDs[4L]!!)
+            isoDigestIDs[4L]!!.toHex
         )
         Assert.assertEquals(
             "fae487f68b7a0e87a749774e56e9e1dc3a8ec7b77e490d21f0e1d3475661aa1d",
-            Util.toHex(isoDigestIDs[5L]!!)
+            isoDigestIDs[5L]!!.toHex
         )
         Assert.assertEquals(
             "7d83e507ae77db815de4d803b88555d0511d894c897439f5774056416a1c7533",
-            Util.toHex(isoDigestIDs[6L]!!)
+            isoDigestIDs[6L]!!.toHex
         )
         Assert.assertEquals(
             "f0549a145f1cf75cbeeffa881d4857dd438d627cf32174b1731c4c38e12ca936",
-            Util.toHex(isoDigestIDs[7L]!!)
+            isoDigestIDs[7L]!!.toHex
         )
         Assert.assertEquals(
             "b68c8afcb2aaf7c581411d2877def155be2eb121a42bc9ba5b7312377e068f66",
-            Util.toHex(isoDigestIDs[8L]!!)
+            isoDigestIDs[8L]!!.toHex
         )
         Assert.assertEquals(
             "0b3587d1dd0c2a07a35bfb120d99a0abfb5df56865bb7fa15cc8b56a66df6e0c",
-            Util.toHex(isoDigestIDs[9L]!!)
+            isoDigestIDs[9L]!!.toHex
         )
         Assert.assertEquals(
             "c98a170cf36e11abb724e98a75a5343dfa2b6ed3df2ecfbb8ef2ee55dd41c881",
-            Util.toHex(isoDigestIDs[10L]!!)
+            isoDigestIDs[10L]!!.toHex
         )
         Assert.assertEquals(
             "b57dd036782f7b14c6a30faaaae6ccd5054ce88bdfa51a016ba75eda1edea948",
-            Util.toHex(isoDigestIDs[11L]!!)
+            isoDigestIDs[11L]!!.toHex
         )
         Assert.assertEquals(
             "651f8736b18480fe252a03224ea087b5d10ca5485146c67c74ac4ec3112d4c3a",
-            Util.toHex(isoDigestIDs[12L]!!)
+            isoDigestIDs[12L]!!.toHex
         )
         val isoUSDigestIDs = mso.getDigestIDs("org.iso.18013.5.1.US")
         Assert.assertEquals(setOf(0L, 1L, 2L, 3L), isoUSDigestIDs!!.keys)
         Assert.assertEquals(
             "d80b83d25173c484c5640610ff1a31c949c1d934bf4cf7f18d5223b15dd4f21c",
-            Util.toHex(isoUSDigestIDs[0L]!!)
+            isoUSDigestIDs[0L]!!.toHex
         )
         Assert.assertEquals(
             "4d80e1e2e4fb246d97895427ce7000bb59bb24c8cd003ecf94bf35bbd2917e34",
-            Util.toHex(isoUSDigestIDs[1L]!!)
+            isoUSDigestIDs[1L]!!.toHex
         )
         Assert.assertEquals(
             "8b331f3b685bca372e85351a25c9484ab7afcdf0d2233105511f778d98c2f544",
-            Util.toHex(isoUSDigestIDs[2L]!!)
+            isoUSDigestIDs[2L]!!.toHex
         )
         Assert.assertEquals(
             "c343af1bd1690715439161aba73702c474abf992b20c9fb55c36a336ebe01a87",
-            Util.toHex(isoUSDigestIDs[3L]!!)
+            isoUSDigestIDs[3L]!!.toHex
         )
         val deviceKeyFromVector = EcPublicKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y.fromHex
         )
         Assert.assertEquals(deviceKeyFromVector, mso.deviceKey)
         Assert.assertNull(mso.deviceKeyAuthorizedNameSpaces)

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/request/DeviceRequestParserTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/request/DeviceRequestParserTest.kt
@@ -23,8 +23,8 @@ import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.CertificateChain
 import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
-import com.android.identity.internal.Util
 import com.android.identity.mdoc.TestVectors
+import com.android.identity.util.fromHex
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -42,13 +42,12 @@ class DeviceRequestParserTest {
     @Test
     fun testDeviceRequestParserWithVectors() {
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes =
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val encodedSessionTranscript =
             Cbor.encode(Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor)
         val parser = DeviceRequestParser(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST),
+            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST.fromHex,
             encodedSessionTranscript
         )
         val request = parser.parse()
@@ -58,17 +57,17 @@ class DeviceRequestParserTest {
         val dr = docRequests.iterator().next()
         Assert.assertEquals(MDL_DOCTYPE, dr.docType)
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_ITEMS_REQUEST),
+            TestVectors.ISO_18013_5_ANNEX_D_ITEMS_REQUEST.fromHex,
             dr.itemsRequest
         )
         val readerCertChain = dr.readerCertificateChain
         Assert.assertEquals(1, readerCertChain!!.certificates.size.toLong())
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_READER_CERT),
+            TestVectors.ISO_18013_5_ANNEX_D_READER_CERT.fromHex,
             readerCertChain.certificates[0].encodedCertificate
         )
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_READER_AUTH),
+            TestVectors.ISO_18013_5_ANNEX_D_READER_AUTH.fromHex,
             dr.readerAuth
         )
         Assert.assertTrue(dr.readerAuthenticated)
@@ -97,16 +96,15 @@ class DeviceRequestParserTest {
     @Test
     fun testDeviceRequestParserWithVectorsMalformedReaderSignature() {
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes =
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val encodedSessionTranscript =
             Cbor.encode(Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor)
 
         // We know the COSE_Sign1 signature for reader authentication is at index 655 and
         // starts with 1f340006... Poison that so we can check whether signature verification
         // detects it...
-        val encodedDeviceRequest = Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST)
+        val encodedDeviceRequest = TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST.fromHex
         Assert.assertEquals(0x1f.toByte().toLong(), encodedDeviceRequest[655].toLong())
         encodedDeviceRequest[655] = 0x1e
         val parser = DeviceRequestParser(
@@ -120,13 +118,13 @@ class DeviceRequestParserTest {
         val dr = docRequests.iterator().next()
         Assert.assertEquals(MDL_DOCTYPE, dr.docType)
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_ITEMS_REQUEST),
+            TestVectors.ISO_18013_5_ANNEX_D_ITEMS_REQUEST.fromHex,
             dr.itemsRequest
         )
         val readerCertChain = dr.readerCertificateChain
         Assert.assertEquals(1, readerCertChain!!.certificates.size.toLong())
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_READER_CERT),
+            TestVectors.ISO_18013_5_ANNEX_D_READER_CERT.fromHex,
             readerCertChain.certificates[0].encodedCertificate
         )
         Assert.assertFalse(dr.readerAuthenticated)

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/response/DeviceResponseParserTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/response/DeviceResponseParserTest.kt
@@ -22,9 +22,9 @@ import com.android.identity.crypto.EcPrivateKey
 import com.android.identity.crypto.EcPrivateKeyDoubleCoordinate
 import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
 import com.android.identity.crypto.javaX509Certificate
-import com.android.identity.internal.Util
 import com.android.identity.mdoc.TestVectors
 import com.android.identity.util.Constants
+import com.android.identity.util.fromHex
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
@@ -45,22 +45,19 @@ class DeviceResponseParserTest {
         // NOTE: This tests tests the MAC verification path of DeviceResponseParser, the
         // ECDSA verification path is tested in DeviceResponseGeneratorTest by virtue of
         // SUtil.getIdentityCredentialStore() defaulting to the Jetpack.
-        val encodedDeviceResponse = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE
-        )
+        val encodedDeviceResponse = TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex
 
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes =
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val encodedSessionTranscript = Cbor.encode(
             Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor
         )
         val eReaderKey: EcPrivateKey = EcPrivateKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y.fromHex
         )
         val dr = DeviceResponseParser(
             encodedDeviceResponse,
@@ -86,8 +83,8 @@ class DeviceResponseParserTest {
         // Check DeviceKey is correctly parsed
         val deviceKeyFromVector = EcPublicKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y.fromHex
         )
         Assert.assertEquals(deviceKeyFromVector, d.deviceKey)
 
@@ -145,9 +142,7 @@ class DeviceResponseParserTest {
             )
         )
         Assert.assertArrayEquals(
-            Util.fromHex(
-                TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE_PORTRAIT_DATA
-            ),
+            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE_PORTRAIT_DATA.fromHex,
             d.getIssuerEntryByteString(MDL_NAMESPACE, "portrait")
         )
 
@@ -168,16 +163,15 @@ class DeviceResponseParserTest {
         Assert.assertEquals("C=US, CN=utopia ds", issuerCert.subjectX500Principal.toString())
         Assert.assertEquals("C=US, CN=utopia iaca", issuerCert.issuerX500Principal.toString())
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DS_CERT),
+            TestVectors.ISO_18013_5_ANNEX_D_DS_CERT.fromHex,
             issuerCert.encoded
         )
     }
 
     @Test
     fun testDeviceResponseParserWithVectorsMalformedIssuerItem() {
-        val encodedDeviceResponse = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE
-        )
+        val encodedDeviceResponse =
+            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex
 
         // We know that the value for family_name in IssuerSignedItem is at offset 200.
         // Change this from "Doe" to "Foe" to force validation of that item to fail.
@@ -186,17 +180,16 @@ class DeviceResponseParserTest {
         encodedDeviceResponse[200] = 0x46.toByte()
 
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes =
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val encodedSessionTranscript = Cbor.encode(
             Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor
         )
         val eReaderKey: EcPrivateKey = EcPrivateKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y.fromHex
         )
         val dr = DeviceResponseParser(
             encodedDeviceResponse,
@@ -228,9 +221,7 @@ class DeviceResponseParserTest {
 
     @Test
     fun testDeviceResponseParserWithVectorsMalformedDeviceSigned() {
-        val encodedDeviceResponse = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE
-        )
+        val encodedDeviceResponse = TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex
 
         // We know that the 32 bytes for the MAC in DeviceMac CBOR starts at offset 3522 and
         // starts with E99521A8. Poison that to cause DeviceSigned to not authenticate.
@@ -238,17 +229,16 @@ class DeviceResponseParserTest {
         encodedDeviceResponse[3522] = 0xe8.toByte()
 
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes =
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val encodedSessionTranscript = Cbor.encode(
             Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor
         )
         val eReaderKey: EcPrivateKey = EcPrivateKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y.fromHex
         )
         val dr = DeviceResponseParser(
             encodedDeviceResponse,
@@ -273,9 +263,7 @@ class DeviceResponseParserTest {
 
     @Test
     fun testDeviceResponseParserWithVectorsMalformedIssuerSigned() {
-        val encodedDeviceResponse = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE
-        )
+        val encodedDeviceResponse = TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex
 
         // We know that issuer signature starts at offset 3398 and starts with 59E64205DF1E.
         // Poison that to cause IssuerSigned to not authenticate.
@@ -283,17 +271,16 @@ class DeviceResponseParserTest {
         encodedDeviceResponse[3398] = 0x5a.toByte()
 
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes =
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val encodedSessionTranscript = Cbor.encode(
             Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor
         )
         val eReaderKey: EcPrivateKey = EcPrivateKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y.fromHex
         )
         val dr = DeviceResponseParser(
             encodedDeviceResponse,

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/sessionencryption/SessionEncryptionTest.kt
@@ -20,10 +20,10 @@ import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
 import com.android.identity.crypto.EcPrivateKey
 import com.android.identity.crypto.EcPrivateKeyDoubleCoordinate
-import com.android.identity.internal.Util
 import com.android.identity.mdoc.TestVectors
 import com.android.identity.mdoc.engagement.EngagementParser
 import com.android.identity.util.Constants
+import com.android.identity.util.fromHex
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
@@ -40,15 +40,14 @@ class SessionEncryptionTest {
     fun testReaderAgainstVectors() {
         val eReaderKey: EcPrivateKey = EcPrivateKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_D.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_READER_KEY_Y.fromHex
         )
 
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes = 
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val sessionTranscript = Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor
         val deviceEngagementBytes = sessionTranscript[0]
         val encodedDeviceEngagement = deviceEngagementBytes.asTagged.asBstr
@@ -64,33 +63,33 @@ class SessionEncryptionTest {
 
         // Check that encryption works.
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_ESTABLISHMENT),
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_ESTABLISHMENT.fromHex,
             sessionEncryption.encryptMessage(
-                Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST),
+                TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST.fromHex,
                 null
             )
         )
 
         // Check that decryption works.
         var result = sessionEncryption.decryptMessage(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_DATA)
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_DATA.fromHex
         )
         Assert.assertNull(result.second)
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE),
+            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex,
             result.first
         )
 
         // Check that we parse status correctly.
         result = sessionEncryption.decryptMessage(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION)
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION.fromHex
         )
         Assert.assertEquals(Constants.SESSION_DATA_STATUS_SESSION_TERMINATION, result.second)
         Assert.assertNull(result.first)
 
         // Check we can generate messages with status.
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION),
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION.fromHex,
             sessionEncryption.encryptMessage(
                 null,
                 Constants.SESSION_DATA_STATUS_SESSION_TERMINATION
@@ -102,17 +101,16 @@ class SessionEncryptionTest {
     fun testDeviceAgainstVectors() {
         val eDeviceKey: EcPrivateKey = EcPrivateKeyDoubleCoordinate(
             EcCurve.P256,
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_DEVICE_KEY_D),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_DEVICE_KEY_X),
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_DEVICE_KEY_Y)
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_DEVICE_KEY_D.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_DEVICE_KEY_X.fromHex,
+            TestVectors.ISO_18013_5_ANNEX_D_EPHEMERAL_DEVICE_KEY_Y.fromHex
         )
 
         // Strip the #6.24 tag since our API expects just the bytes of SessionTranscript.
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes = 
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val sessionTranscript = Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor
-        val sessionEstablishment = Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_ESTABLISHMENT)
+        val sessionEstablishment = TestVectors.ISO_18013_5_ANNEX_D_SESSION_ESTABLISHMENT.fromHex
         val eReaderKey = Cbor.decode(sessionEstablishment)["eReaderKey"]
             .asTaggedEncodedCbor.asCoseKey.ecPublicKey
         val sessionEncryptionDevice = SessionEncryption(
@@ -128,22 +126,22 @@ class SessionEncryptionTest {
         )
         Assert.assertNull(result.second)
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST),
+            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST.fromHex,
             result.first
         )
 
         // Check that encryption works.
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_DATA),
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_DATA.fromHex,
             sessionEncryptionDevice.encryptMessage(
-                Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE),
+                TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex,
                 null
             )
         )
 
         // Check that we parse status correctly.
         result = sessionEncryptionDevice.decryptMessage(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION)
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION.fromHex
         )
         Assert.assertEquals(
             Constants.SESSION_DATA_STATUS_SESSION_TERMINATION,
@@ -153,7 +151,7 @@ class SessionEncryptionTest {
 
         // Check we can generate messages with status.
         Assert.assertArrayEquals(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION),
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TERMINATION.fromHex,
             sessionEncryptionDevice.encryptMessage(null, 20L)
         )
     }
@@ -178,7 +176,7 @@ class SessionEncryptionTest {
         for (i in 1..3) {
             // have reader generate sessionEstablishment and check holder decryption of sessionEstablishment
             val mdocRequest = sessionEncryptionReader.encryptMessage(
-                Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST),
+                TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST.fromHex,
                 null
             )
             var result = sessionEncryptionHolder.decryptMessage(
@@ -186,7 +184,7 @@ class SessionEncryptionTest {
             )
             Assert.assertNull(result.second)
             Assert.assertArrayEquals(
-                Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST),
+                TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST.fromHex,
                 result.first
             )
             Assert.assertEquals(i.toLong(), sessionEncryptionReader.numMessagesEncrypted.toLong())
@@ -194,13 +192,13 @@ class SessionEncryptionTest {
 
             // have holder generate deviceResponse and check reader decryption of deviceResponse
             val deviceResponse = sessionEncryptionHolder.encryptMessage(
-                Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE),
+                TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex,
                 null
             )
             result = sessionEncryptionReader.decryptMessage(deviceResponse)
             Assert.assertNull(result.second)
             Assert.assertArrayEquals(
-                Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE),
+                TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex,
                 result.first
             )
             Assert.assertEquals(i.toLong(), sessionEncryptionHolder.numMessagesEncrypted.toLong())

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/util/MdocUtilTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/util/MdocUtilTest.kt
@@ -29,6 +29,8 @@ import com.android.identity.mdoc.util.MdocUtil.calculateDigestsForNameSpace
 import com.android.identity.mdoc.util.MdocUtil.generateCredentialRequest
 import com.android.identity.mdoc.util.MdocUtil.generateIssuerNameSpaces
 import com.android.identity.mdoc.util.MdocUtil.stripIssuerNameSpaces
+import com.android.identity.util.fromHex
+import com.android.identity.util.toHex
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
@@ -136,25 +138,25 @@ class MdocUtilTest {
         Assert.assertEquals(3, digests.size.toLong())
         Assert.assertEquals(
             "9f10afbca223fcfe0ee9f239e995cfe79e7f845b68981a4a0943706717c64efa",
-            Util.toHex(digests[0L]!!)
+            digests[0L]!!.toHex
         )
         Assert.assertEquals(
             "a5e74b031ea380267d39905981ea80c68178229219556ffd72d312a0366a7d63",
-            Util.toHex(digests[4L]!!)
+            digests[4L]!!.toHex
         )
         Assert.assertEquals(
             "03f0ac0623c2eaefd76bcbca00df782d84f544cf7ac1b1f9ed46144275e1d47c",
-            Util.toHex(digests[2L]!!)
+            digests[2L]!!.toHex
         )
         digests = calculateDigestsForNameSpace("ns2", issuerNameSpaces, Algorithm.SHA256)
         Assert.assertEquals(2, digests.size.toLong())
         Assert.assertEquals(
             "fd69be5fcc0df04ae78e147bb3ad95ce4ecff51028322cccf02195f36612a212",
-            Util.toHex(digests[1L]!!)
+            digests[1L]!!.toHex
         )
         Assert.assertEquals(
             "47083a3473ddfcf3c8cc00f2035ac41d0b791fc50106be416c068536c249c0dd",
-            Util.toHex(digests[3L]!!)
+            digests[3L]!!.toHex
         )
 
         // Check stripping
@@ -228,7 +230,7 @@ class MdocUtilTest {
     @Test
     fun testGetDigestsForNameSpaceInTestVectors() {
         val deviceResponse = Cbor.decode(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE)
+            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_RESPONSE.fromHex
         )
         val documentDataItem = deviceResponse["documents"][0]
         val issuerSigned = documentDataItem["issuerSigned"]
@@ -266,14 +268,13 @@ class MdocUtilTest {
 
     @Test
     fun testGenerateCredentialRequest() {
-        val encodedSessionTranscriptBytes = Util.fromHex(
-            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES
-        )
+        val encodedSessionTranscriptBytes =
+            TestVectors.ISO_18013_5_ANNEX_D_SESSION_TRANSCRIPT_BYTES.fromHex
         val encodedSessionTranscript = Cbor.encode(
             Cbor.decode(encodedSessionTranscriptBytes).asTaggedEncodedCbor
         )
         val parser = DeviceRequestParser(
-            Util.fromHex(TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST),
+            TestVectors.ISO_18013_5_ANNEX_D_DEVICE_REQUEST.fromHex,
             encodedSessionTranscript
         )
         val request = parser.parse()

--- a/identity/src/main/java/com/android/identity/util/HexUtil.kt
+++ b/identity/src/main/java/com/android/identity/util/HexUtil.kt
@@ -1,0 +1,58 @@
+package com.android.identity.util
+
+private val HEX_DIGITS_LOWER = "0123456789abcdef".toCharArray()
+private val HEX_DIGITS_UPPER = "0123456789abcdef".toCharArray()
+
+object HexUtil {
+    /**
+     * Encodes a byte array into hexadecimal numbers.
+     *
+     * The returned string can be decoded using the [fromHex] method.
+     *
+     * @param bytes the byte array to encode.
+     * @param upperCase if `true`, will use upper-case characters, otherwise lower-case is used.
+     * @return a string with hexadecimal numbers.
+     */
+    fun toHex(bytes: ByteArray, upperCase: Boolean = false): String {
+        val sb = StringBuilder(bytes.size * 2)
+        for (n in 0 until bytes.size) {
+            val b = bytes[n]
+            val digits = if (upperCase) HEX_DIGITS_UPPER else HEX_DIGITS_LOWER
+            sb.append(digits[b.toInt().and(0xff) shr 4])
+            sb.append(digits[b.toInt().and(0x0f)])
+        }
+        return sb.toString()
+    }
+
+    /**
+     * Decodes a string with hexadecimal numbers.
+     *
+     * The string must contain no whitespace.
+     *
+     * @param stringWithHex a string with hexadecimal numbers.
+     * @throws IllegalArgumentException if the string isn't properly formatted.
+     */
+    fun fromHex(stringWithHex: String): ByteArray {
+        val stringLength = stringWithHex.length
+        require(stringLength % 2 == 0) { "Invalid length of hex string: $stringLength" }
+        val numBytes = stringLength / 2
+        val data = ByteArray(numBytes)
+        for (n in 0 until numBytes) {
+            val byteStr = stringWithHex.substring(2 * n, 2 * n + 2)
+            data[n] = byteStr.toInt(16).toByte()
+        }
+        return data
+    }
+}
+
+/**
+ * Extension to encode a [ByteArray] to a string with hexadecimal numbers.
+ */
+val ByteArray.toHex: String
+    get() = HexUtil.toHex(this)
+
+/**
+ * Extension to decode a [ByteArray] from a string with hexadecimal numbers.
+ */
+val String.fromHex: ByteArray
+    get() = HexUtil.fromHex(this)

--- a/identity/src/test/java/com/android/identity/cbor/CborTests.kt
+++ b/identity/src/test/java/com/android/identity/cbor/CborTests.kt
@@ -1,6 +1,7 @@
 package com.android.identity.cbor
 
 import com.android.identity.internal.Util
+import com.android.identity.util.fromHex
 import kotlinx.datetime.Instant
 import org.junit.Assert
 import org.junit.Test
@@ -710,7 +711,7 @@ class CborTests {
     @Test
     fun diagnosticsVectors() {
         for (testVector in diagnosticsTestVectors) {
-            val encodedCbor = Util.fromHex(testVector.hexEncoding)
+            val encodedCbor = testVector.hexEncoding.fromHex
             Assert.assertEquals(testVector.expectedDiagnostics, Cbor.toDiagnostics(encodedCbor))
         }
     }
@@ -774,7 +775,7 @@ class CborTests {
     @Test
     fun nonWellformedThrowsWhenDecoding() {
         for (hexEncodedData in nonWellformedExamples) {
-            val data = Util.fromHex(hexEncodedData.replace(" ", ""))
+            val data = hexEncodedData.replace(" ", "").fromHex
             Assert.assertThrows(IllegalArgumentException::class.java) {
                 Cbor.decode(data)
             }

--- a/identity/src/test/java/com/android/identity/cose/CoseTests.kt
+++ b/identity/src/test/java/com/android/identity/cose/CoseTests.kt
@@ -5,7 +5,6 @@ import com.android.identity.cbor.CborMap
 import com.android.identity.cbor.DataItem
 import com.android.identity.cbor.DiagnosticOption
 import com.android.identity.cbor.toDataItem
-import com.android.identity.internal.Util
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
 import com.android.identity.securearea.CreateKeySettings
@@ -16,6 +15,7 @@ import com.android.identity.crypto.toEcPublicKey
 import com.android.identity.securearea.KeyPurpose
 import com.android.identity.securearea.software.SoftwareSecureArea
 import com.android.identity.storage.EphemeralStorageEngine
+import com.android.identity.util.fromHex
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.util.BigIntegers
 import org.junit.Assert
@@ -83,8 +83,8 @@ class CoseTests {
         //
         //   https://datatracker.ietf.org/doc/html/rfc9052#name-public-keys
         //
-        val x = Util.fromHex("65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d")
-        val y = Util.fromHex("1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c")
+        val x = "65eda5a12577c2bae829437fe338701a10aaa375e1bb5b5de108de439c08551d".fromHex
+        val y = "1e52ed75701163f7f9e40ddf9f341b3dc9ba860af7e0ca7ca7e9eecd0084d19c".fromHex
         val id = "meriadoc.brandybuck@buckland.example".toByteArray()
         val item = CborMap.builder()
             .put(-1, 1)
@@ -149,8 +149,8 @@ class CoseTests {
         //
         //  https://datatracker.ietf.org/doc/html/rfc9052#name-public-keys
         //
-        val x = Util.fromHex("bac5b11cad8f99f9c72b05cf4b9e26d244dc189f745228255a219a86d6a09eff")
-        val y = Util.fromHex("20138bf82dc1b6d562be0fa54ab7804a3a64b6d72ccfed6b6fb6ed28bbfc117e")
+        val x = "bac5b11cad8f99f9c72b05cf4b9e26d244dc189f745228255a219a86d6a09eff".fromHex
+        val y = "20138bf82dc1b6d562be0fa54ab7804a3a64b6d72ccfed6b6fb6ed28bbfc117e".fromHex
         val coseKey = CborMap.builder()
             .put(-1, 1)
             .put(-2, x)
@@ -165,9 +165,9 @@ class CoseTests {
             mutableMapOf(
                 Pair(11L.toCoseLabel, byteArrayOf(1, 1).toDataItem)
             ),
-            Util.fromHex("8eb33e4ca31d1c465ab05aac34cc6b23d58fef5c083106c4" +
+            ("8eb33e4ca31d1c465ab05aac34cc6b23d58fef5c083106c4" +
                     "d25a91aef0b0117e2af9a291aa32e14ab834dc56ed2a223444547e01f11d3b0916e5" +
-                    "a4c345cacb36"),
+                    "a4c345cacb36").fromHex,
             "This is the content.".toByteArray()
         )
 
@@ -225,7 +225,7 @@ class CoseTests {
             "23032312d31302d30315431333a33303a30325a584059e64205df1e2f708dd6db0847aed7" +
             "9fc7c0201d80fa55badcaf2e1bcf5902e1e5a62e4832044b890ad85aa53f129134775d733" +
             "754d7cb7a413766aeff13cb2e"
-        val coseSign1 = Cbor.decode(Util.fromHex(issuerAuth)).asCoseSign1
+        val coseSign1 = Cbor.decode(issuerAuth.fromHex).asCoseSign1
 
         val signatureAlgorithm = coseSign1.protectedHeaders[Cose.COSE_LABEL_ALG.toCoseLabel]!!.asNumber
         Assert.assertEquals(signatureAlgorithm, Algorithm.ES256.coseAlgorithmIdentifier.toLong())
@@ -237,8 +237,8 @@ class CoseTests {
         Assert.assertEquals("C=US, CN=utopia iaca", cert.issuerX500Principal.toString())
         Assert.assertEquals("C=US, CN=utopia ds", cert.subjectX500Principal.toString())
 
-        val x = Util.fromHex("ace7ab7340e5d9648c5a72a9a6f56745c7aad436a03a43efea77b5fa7b88f019")
-        val y = Util.fromHex("7d57d8983e1b37d3a539f4d588365e38cbbf5b94d68c547b5bc8731dcd2f146b")
+        val x = "ace7ab7340e5d9648c5a72a9a6f56745c7aad436a03a43efea77b5fa7b88f019".fromHex
+        val y = "7d57d8983e1b37d3a539f4d588365e38cbbf5b94d68c547b5bc8731dcd2f146b".fromHex
         val publicKey = EcPublicKeyDoubleCoordinate(EcCurve.P256, x, y)
         Assert.assertEquals(publicKey, cert.publicKey.toEcPublicKey(EcCurve.P256))
     }

--- a/identity/src/test/java/com/android/identity/crypto/CryptoTests.kt
+++ b/identity/src/test/java/com/android/identity/crypto/CryptoTests.kt
@@ -1,6 +1,7 @@
 package com.android.identity.crypto
 
-import com.android.identity.internal.Util
+import com.android.identity.util.toHex
+import com.android.identity.util.fromHex
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
@@ -19,19 +20,19 @@ class CryptoTests {
     fun digests() {
         Assert.assertEquals(
             "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
-            Util.toHex(Crypto.digest(Algorithm.SHA256, "".toByteArray()))
+            Crypto.digest(Algorithm.SHA256, "".toByteArray()).toHex
         )
         Assert.assertEquals(
             "a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e",
-            Util.toHex(Crypto.digest(Algorithm.SHA256, "Hello World".toByteArray()))
+            Crypto.digest(Algorithm.SHA256, "Hello World".toByteArray()).toHex
         )
         Assert.assertEquals(
             "38b060a751ac96384cd9327eb1b1e36a21fdb71114be07434c0cc7bf63f6e1da274edebfe76f65fbd51ad2f14898b95b",
-            Util.toHex(Crypto.digest(Algorithm.SHA384, "".toByteArray()))
+            Crypto.digest(Algorithm.SHA384, "".toByteArray()).toHex
         )
         Assert.assertEquals(
             "cf83e1357eefb8bdf1542850d66d8007d620e4050b5715dc83f4a921d36ce9ce47d0d13c5d85f2b0ff8318d2877eec2f63b931bd47417a81a538327af927da3e",
-            Util.toHex(Crypto.digest(Algorithm.SHA512, "".toByteArray()))
+            Crypto.digest(Algorithm.SHA512, "".toByteArray()).toHex
         )
     }
 
@@ -45,37 +46,31 @@ class CryptoTests {
         // First item with L=32 and T=32
         Assert.assertEquals(
             "769f00d3e6a6cc1fb426a14a4f76c6462e6149726e0dee0ec0cf97a16605ac8b",
-            Util.toHex(
-                Crypto.mac(
-                    Algorithm.HMAC_SHA256,
-                    Util.fromHex("9779d9120642797f1747025d5b22b7ac607cab08e1758f2f3a46c8be1e25c53b8c6a8f58ffefa176"),
-                    Util.fromHex("b1689c2591eaf3c9e66070f8a77954ffb81749f1b00346f9dfe0b2ee905dcc288baf4a92de3f4001dd9f44c468c3d07d6c6ee82faceafc97c2fc0fc0601719d2dcd0aa2aec92d1b0ae933c65eb06a03c9c935c2bad0459810241347ab87e9f11adb30415424c6c7f5f22a003b8ab8de54f6ded0e3ab9245fa79568451dfa258e")
-                )
-            )
+            Crypto.mac(
+                Algorithm.HMAC_SHA256,
+                "9779d9120642797f1747025d5b22b7ac607cab08e1758f2f3a46c8be1e25c53b8c6a8f58ffefa176".fromHex,
+                "b1689c2591eaf3c9e66070f8a77954ffb81749f1b00346f9dfe0b2ee905dcc288baf4a92de3f4001dd9f44c468c3d07d6c6ee82faceafc97c2fc0fc0601719d2dcd0aa2aec92d1b0ae933c65eb06a03c9c935c2bad0459810241347ab87e9f11adb30415424c6c7f5f22a003b8ab8de54f6ded0e3ab9245fa79568451dfa258e".fromHex
+            ).toHex
         )
 
         // First item with L=48 and T=48
         Assert.assertEquals(
             "7cf5a06156ad3de5405a5d261de90275f9bb36de45667f84d08fbcb308ca8f53a419b07deab3b5f8ea231c5b036f8875",
-            Util.toHex(
-                Crypto.mac(
-                    Algorithm.HMAC_SHA384,
-                    Util.fromHex("5eab0dfa27311260d7bddcf77112b23d8b42eb7a5d72a5a318e1ba7e7927f0079dbb701317b87a3340e156dbcee28ec3a8d9"),
-                    Util.fromHex("f41380123ccbec4c527b425652641191e90a17d45e2f6206cf01b5edbe932d41cc8a2405c3195617da2f420535eed422ac6040d9cd65314224f023f3ba730d19db9844c71c329c8d9d73d04d8c5f244aea80488292dc803e772402e72d2e9f1baba5a6004f0006d822b0b2d65e9e4a302dd4f776b47a972250051a701fab2b70")
-                )
-            )
+            Crypto.mac(
+                Algorithm.HMAC_SHA384,
+                "5eab0dfa27311260d7bddcf77112b23d8b42eb7a5d72a5a318e1ba7e7927f0079dbb701317b87a3340e156dbcee28ec3a8d9".fromHex,
+                "f41380123ccbec4c527b425652641191e90a17d45e2f6206cf01b5edbe932d41cc8a2405c3195617da2f420535eed422ac6040d9cd65314224f023f3ba730d19db9844c71c329c8d9d73d04d8c5f244aea80488292dc803e772402e72d2e9f1baba5a6004f0006d822b0b2d65e9e4a302dd4f776b47a972250051a701fab2b70".fromHex
+            ).toHex
         )
 
         // First item with L=64 and T=64
         Assert.assertEquals(
             "33c511e9bc2307c62758df61125a980ee64cefebd90931cb91c13742d4714c06de4003faf3c41c06aefc638ad47b21906e6b104816b72de6269e045a1f4429d4",
-            Util.toHex(
-                Crypto.mac(
-                    Algorithm.HMAC_SHA512,
-                    Util.fromHex("57c2eb677b5093b9e829ea4babb50bde55d0ad59fec34a618973802b2ad9b78e26b2045dda784df3ff90ae0f2cc51ce39cf54867320ac6f3ba2c6f0d72360480c96614ae66581f266c35fb79fd28774afd113fa5187eff9206d7cbe90dd8bf67c844e202"),
-                    Util.fromHex("2423dff48b312be864cb3490641f793d2b9fb68a7763b8e298c86f42245e4540eb01ae4d2d4500370b1886f23ca2cf9701704cad5bd21ba87b811daf7a854ea24a56565ced425b35e40e1acbebe03603e35dcf4a100e57218408a1d8dbcc3b99296cfea931efe3ebd8f719a6d9a15487b9ad67eafedf15559ca42445b0f9b42e")
-                )
-            )
+            Crypto.mac(
+                Algorithm.HMAC_SHA512,
+                "57c2eb677b5093b9e829ea4babb50bde55d0ad59fec34a618973802b2ad9b78e26b2045dda784df3ff90ae0f2cc51ce39cf54867320ac6f3ba2c6f0d72360480c96614ae66581f266c35fb79fd28774afd113fa5187eff9206d7cbe90dd8bf67c844e202".fromHex,
+                "2423dff48b312be864cb3490641f793d2b9fb68a7763b8e298c86f42245e4540eb01ae4d2d4500370b1886f23ca2cf9701704cad5bd21ba87b811daf7a854ea24a56565ced425b35e40e1acbebe03603e35dcf4a100e57218408a1d8dbcc3b99296cfea931efe3ebd8f719a6d9a15487b9ad67eafedf15559ca42445b0f9b42e".fromHex
+            ).toHex
         )
     }
 
@@ -87,38 +82,32 @@ class CryptoTests {
         //
         Assert.assertEquals(
             "2ccda4a5415cb91e135c2a0f78c9b2fd" + "b36d1df9b9d5e596f83e8b7f52971cb3",
-            Util.toHex(
-                Crypto.encrypt(
-                    Algorithm.A128GCM,
-                    Util.fromHex("7fddb57453c241d03efbed3ac44e371c"),
-                    Util.fromHex("ee283a3fc75575e33efd4887"),
-                    Util.fromHex("d5de42b461646c255c87bd2962d3b9a2"),
-                )
-            )
+            Crypto.encrypt(
+                Algorithm.A128GCM,
+                "7fddb57453c241d03efbed3ac44e371c".fromHex,
+                "ee283a3fc75575e33efd4887".fromHex,
+                "d5de42b461646c255c87bd2962d3b9a2".fromHex,
+            ).toHex
         )
 
         Assert.assertEquals(
             "69482957e6be5c54882d00314e0259cf" + "191e9f29bef63a26860c1e020a21137e",
-            Util.toHex(
-                Crypto.encrypt(
-                    Algorithm.A192GCM,
-                    Util.fromHex("fbc0b4c56a714c83217b2d1bcadd2ed2e9efb0dcac6cc19f"),
-                    Util.fromHex("5f4b43e811da9c470d6a9b01"),
-                    Util.fromHex("d2ae38c4375954835d75b8e4c2f9bbb4"),
-                )
-            )
+            Crypto.encrypt(
+                Algorithm.A192GCM,
+                "fbc0b4c56a714c83217b2d1bcadd2ed2e9efb0dcac6cc19f".fromHex,
+                "5f4b43e811da9c470d6a9b01".fromHex,
+                "d2ae38c4375954835d75b8e4c2f9bbb4".fromHex,
+            ).toHex
         )
 
         Assert.assertEquals(
             "fa4362189661d163fcd6a56d8bf0405a" + "d636ac1bbedd5cc3ee727dc2ab4a9489",
-            Util.toHex(
-                Crypto.encrypt(
-                    Algorithm.A256GCM,
-                    Util.fromHex("31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22"),
-                    Util.fromHex("0d18e06c7c725ac9e362e1ce"),
-                    Util.fromHex("2db5168e932556f8089a0622981d017d"),
-                )
-            )
+            Crypto.encrypt(
+                Algorithm.A256GCM,
+                "31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22".fromHex,
+                "0d18e06c7c725ac9e362e1ce".fromHex,
+                "2db5168e932556f8089a0622981d017d".fromHex,
+            ).toHex
         )
     }
 
@@ -130,45 +119,39 @@ class CryptoTests {
         //
         Assert.assertEquals(
             "28286a321293253c3e0aa2704a278032",
-            Util.toHex(
-                Crypto.decrypt(
-                    Algorithm.A128GCM,
-                    Util.fromHex("e98b72a9881a84ca6b76e0f43e68647a"),
-                    Util.fromHex("8b23299fde174053f3d652ba"),
-                    Util.fromHex("5a3c1cf1985dbb8bed818036fdd5ab42" + "23c7ab0f952b7091cd324835043b5eb5"),
-                )
-            )
+            Crypto.decrypt(
+                Algorithm.A128GCM,
+                "e98b72a9881a84ca6b76e0f43e68647a".fromHex,
+                "8b23299fde174053f3d652ba".fromHex,
+                ("5a3c1cf1985dbb8bed818036fdd5ab42" + "23c7ab0f952b7091cd324835043b5eb5").fromHex,
+            ).toHex
         )
 
         Assert.assertEquals(
             "99ae6f479b3004354ff18cd86c0b6efb",
-            Util.toHex(
-                Crypto.decrypt(
-                    Algorithm.A192GCM,
-                    Util.fromHex("7a7c5b6a8a9ab5acae34a9f6e41f19a971f9c330023c0f0c"),
-                    Util.fromHex("aa4c38bf587f94f99fee77d5"),
-                    Util.fromHex("132ae95bd359c44aaefa6348632cafbd" + "19d7c7d5809ad6648110f22f272e7d72"),
-                )
-            )
+            Crypto.decrypt(
+                Algorithm.A192GCM,
+                "7a7c5b6a8a9ab5acae34a9f6e41f19a971f9c330023c0f0c".fromHex,
+                "aa4c38bf587f94f99fee77d5".fromHex,
+                ("132ae95bd359c44aaefa6348632cafbd" + "19d7c7d5809ad6648110f22f272e7d72").fromHex,
+            ).toHex
         )
 
         Assert.assertEquals(
             "7789b41cb3ee548814ca0b388c10b343",
-            Util.toHex(
-                Crypto.decrypt(
-                    Algorithm.A256GCM,
-                    Util.fromHex("4c8ebfe1444ec1b2d503c6986659af2c94fafe945f72c1e8486a5acfedb8a0f8"),
-                    Util.fromHex("473360e0ad24889959858995"),
-                    Util.fromHex("d2c78110ac7e8f107c0df0570bd7c90c" + "c26a379b6d98ef2852ead8ce83a833a7"),
-                )
-            )
+            Crypto.decrypt(
+                Algorithm.A256GCM,
+                "4c8ebfe1444ec1b2d503c6986659af2c94fafe945f72c1e8486a5acfedb8a0f8".fromHex,
+                "473360e0ad24889959858995".fromHex,
+                ("d2c78110ac7e8f107c0df0570bd7c90c" + "c26a379b6d98ef2852ead8ce83a833a7").fromHex,
+            ).toHex
         )
     }
 
     @Test
     fun encryptDecrypt() {
-        val key = Util.fromHex("00000000000000000000000000000000")
-        val nonce = Util.fromHex("000000000000000000000000")
+        val key = "00000000000000000000000000000000".fromHex
+        val nonce = "000000000000000000000000".fromHex
         val message = "Hello World".toByteArray()
         val ciptherTextAndTag = Crypto.encrypt(Algorithm.A128GCM, key, nonce, message)
         val decryptedMessage = Crypto.decrypt(Algorithm.A128GCM, key, nonce, ciptherTextAndTag)
@@ -177,8 +160,8 @@ class CryptoTests {
 
     @Test
     fun decryptionFailure() {
-        val key = Util.fromHex("00000000000000000000000000000000")
-        val nonce = Util.fromHex("000000000000000000000000")
+        val key = "00000000000000000000000000000000".fromHex
+        val nonce = "000000000000000000000000".fromHex
         val message = "Hello World".toByteArray()
         val ciptherTextAndTag = Crypto.encrypt(Algorithm.A128GCM, key, nonce, message)
         // Tamper with the cipher text to induce failure.
@@ -193,15 +176,13 @@ class CryptoTests {
         // From https://datatracker.ietf.org/doc/html/rfc5869#appendix-A
         Assert.assertEquals(
             "3cb25f25faacd57a90434f64d0362f2a2d2d0a90cf1a5a4c5db02d56ecc4c5bf34007208d5b887185865",
-            Util.toHex(
-                Crypto.hkdf(
-                    Algorithm.HMAC_SHA256,
-                    Util.fromHex("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b"),
-                    Util.fromHex("000102030405060708090a0b0c"),
-                    Util.fromHex("f0f1f2f3f4f5f6f7f8f9"),
-                    42
-                )
-            )
+            Crypto.hkdf(
+                Algorithm.HMAC_SHA256,
+                "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b".fromHex,
+                "000102030405060708090a0b0c".fromHex,
+                "f0f1f2f3f4f5f6f7f8f9".fromHex,
+                42
+            ).toHex
         )
     }
 

--- a/identity/src/test/java/com/android/identity/util/HexUtilTest.kt
+++ b/identity/src/test/java/com/android/identity/util/HexUtilTest.kt
@@ -1,0 +1,59 @@
+package com.android.identity.util
+
+import org.junit.Assert
+import org.junit.Test
+import kotlin.random.Random
+
+class HexUtilTest {
+
+    @Test
+    fun toHex() {
+        Assert.assertEquals("", HexUtil.toHex(byteArrayOf()))
+        Assert.assertEquals(
+            "00ff13ab0b",
+            HexUtil.toHex(byteArrayOf(0x00, 0xff.toByte(), 0x13, 0xAB.toByte(), 0x0B))
+        )
+    }
+
+    @Test
+    fun fromHex() {
+        Assert.assertArrayEquals(ByteArray(0), HexUtil.fromHex(""))
+        Assert.assertArrayEquals(
+            byteArrayOf(0x00, 0xFF.toByte(), 0x13, 0xAB.toByte(), 0x0B),
+            HexUtil.fromHex("00ff13ab0b")
+        )
+        Assert.assertArrayEquals(
+            byteArrayOf(0x00, 0xFF.toByte(), 0x13, 0xAB.toByte(), 0x0B),
+            HexUtil.fromHex("00FF13AB0B")
+        )
+    }
+
+    @Test
+    fun toHexFromHexRoundTrip() {
+        val random = Random(31337) // deterministic but arbitrary
+        for (numBytes in intArrayOf(0, 1, 2, 10, 50000)) {
+            val bytes = ByteArray(numBytes)
+            random.nextBytes(bytes)
+            Assert.assertArrayEquals(bytes, HexUtil.fromHex(HexUtil.toHex(bytes)))
+        }
+    }
+
+    @Test
+    fun fromHexThrows() {
+        Assert.assertThrows(IllegalArgumentException::class.java) { HexUtil.fromHex("0") }
+        Assert.assertThrows(IllegalArgumentException::class.java) { HexUtil.fromHex("XX") }
+    }
+
+    @Test
+    fun extensions() {
+        Assert.assertArrayEquals(
+            "deadbeef".fromHex,
+            byteArrayOf(0xde.toByte(), 0xad.toByte(), 0xbe.toByte(), 0xef.toByte())
+        )
+        Assert.assertEquals(
+            byteArrayOf(0xde.toByte(), 0xad.toByte(), 0xbe.toByte(), 0xef.toByte()).toHex,
+            "deadbeef"
+        )
+    }
+
+}


### PR DESCRIPTION
Also migrate all code to use HexUtil instead of Util.fromHex() and Util.toHex(). This is part of the work on getting rid of Util.kt.

Test: All unit tests pass.
