### PR TITLE
Set the appropriate headers on IssuerAuth.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/util/ProvisioningUtil.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/ProvisioningUtil.kt
@@ -11,6 +11,7 @@ import android.graphics.Rect
 import com.android.identity.cbor.Bstr
 import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.Tagged
+import com.android.identity.cbor.toDataItem
 import com.android.identity.cose.Cose
 import com.android.identity.cose.CoseNumberLabel
 import com.android.identity.credential.Credential
@@ -194,13 +195,18 @@ class ProvisioningUtil private constructor(
                     taggedEncodedMso,
                     true,
                     Algorithm.ES256,
-                    mapOf(
+                    protectedHeaders = mapOf(
+                        Pair(
+                            CoseNumberLabel(Cose.COSE_LABEL_ALG),
+                            Algorithm.ES256.coseAlgorithmIdentifier.toDataItem
+                        )
+                    ),
+                    unprotectedHeaders = mapOf(
                         Pair(
                             CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
                             CertificateChain(listOf(Certificate(issuerCert.encoded))).dataItem
                         )
                     ),
-                    mapOf(),
                 ).toDataItem
             )
 


### PR DESCRIPTION
These headers (x5chain and alg) are required by 18013-5.

Test: Manually tested.
