### PR TITLE
Fix race when receiving an issuer update notification.

### DIFF
--- a/identity/src/main/java/com/android/identity/credential/CredentialUtil.kt
+++ b/identity/src/main/java/com/android/identity/credential/CredentialUtil.kt
@@ -17,6 +17,7 @@ package com.android.identity.credential
 
 import com.android.identity.securearea.CreateKeySettings
 import com.android.identity.securearea.SecureArea
+import com.android.identity.util.Logger
 import com.android.identity.util.Timestamp
 
 /**
@@ -97,8 +98,11 @@ object CredentialUtil {
             numKeysNotNeedingReplacement++
         }
 
-        val numExistingPendingKeys =
+        var numExistingPendingKeys =
             credential.pendingAuthenticationKeys.filter { it.domain == domain }.size
+        if (dryRun) {
+            numExistingPendingKeys += numReplacementsGenerated
+        }
 
         // It's possible we need to generate pending keys that aren't replacements
         val numNonReplacementsToGenerate = (numAuthenticationKeys

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdlIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdlIssuingAuthority.kt
@@ -108,7 +108,6 @@ abstract class SelfSignedMdlIssuingAuthority(
         ensureDocumentSigningKey()
         val mso = msoGenerator.generate()
         val taggedEncodedMso = Cbor.encode(Tagged(Tagged.ENCODED_CBOR, Bstr(mso)))
-        val issuerCertChain = listOf(documentSigningKeyCert)
         val protectedHeaders = mapOf<CoseLabel, DataItem>(Pair(
             CoseNumberLabel(Cose.COSE_LABEL_ALG),
             Algorithm.ES256.coseAlgorithmIdentifier.toDataItem
@@ -222,9 +221,9 @@ abstract class SelfSignedMdlIssuingAuthority(
         }
 
         val paint = Paint(Paint.ANTI_ALIAS_FLAG)
-        paint.setColor(android.graphics.Color.WHITE)
+        paint.setColor(Color.WHITE)
         paint.textSize = bitmap.width / 10.0f
-        paint.setShadowLayer(2.0f, 1.0f, 1.0f, android.graphics.Color.BLACK)
+        paint.setShadowLayer(2.0f, 1.0f, 1.0f, Color.BLACK)
         val bounds = Rect()
         paint.getTextBounds(artworkText, 0, artworkText.length, bounds)
         val textPadding = bitmap.width/25f

--- a/wallet/src/main/java/com/android/identity_credential/wallet/presentation/TransferHelper.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/presentation/TransferHelper.kt
@@ -2,7 +2,10 @@ package com.android.identity_credential.wallet.presentation
 
 import android.content.Context
 import android.content.SharedPreferences
+import android.os.Handler
+import android.os.Looper
 import android.preference.PreferenceManager
+import android.widget.Toast
 import com.android.identity.android.mdoc.deviceretrieval.DeviceRetrievalHelper
 import com.android.identity.cbor.Cbor
 import com.android.identity.credential.AuthenticationKey
@@ -28,12 +31,12 @@ import com.android.identity.trustmanagement.TrustPoint
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity.util.Timestamp
+import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.SelfSignedMdlIssuingAuthority
 import com.android.identity_credential.wallet.WalletApplication
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.withContext
-import java.util.OptionalLong
 import kotlin.coroutines.resume
 
 /**
@@ -239,7 +242,16 @@ class TransferHelper(
                     )
                     .generate()
             )
-
+            authKey.increaseUsageCount()
+            if (authKey.usageCount > 1) {
+                Handler(Looper.getMainLooper()).post {
+                    Toast.makeText(
+                        context,
+                        context.resources.getString(R.string.presentation_authkey_usage_warning),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
+            }
             result = null
         } catch (e: KeyLockedException) {
             result = authKey

--- a/wallet/src/main/res/values/plurals.xml
+++ b/wallet/src/main/res/values/plurals.xml
@@ -24,4 +24,8 @@
         <item quantity="one">%d minute</item>
         <item quantity="other">%d minutes</item>
     </plurals>
+    <plurals name="refreshed_authkey">
+        <item quantity="one">Refreshed %d Authentication Key</item>
+        <item quantity="other">Refreshed %d Authentication Keys</item>
+    </plurals>
 </resources>

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -81,7 +81,7 @@
     <string name="provisioning_unexpected">Unexpected state: %1$s</string>
 
     <!-- Presentation screen -->
-    <string name="presentation_authkey_usage_warning">Using previously used Auth Key</string>
+    <string name="presentation_authkey_usage_warning">Reused Authentication Key</string>
     <string name="presentation_biometric_prompt_title">Authentication Required</string>
 
     <!-- QR screen -->


### PR DESCRIPTION
At provisioning the issuer sends out multiple "the credential has changed" updates which we process in separate threads from CardViewModel by running Credential.housekeeping() to call back into the issuer and run the issuance flow. Fix this race by seralizing these housekeeping() calls. Add a note that in the future we might want to do this more elegantly through e.g. a channel.

Fix a bug in where we forgot to increase the use-count at presentation time. Also show a Toast if the auth-key being used has previously been used.

If forcibly refreshing a credential, show a toast conveying how many authentication keys were refreshed.

Fix a bug in CredentialUtil.managedAuthenticationKeyHelper() where we miscounted the number of pending authentication keys on a dry run.

Test: All unit tests pass.
Test: Manually tested.
