### PR TITLE
Make appverifier work on the emulator.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
@@ -269,10 +269,13 @@ class RequestOptionsFragment() : Fragment() {
     override fun onResume() {
         super.onResume()
         checkRequiredPermissions()
-        transferManager.setNdefDeviceEngagement(
-            NfcAdapter.getDefaultAdapter(requireContext()),
-            requireActivity()
-        )
+        val adapter = NfcAdapter.getDefaultAdapter(requireContext())
+        if (adapter != null) {
+            transferManager.setNdefDeviceEngagement(
+                adapter,
+                requireActivity()
+            )
+        }
     }
 
     private fun checkRequiredPermissions() {


### PR DESCRIPTION
Of course in-person presentations won't work (those require QR/NFC and BLE) but this is useful for Credman presentations.

Test: Manually tested on emulator
