### PR TITLE
Fix for Consent Prompt showing a scrollable list of credentials to approve, resolving issue 543

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/consentprompt/ConsentPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/consentprompt/ConsentPrompt.kt
@@ -98,6 +98,7 @@ fun ConsentPrompt(
 
         Box(
             modifier = Modifier
+                .fillMaxHeight(0.8f)
                 .fillMaxWidth()
         ) {
             DataElementsListView(dataElements = consentDataElements)


### PR DESCRIPTION
Fixes issue https://github.com/openwallet-foundation-labs/identity-credential/issues/543 where if there are a large number of credential data requested now they are in a scrollable list with the bottom action buttons visible.


https://github.com/openwallet-foundation-labs/identity-credential/assets/1477025/98e3fb8d-36c9-44c1-9450-0f26ea979348

Tested manually for sharing of documents between Wallet and Verifier apps.