### PR TITLE
Add Warning for Users Without Secure Lock Screen

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -5,6 +5,7 @@ import androidx.compose.runtime.Composable
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.android.identity.android.securearea.AndroidKeystoreSecureArea
 import com.android.identity_credential.wallet.CardViewModel
 import com.android.identity_credential.wallet.PermissionTracker
 import com.android.identity_credential.wallet.ProvisioningViewModel
@@ -75,7 +76,8 @@ fun WalletNavigation(
                 qrEngagementViewModel = qrEngagementViewModel,
                 cardViewModel = cardViewModel,
                 settingsModel = application.settingsModel,
-                permissionTracker = permissionTracker
+                permissionTracker = permissionTracker,
+                context = application.applicationContext,
             )
         }
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/qrengagement/QrEngagementScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/qrengagement/QrEngagementScreen.kt
@@ -4,11 +4,8 @@ import android.graphics.Bitmap
 import android.graphics.Color
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -27,7 +24,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.dp
-import androidx.navigation.NavHostController
 import com.android.identity_credential.wallet.QrEngagementViewModel
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.navigation.WalletDestination

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -28,6 +28,12 @@
     <string name="wallet_screen_add">Add to Wallet</string>
     <string name="wallet_screen_permissions">Need permissions</string>
     <string name="wallet_screen_permissions_dismiss">Dismiss</string>
+    <string name="qr_lskf_warning_dismiss_btn">Ok</string>
+    <string name="qr_lskf_warning_dialog_title">Unable to Present Document</string>
+    <string name="qr_lskf_warning_dialog_text">In order to present the document, your device must have a lock-screen pin/password/pattern</string>
+    <string name="add_cred_lskf_warning_dismiss_btn">Ok</string>
+    <string name="add_cred_lskf_warning_dialog_title">Unable to Add Document</string>
+    <string name="add_cred_lskf_warning_dialog_text">In order to add a document to your wallet, your device must have a lock-screen pin/password/pattern</string>
 
     <!-- About screen -->
     <string name="about_screen_title">About Wallet</string>
@@ -100,6 +106,9 @@
     <string name="presentation_authkey_usage_warning">Reused Authentication Key</string>
     <string name="presentation_biometric_prompt_title">Use your screen lock</string>
     <string name="presentation_biometric_prompt_subtitle">Authentication is required to share this information</string>
+    <string name="presentation_lskf_warning_dismiss_btn">Ok</string>
+    <string name="presentation_lskf_warning_dialog_title">Unable to Present Document</string>
+    <string name="presentation_lskf_warning_dialog_text">In order to present the document, your device must have a lock-screen pin/password/pattern</string>
 
     <!-- QR screen -->
     <string name="qr_title">Share using QR code</string>


### PR DESCRIPTION
Both provisioning and presenting a credential in wallet require a secure lockscreen (ie. the user has set a pin/pattern/password). In order to improve UX when a user does not have one set, the PR adds a dialog to warn the users when functionality is blocked. 

![image](https://github.com/openwallet-foundation-labs/identity-credential/assets/69648786/5b3ecdb3-b7d5-4c9d-ac01-2b8afe68ddbe)

Fixes #534 