### PR TITLE
Add method MdocDataElement.renderValue() to nicely render values.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/document/DocumentManager.kt
@@ -101,6 +101,14 @@ class DocumentManager private constructor(private val context: Context) {
                     )
                 }
 
+                is CredentialAttributeType.Number -> {
+                    builder.putEntryNumber(
+                        field.namespace!!,
+                        field.name,
+                        field.getValueLong()
+                    )
+                }
+
                 is CredentialAttributeType.Boolean -> {
                     builder.putEntryBoolean(
                         field.namespace!!,

--- a/appverifier/build.gradle
+++ b/appverifier/build.gradle
@@ -73,6 +73,7 @@ dependencies {
     implementation libs.bundles.compose
     implementation libs.cbor
     implementation libs.code.scanner
+    implementation libs.kotlinx.datetime
 
     androidTestImplementation libs.bundles.ui.testing
 

--- a/identity/src/main/java/com/android/identity/cbor/Cbor.kt
+++ b/identity/src/main/java/com/android/identity/cbor/Cbor.kt
@@ -303,21 +303,25 @@ object Cbor {
             MajorType.BYTE_STRING -> {
                 when (item) {
                     is IndefLengthBstr -> {
-                        sb.append("(_")
-                        var count = 0
-                        for (chunk in item.chunks) {
-                            if (count++ == 0) {
-                                sb.append(" h'")
-                            } else {
-                                sb.append(", h'")
+                        if (DiagnosticOption.BSTR_PRINT_LENGTH in options) {
+                            sb.append("indefinite-size byte-string")
+                        } else {
+                            sb.append("(_")
+                            var count = 0
+                            for (chunk in item.chunks) {
+                                if (count++ == 0) {
+                                    sb.append(" h'")
+                                } else {
+                                    sb.append(", h'")
+                                }
+                                for (b in chunk) {
+                                    sb.append(HEX_DIGITS[b.toInt().and(0xff) shr 4])
+                                    sb.append(HEX_DIGITS[b.toInt().and(0x0f)])
+                                }
+                                sb.append('\'')
                             }
-                            for (b in chunk) {
-                                sb.append(HEX_DIGITS[b.toInt().and(0xff) shr 4])
-                                sb.append(HEX_DIGITS[b.toInt().and(0x0f)])
-                            }
-                            sb.append('\'')
+                            sb.append(')')
                         }
-                        sb.append(')')
                     }
 
                     is Bstr -> {
@@ -332,12 +336,19 @@ object Cbor {
                             }
                             sb.append(" >>")
                         } else {
-                            sb.append("h'")
-                            for (b in item.value) {
-                                sb.append(HEX_DIGITS[b.toInt().and(0xff) shr 4])
-                                sb.append(HEX_DIGITS[b.toInt().and(0x0f)])
+                            if (DiagnosticOption.BSTR_PRINT_LENGTH in options) {
+                                when (item.value.size) {
+                                    1 -> sb.append("${item.value.size} byte")
+                                    else -> sb.append("${item.value.size} bytes")
+                                }
+                            } else {
+                                sb.append("h'")
+                                for (b in item.value) {
+                                    sb.append(HEX_DIGITS[b.toInt().and(0xff) shr 4])
+                                    sb.append(HEX_DIGITS[b.toInt().and(0x0f)])
+                                }
+                                sb.append("'")
                             }
-                            sb.append("'")
                         }
                     }
 

--- a/identity/src/main/java/com/android/identity/cbor/DataItemExtensions.kt
+++ b/identity/src/main/java/com/android/identity/cbor/DataItemExtensions.kt
@@ -1,6 +1,7 @@
 package com.android.identity.cbor
 
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.toInstant
 
 /**
@@ -89,3 +90,10 @@ val Long.toDataItemDateTimeString: DataItem
 val String.toDataItemDateTimeString: DataItem
     get() = this.toInstant().toDataItemDateTimeString
 
+/**
+ * Extension to get a full-date data item as specified in RFC 8943.
+ *
+ * The tagged text string is represented as specified by the RFC 3339 full-date production.
+ */
+val LocalDate.toDataItemFullDate: DataItem
+    get() = Tagged(Tagged.FULL_DATE_STRING, Tstr(this.toString()))

--- a/identity/src/main/java/com/android/identity/cbor/DiagnosticOption.kt
+++ b/identity/src/main/java/com/android/identity/cbor/DiagnosticOption.kt
@@ -12,5 +12,11 @@ enum class DiagnosticOption {
     /**
      * Inserts newlines and indentation to make the output more readable.
      */
-    PRETTY_PRINT
+    PRETTY_PRINT,
+
+    /**
+     * Prints "<length> bytes" or "indefinite-size byte-string" instead of the bytes in the byte
+     * string.
+     */
+    BSTR_PRINT_LENGTH
 }

--- a/identity/src/main/java/com/android/identity/credentialtype/MdocDataElement.kt
+++ b/identity/src/main/java/com/android/identity/credentialtype/MdocDataElement.kt
@@ -16,6 +16,18 @@
 
 package com.android.identity.credentialtype
 
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.DataItem
+import com.android.identity.cbor.Tagged
+import com.android.identity.cbor.DiagnosticOption
+import com.android.identity.util.Logger
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.LocalTime
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
 /**
  * Class containing the metadata of a data element of an mDoc
  * Credential Type
@@ -24,7 +36,115 @@ package com.android.identity.credentialtype
  * @param mandatory a mDoc specific indication whether the
  * data element is mandatory
  */
-class MdocDataElement(
+data class MdocDataElement(
     val attribute: CredentialAttribute,
     val mandatory: Boolean
-)
+) {
+    companion object {
+        private const val TAG = "MdocDataElement"
+    }
+
+    /**
+     * Renders the value of this data element as a string.
+     *
+     * The returned value is suitable for displaying in an user interface.
+     *
+     * This method never throws an exception, if an error happens it falls back
+     * to returning the CBOR rendered as diagnostics using [Cbor.toDiagnostics]
+     * using the flag [DiagnosticOption.BSTR_PRINT_LENGTH].
+     *
+     * @param value the value, as a CBOR data item
+     * @param timeZone the time zone to use, for rendering date-time. It is never used
+     * for rendering a full-date.
+     * @param trueFalseStrings a pair with the strings to use for false and true.
+     * @return a string representing the value.
+     */
+    fun renderValue(
+        value: DataItem,
+        timeZone: TimeZone = TimeZone.currentSystemDefault(),
+        trueFalseStrings: Pair<String, String> = Pair("false", "true")
+    ): String {
+        val diagnosticsOptions = setOf(DiagnosticOption.BSTR_PRINT_LENGTH)
+        val ret = try {
+            when (attribute.type) {
+                // TODO: translations? maybe take the strings to use for true/false as a param
+                CredentialAttributeType.Boolean -> {
+                    if (value.asBoolean)
+                        trueFalseStrings.second
+                    else
+                        trueFalseStrings.first
+                }
+
+                CredentialAttributeType.ComplexType -> Cbor.toDiagnostics(value)
+
+                CredentialAttributeType.Date -> {
+                    // value can be either tdate or full-date
+                    val tagNumber = (value as Tagged).tagNumber
+                    val dt = when (tagNumber) {
+                        Tagged.FULL_DATE_STRING -> {
+                            LocalDateTime(
+                                LocalDate.parse(value.asTagged.asTstr),
+                                LocalTime(0, 0, 0)
+                            )
+                        }
+                        Tagged.DATE_TIME_STRING -> {
+                            val pointInTime = Instant.parse(value.asTagged.asTstr)
+                            pointInTime.toLocalDateTime(timeZone)
+                        }
+                        else -> {
+                            throw IllegalArgumentException("Unexpected tag $tagNumber")
+                        }
+                    }
+                    // TODO: use DateTimeFormat in kotlinx-datetime 0.6.0 when released
+                    String.format(
+                        "%04d-%02d-%02d", dt.year, dt.monthNumber, dt.dayOfMonth
+                    )
+                }
+
+                CredentialAttributeType.DateTime -> {
+                    // value can be either tdate or full-date
+                    val tagNumber = (value as Tagged).tagNumber
+                    val dt = when (tagNumber) {
+                        Tagged.FULL_DATE_STRING -> {
+                            LocalDateTime(
+                                LocalDate.parse(value.asTagged.asTstr),
+                                LocalTime(0, 0, 0)
+                            )
+                        }
+                        Tagged.DATE_TIME_STRING -> {
+                            val pointInTime = Instant.parse(value.asTagged.asTstr)
+                            pointInTime.toLocalDateTime(timeZone)
+                        }
+                        else -> {
+                            throw IllegalArgumentException("Unexpected tag $tagNumber")
+                        }
+                    }
+                    // TODO: use DateTimeFormat in kotlinx-datetime 0.6.0 when released
+                    String.format(
+                        "%04d-%02d-%02d %02d:%02d:%02d",
+                        dt.year, dt.monthNumber, dt.dayOfMonth, dt.time.hour, dt.time.minute, dt.time.second
+                    )
+                }
+
+                is CredentialAttributeType.IntegerOptions -> {
+                    val option = attribute.type.options.find { it.value == value.asNumber.toInt() }
+                    option?.displayName ?: value.asNumber.toString()
+                }
+                CredentialAttributeType.Number -> value.asNumber.toString()
+                CredentialAttributeType.Picture -> Cbor.toDiagnostics(value, diagnosticsOptions)
+                CredentialAttributeType.String -> value.asTstr
+                is CredentialAttributeType.StringOptions -> {
+                    val option = attribute.type.options.find { it.value == value.asTstr }
+                    option?.displayName ?: value.asTstr
+                }
+            }
+        } catch (e: Throwable) {
+            val diagnosticsString = Cbor.toDiagnostics(value, diagnosticsOptions)
+            Logger.w(TAG, "Error decoding value $diagnosticsString for data element " +
+                    "${attribute.identifier}, falling back to diagnostics", e)
+            diagnosticsString
+        }
+
+        return ret
+    }
+}

--- a/identity/src/test/java/com/android/identity/credentialtype/TestCredentialTypeRepository.kt
+++ b/identity/src/test/java/com/android/identity/credentialtype/TestCredentialTypeRepository.kt
@@ -1,6 +1,18 @@
 package com.android.identity.credentialtype
 
+import com.android.identity.cbor.Bstr
+import com.android.identity.cbor.CborArray
+import com.android.identity.cbor.Simple
+import com.android.identity.cbor.Tagged
+import com.android.identity.cbor.Tstr
+import com.android.identity.cbor.Uint
+import com.android.identity.cbor.toDataItemDateTimeString
+import com.android.identity.cbor.toDataItemFullDate
 import com.android.identity.credentialtype.knowntypes.DrivingLicense
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.TimeZone
+import org.junit.Assert
 import org.junit.Test
 
 class TestCredentialTypeRepository {
@@ -36,7 +48,185 @@ class TestCredentialTypeRepository {
                 "domestic_driving_privileges"
             )?.attribute?.type == CredentialAttributeType.ComplexType
         )
+    }
 
+    @Test
+    fun testRenderValueAsString() {
+        val ct = DrivingLicense.getCredentialType()
+        val mdlNs = ct.mdocCredentialType!!.namespaces[DrivingLicense.MDL_NAMESPACE]!!
+        val aamvaNs = ct.mdocCredentialType!!.namespaces[DrivingLicense.AAMVA_NAMESPACE]!!
+
+        // CredentialAttributeType.Boolean
+        Assert.assertEquals(
+            "true",
+            mdlNs.dataElements["age_over_18"]?.renderValue(Simple.TRUE)
+        )
+        Assert.assertEquals(
+            "false",
+            mdlNs.dataElements["age_over_18"]?.renderValue(Simple.FALSE)
+        )
+        Assert.assertEquals(
+            "yes",
+            mdlNs.dataElements["age_over_18"]?.renderValue(
+                Simple.TRUE, trueFalseStrings = Pair("no", "yes"))
+        )
+        Assert.assertEquals(
+            "no",
+            mdlNs.dataElements["age_over_18"]?.renderValue(
+                Simple.FALSE, trueFalseStrings = Pair("no", "yes"))
+        )
+
+        // CredentialAttributeType.String
+        Assert.assertEquals(
+            "Erika",
+            mdlNs.dataElements["given_name"]?.renderValue(Tstr("Erika"))
+        )
+
+        // CredentialAttributeType.Number
+        Assert.assertEquals(
+            "180",
+            mdlNs.dataElements["height"]?.renderValue(Uint(180UL))
+        )
+
+        // CredentialAttributeType.IntegerOptions
+        Assert.assertEquals(
+            "Donor",
+            aamvaNs.dataElements["organ_donor"]?.renderValue(Uint(1UL))
+        )
+        // If we don't know the enumerated value, check we render the raw value.
+        Assert.assertEquals(
+            "2",
+            aamvaNs.dataElements["organ_donor"]?.renderValue(Uint(2UL))
+        )
+
+        // CredentialAttributeType.StringOptions
+        Assert.assertEquals(
+            "Asian or Pacific Islander",
+            aamvaNs.dataElements["race_ethnicity"]?.renderValue(Tstr("AP"))
+        )
+        // If we don't know the enumerated value, check we render the raw value.
+        Assert.assertEquals(
+            "AddedLater",
+            aamvaNs.dataElements["race_ethnicity"]?.renderValue(Tstr("AddedLater"))
+        )
+
+        // CredentialAttributeType.Picture
+        Assert.assertEquals(
+            "0 bytes",
+            mdlNs.dataElements["portrait"]?.renderValue(Bstr(byteArrayOf()))
+        )
+        Assert.assertEquals(
+            "1 byte",
+            mdlNs.dataElements["portrait"]?.renderValue(Bstr(byteArrayOf(1)))
+        )
+        Assert.assertEquals(
+            "3 bytes",
+            mdlNs.dataElements["portrait"]?.renderValue(Bstr(byteArrayOf(1, 2, 3)))
+        )
+
+        // CredentialAttributeType.DateTime - supports both tdate and full-date
+        Assert.assertEquals(
+            "1976-02-03 06:30:00",
+            MdocDataElement(
+                CredentialAttribute(
+                    CredentialAttributeType.DateTime,
+                    "",
+                    "",
+                    "",
+                ),
+                false
+            ).renderValue(
+                Instant.parse("1976-02-03T05:30:00Z").toDataItemDateTimeString,
+                timeZone = TimeZone.of("Europe/Copenhagen")
+            )
+        )
+        // ... if using a full-date we render the point in time as midnight. The timezone
+        // isn't taken into account, check a couple of different timezones
+        for (zoneId in listOf("Europe/Copenhagen", "Australia/Brisbane", "Pacific/Honolulu")) {
+            Assert.assertEquals(
+                "1976-02-03 00:00:00",
+                MdocDataElement(
+                    CredentialAttribute(
+                        CredentialAttributeType.DateTime,
+                        "",
+                        "",
+                        "",
+                    ),
+                    false
+                ).renderValue(
+                    LocalDate.parse("1976-02-03").toDataItemFullDate,
+                    timeZone = TimeZone.of(zoneId)
+                )
+            )
+        }
+
+        // CredentialAttributeType.Date - supports both tdate and full-date... for tdate
+        // the timezone is taken into account, for full-date it isn't.
+        Assert.assertEquals(
+            "1976-02-03",
+            mdlNs.dataElements["birth_date"]?.renderValue(
+                Instant.parse("1976-02-03T05:30:00Z").toDataItemDateTimeString,
+                timeZone = TimeZone.of("Europe/Copenhagen")
+            )
+        )
+        Assert.assertEquals(
+            "1976-02-02",
+            mdlNs.dataElements["birth_date"]?.renderValue(
+                Instant.parse("1976-02-03T05:30:00Z").toDataItemDateTimeString,
+                timeZone = TimeZone.of("America/Los_Angeles")
+            )
+        )
+        Assert.assertEquals(
+            "1976-02-03",
+            mdlNs.dataElements["birth_date"]?.renderValue(
+                LocalDate.parse("1976-02-03").toDataItemFullDate,
+                timeZone = TimeZone.of("Europe/Copenhagen")
+            )
+        )
+        Assert.assertEquals(
+            "1976-02-03",
+            mdlNs.dataElements["birth_date"]?.renderValue(
+                LocalDate.parse("1976-02-03").toDataItemFullDate,
+                timeZone = TimeZone.of("America/Los_Angeles")
+            )
+        )
+
+        // CredentialAttributeType.ComplexType
+        val drivingPrivileges = CborArray.builder()
+            .addMap()
+            .put("vehicle_category_code", "A")
+            .put("issue_date", Tagged(1004, Tstr("2018-08-09")))
+            .put("expiry_date", Tagged(1004, Tstr("2024-10-20")))
+            .end()
+            .addMap()
+            .put("vehicle_category_code", "B")
+            .put("issue_date", Tagged(1004, Tstr("2017-02-23")))
+            .put("expiry_date", Tagged(1004, Tstr("2024-10-20")))
+            .end()
+            .end().build()
+        // Note, this isn't very nice but it's not clear we can do any better at this point,
+        // fitting complex stuff like this into a string is going to be a mess no matter how
+        // you slice or dice it.
+        //
+        // We could add the ability to add dedicated renderers at credential type registration
+        // time and those could return rich text, e.g. Markup. It's not clear that this would
+        // be an advantage of the app doing this itself. Maybe...
+        //
+        Assert.assertEquals(
+            "[{\"vehicle_category_code\": \"A\", \"issue_date\": 1004(\"2018-08-09\"), " +
+                    "\"expiry_date\": 1004(\"2024-10-20\")}, {\"vehicle_category_code\": \"B\", " +
+                    "\"issue_date\": 1004(\"2017-02-23\"), \"expiry_date\": 1004(\"2024-10-20\")}]",
+            mdlNs.dataElements["driving_privileges"]?.renderValue(drivingPrivileges)
+        )
+
+
+        // Now check that it does the right thing if a value is passed which
+        // isn't expected by the document type
+        Assert.assertEquals(
+            "3 bytes",
+            mdlNs.dataElements["portrait"]?.renderValue(Bstr(byteArrayOf(1, 2, 3)))
+        )
 
     }
+
 }


### PR DESCRIPTION
This takes the type of the value into account as per the CredentialTypeRepository and supports enumerations used for that particular DocType. For example, for in the AAMVA namespace instead of rendering "1" for data element `organ_donor`, it will render "Donor". Similarly, instead of rendering "AP" for data element `race_ethnicity` it will render "Asian or Pacific Islander".

Use this in appverifier to display the retrieved document and test with retrieving "Full mDL" from appholder to manually verify it's correct. This uncovered a bug in appholder where data elements for numbers were accidentially encoded as strings. Fix this.

This code will be used to render the values for the Credman credential picker which has "View details" button to see the value of the data elements which will be shared.

Test: New unit tests and all unit tests pass.
Test: Manually tested appverifier.
