### PR TITLE
Change Biometric Prompt Title/Subtitle in Presentation Activity

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/BiometricUserAuthPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/BiometricUserAuthPrompt.kt
@@ -16,6 +16,7 @@ import com.android.identity.android.securearea.UserAuthenticationType
  *
  * @param activity the activity hosting the authentication prompt
  * @param title the title for the authentication prompt
+ * @param subtitle the subtitle for the authentication prompt
  * @param cryptoObject a crypto object to be associated with this authentication
  * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
  *                                least one element
@@ -28,6 +29,7 @@ import com.android.identity.android.securearea.UserAuthenticationType
 fun showBiometricPrompt(
     activity: FragmentActivity,
     title: String,
+    subtitle: String,
     cryptoObject: BiometricPrompt.CryptoObject?,
     userAuthenticationTypes: Set<UserAuthenticationType>,
     requireConfirmation: Boolean,
@@ -46,6 +48,7 @@ fun showBiometricPrompt(
     BiometricUserAuthPrompt(
         activity = activity,
         title = title,
+        subtitle = subtitle,
         cryptoObject = cryptoObject,
         userAuthenticationTypes = userAuthenticationTypes,
         requireConfirmation = requireConfirmation,
@@ -58,6 +61,7 @@ fun showBiometricPrompt(
 private class BiometricUserAuthPrompt(
     private val activity: FragmentActivity,
     private val title: String,
+    private val subtitle: String,
     private val cryptoObject: BiometricPrompt.CryptoObject?,
     private val userAuthenticationTypes: Set<UserAuthenticationType>,
     private val requireConfirmation: Boolean,
@@ -125,6 +129,7 @@ private class BiometricUserAuthPrompt(
 
         val biometricPromptInfo = PromptInfo.Builder()
             .setTitle(title)
+            .setSubtitle(subtitle)
             .setNegativeButtonText(negativeTxt)
             .setConfirmationRequired(requireConfirmation)
             .build()
@@ -141,6 +146,7 @@ private class BiometricUserAuthPrompt(
 
         val lskfPromptInfo = PromptInfo.Builder()
             .setTitle(title)
+            .setSubtitle(subtitle)
             .setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
             .setConfirmationRequired(requireConfirmation)
             .build()

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -176,6 +176,7 @@ class PresentationActivity : FragmentActivity() {
         showBiometricPrompt(
             activity = this,
             title = applicationContext.resources.getString(R.string.presentation_biometric_prompt_title),
+            subtitle = applicationContext.resources.getString(R.string.presentation_biometric_prompt_subtitle),
             cryptoObject = cryptoObject,
             userAuthenticationTypes = userAuthenticationTypes,
             requireConfirmation = false,

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -82,7 +82,8 @@
 
     <!-- Presentation screen -->
     <string name="presentation_authkey_usage_warning">Reused Authentication Key</string>
-    <string name="presentation_biometric_prompt_title">Authentication Required</string>
+    <string name="presentation_biometric_prompt_title">Use your screen lock</string>
+    <string name="presentation_biometric_prompt_subtitle">Authentication is required to share this information</string>
 
     <!-- QR screen -->
     <string name="qr_title">QR Code</string>


### PR DESCRIPTION
Modified showBiometricPrompt to take in a subtitle and updated the strings passed by PresentationActivity to be more informative.

Tested manually. 