### PR TITLE
Don't re-add cards on configuration change.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/CardViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/CardViewModel.kt
@@ -338,6 +338,9 @@ class CardViewModel : ViewModel() {
         secureAreaRepository: SecureAreaRepository,
         credentialTypeRepository: CredentialTypeRepository
     ) {
+        if (this::context.isInitialized) {
+            return
+        }
         this.context = context
         this.credentialStore = credentialStore
         this.issuingAuthorityRepository = issuingAuthorityRepository


### PR DESCRIPTION
On a configuration change (e.g. device rotation) `MainActivity.onCreate()` is called which in turn calls `CardViewModel.setData()`. Because we didn't guard against this we ended up adding all cards to the view model.

Test: Manually tested
