### PR TITLE
Extracted Kotlin DSL updates to PR #517 for Kotlinizing Identity Android

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/transfer/QrCommunicationSetup.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/QrCommunicationSetup.kt
@@ -43,17 +43,20 @@ class QrCommunicationSetup(
             }
             log("OnDeviceConnected via QR: qrEngagement=$qrEngagement")
             val builder = DeviceRetrievalHelper.Builder(
-                context,
-                deviceRetrievalHelperListener,
-                context.mainExecutor(),
-                eDeviceKey
+                context = context,
+                listener = deviceRetrievalHelperListener,
+                executor = context.mainExecutor(),
+                eDeviceKey = eDeviceKey
             )
-            builder.useForwardEngagement(
-                transport,
-                qrEngagement.deviceEngagement,
-                qrEngagement.handover
-            )
-            deviceRetrievalHelper = builder.build()
+            deviceRetrievalHelper =
+                builder
+                    .useForwardEngagement(
+                        transport = transport,
+                        deviceEngagement = qrEngagement.deviceEngagement,
+                        handover = qrEngagement.handover
+                    )
+                    .build()
+
             qrEngagement.close()
             onDeviceRetrievalHelperReady(requireNotNull(deviceRetrievalHelper))
         }
@@ -87,20 +90,19 @@ class QrCommunicationSetup(
 
     fun configure() {
         qrEngagement = QrEngagementHelper.Builder(
-            context,
-            eDeviceKey.publicKey,
-            connectionSetup.getConnectionOptions(),
-            qrEngagementListener,
-            context.mainExecutor()
+            context = context,
+            eDeviceKey = eDeviceKey.publicKey,
+            options = connectionSetup.getConnectionOptions(),
+            listener = qrEngagementListener,
+            executor = context.mainExecutor()
         ).setConnectionMethods(connectionSetup.getConnectionMethods())
             .build()
     }
 
-    fun close() {
+    fun close() =
         try {
             qrEngagement.close()
         } catch (exception: RuntimeException) {
             log("Error closing QR engagement", exception)
         }
-    }
 }

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/ReverseQrCommunicationSetup.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/ReverseQrCommunicationSetup.kt
@@ -57,10 +57,8 @@ class ReverseQrCommunicationSetup(
             uri.encodedSchemeSpecificPart,
             Base64.URL_SAFE or Base64.NO_PADDING
         )
-        val engagement = EngagementParser(
-            encodedReaderEngagement
-        ).parse()
-        if (engagement.connectionMethods.size == 0) {
+        val engagement = EngagementParser(encodedReaderEngagement).parse()
+        if (engagement.connectionMethods.isEmpty()) {
             throw IllegalStateException("No connection methods in engagement")
         }
 
@@ -69,20 +67,21 @@ class ReverseQrCommunicationSetup(
         log("Using connection method $connectionMethod")
 
         val transport = DataTransport.fromConnectionMethod(
-            context,
-            connectionMethod,
-            DataTransport.Role.MDOC,
-            connectionSetup.getConnectionOptions()
+            context = context,
+            connectionMethod = connectionMethod,
+            role = DataTransport.Role.MDOC,
+            options = connectionSetup.getConnectionOptions()
         )
 
-        val builder = DeviceRetrievalHelper.Builder(
-            context,
-            presentationListener,
-            context.mainExecutor(),
-            eDeviceKey
-        )
-        builder.useReverseEngagement(transport, encodedReaderEngagement, origins)
-        presentation = builder.build()
+        presentation = DeviceRetrievalHelper
+            .Builder(
+                context = context,
+                listener = presentationListener,
+                executor = context.mainExecutor(),
+                eDeviceKey = eDeviceKey
+            )
+            .useReverseEngagement(transport, encodedReaderEngagement, origins)
+            .build()
         onPresentationReady(requireNotNull(presentation))
     }
 }

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowQrFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowQrFragment.kt
@@ -40,8 +40,9 @@ class ShowQrFragment : Fragment() {
     ): View {
 
         _binding = FragmentShowQrBinding.inflate(inflater, container, false)
-        transferManager = TransferManager.getInstance(requireContext())
-        transferManager.initVerificationHelperReverseEngagement()
+        transferManager = TransferManager.getInstance(requireContext()).apply {
+            initVerificationHelperReverseEngagement()
+        }
         return binding.root
     }
 
@@ -69,9 +70,11 @@ class ShowQrFragment : Fragment() {
         return bitmap
     }
 
-    private fun getViewForReaderEngagementQrCode(readerEngagement : ByteArray): View {
-        val base64Encoded = Base64.encodeToString(readerEngagement,
-            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP)
+    private fun getViewForReaderEngagementQrCode(readerEngagement: ByteArray): View {
+        val base64Encoded = Base64.encodeToString(
+            readerEngagement,
+            Base64.URL_SAFE or Base64.NO_PADDING or Base64.NO_WRAP
+        )
         val uriEncoded = Uri.Builder()
             .scheme("mdoc://")
             .encodedOpaquePart(base64Encoded)
@@ -101,11 +104,13 @@ class ShowQrFragment : Fragment() {
 
                 TransferStatus.CONNECTED -> {
                     logDebug("Connected")
-                    val requestedDocuments = createRequestViewModel.calculateRequestDocumentList(false)
+                    val requestedDocuments =
+                        createRequestViewModel.calculateRequestDocumentList(false)
                     findNavController().navigate(
                         ShowQrFragmentDirections.actionShowQrToTransfer(requestedDocuments)
                     )
                 }
+
                 else -> {}
             }
         }

--- a/identity-android/src/androidTest/java/com/android/identity/AndroidAttestationExtensionParser.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/AndroidAttestationExtensionParser.kt
@@ -49,44 +49,41 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
     val teeEnforcedAuthorizationTags: Set<Int>
         get() = teeEnforcedAuthorizations.keys
 
-    fun getSoftwareAuthorizationInteger(tag: Int): Optional<Int> {
-        val entry = findAuthorizationListEntry(softwareEnforcedAuthorizations, tag)
-        return Optional.ofNullable(entry)
-            .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
-    }
+    fun getSoftwareAuthorizationInteger(tag: Int): Optional<Int> =
+        findAuthorizationListEntry(softwareEnforcedAuthorizations, tag).let { entry ->
+            Optional.ofNullable(entry)
+                .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
+        }
 
-    fun getSoftwareAuthorizationLong(tag: Int): Optional<Long> {
-        val entry = findAuthorizationListEntry(softwareEnforcedAuthorizations, tag)
-        return Optional.ofNullable(entry)
-            .map { asn1Value: ASN1Primitive -> getLongFromAsn1(asn1Value) }
-    }
+    fun getSoftwareAuthorizationLong(tag: Int): Optional<Long> =
+        findAuthorizationListEntry(softwareEnforcedAuthorizations, tag).let { entry ->
+            Optional.ofNullable(entry)
+                .map { asn1Value: ASN1Primitive -> getLongFromAsn1(asn1Value) }
+        }
 
-    fun getTeeAuthorizationInteger(tag: Int): Optional<Int> {
-        val entry = findAuthorizationListEntry(teeEnforcedAuthorizations, tag)
-        return Optional.ofNullable(entry)
-            .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
-    }
+    fun getTeeAuthorizationInteger(tag: Int): Optional<Int> =
+        findAuthorizationListEntry(teeEnforcedAuthorizations, tag).let { entry ->
+            Optional.ofNullable(entry)
+                .map { asn1Value: ASN1Primitive -> getIntegerFromAsn1(asn1Value) }
+        }
 
-    fun getSoftwareAuthorizationBoolean(tag: Int): Boolean {
-        val entry = findAuthorizationListEntry(softwareEnforcedAuthorizations, tag)
-        return entry != null
-    }
+    fun getSoftwareAuthorizationBoolean(tag: Int): Boolean =
+        findAuthorizationListEntry(softwareEnforcedAuthorizations, tag) != null
 
-    fun getTeeAuthorizationBoolean(tag: Int): Boolean {
-        val entry = findAuthorizationListEntry(teeEnforcedAuthorizations, tag)
-        return entry != null
-    }
+    fun getTeeAuthorizationBoolean(tag: Int): Boolean =
+        findAuthorizationListEntry(teeEnforcedAuthorizations, tag) != null
 
-    fun getSoftwareAuthorizationByteString(tag: Int): Optional<ByteArray> {
-        val entry =
-            findAuthorizationListEntry(softwareEnforcedAuthorizations, tag) as ASN1OctetString?
-        return Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
-    }
+    fun getSoftwareAuthorizationByteString(tag: Int): Optional<ByteArray> =
+        (findAuthorizationListEntry(softwareEnforcedAuthorizations, tag) as ASN1OctetString?)
+            .let { entry ->
+                Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
+            }
 
-    fun getTeeAuthorizationByteString(tag: Int): Optional<ByteArray> {
-        val entry = findAuthorizationListEntry(teeEnforcedAuthorizations, tag) as ASN1OctetString?
-        return Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
-    }
+    fun getTeeAuthorizationByteString(tag: Int): Optional<ByteArray> =
+        (findAuthorizationListEntry(teeEnforcedAuthorizations, tag) as ASN1OctetString?)
+            .let { entry ->
+                Optional.ofNullable(entry).map { obj: ASN1OctetString -> obj.octets }
+            }
 
     init {
         val attestationExtensionBytes = cert.getExtensionValue(KEY_DESCRIPTION_OID)
@@ -144,18 +141,17 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
             return authorizationMap.getOrDefault(tag, null)
         }
 
-        private fun getBooleanFromAsn1(asn1Value: ASN1Encodable): Boolean {
-            return if (asn1Value is ASN1Boolean) {
+        private fun getBooleanFromAsn1(asn1Value: ASN1Encodable): Boolean =
+            if (asn1Value is ASN1Boolean) {
                 asn1Value.isTrue
             } else {
                 throw RuntimeException(
                     "Boolean value expected; found " + asn1Value.javaClass.name + " instead."
                 )
             }
-        }
 
-        private fun getIntegerFromAsn1(asn1Value: ASN1Encodable): Int {
-            return if (asn1Value is ASN1Integer) {
+        private fun getIntegerFromAsn1(asn1Value: ASN1Encodable): Int =
+            if (asn1Value is ASN1Integer) {
                 asn1Value.value.toInt()
             } else if (asn1Value is ASN1Enumerated) {
                 asn1Value.value.toInt()
@@ -164,10 +160,9 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
                     "Integer value expected; found " + asn1Value.javaClass.name + " instead."
                 )
             }
-        }
 
-        private fun getLongFromAsn1(asn1Value: ASN1Encodable): Long {
-            return if (asn1Value is ASN1Integer) {
+        private fun getLongFromAsn1(asn1Value: ASN1Encodable): Long =
+            if (asn1Value is ASN1Integer) {
                 asn1Value.value.toLong()
             } else if (asn1Value is ASN1Enumerated) {
                 asn1Value.value.toLong()
@@ -176,26 +171,22 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
                     "Integer value expected; found " + asn1Value.javaClass.name + " instead."
                 )
             }
-        }
 
         private fun getAuthorizationMap(
             authorizationList: Array<ASN1Encodable>
-        ): Map<Int, ASN1Primitive?> {
-            val authorizationMap: MutableMap<Int, ASN1Primitive?> = HashMap()
-            for (entry in authorizationList) {
-                val taggedEntry = entry as ASN1TaggedObject
-                authorizationMap[taggedEntry.tagNo] = taggedEntry.getObject()
+        ): Map<Int, ASN1Primitive?> = mutableMapOf<Int, ASN1Primitive?>().apply {
+            authorizationList.forEach { taggedEntry ->
+                taggedEntry as ASN1TaggedObject
+                this[taggedEntry.tagNo] = taggedEntry.getObject()
             }
-            return authorizationMap
         }
 
-        private fun securityLevelToEnum(securityLevel: Int): SecurityLevel {
-            return when (securityLevel) {
+        private fun securityLevelToEnum(securityLevel: Int): SecurityLevel =
+            when (securityLevel) {
                 KM_SECURITY_LEVEL_SOFTWARE -> SecurityLevel.SOFTWARE
                 KM_SECURITY_LEVEL_TRUSTED_ENVIRONMENT -> SecurityLevel.TRUSTED_ENVIRONMENT
                 KM_SECURITY_LEVEL_STRONG_BOX -> SecurityLevel.STRONG_BOX
                 else -> throw IllegalArgumentException("Invalid security level.")
             }
-        }
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.kt
@@ -207,6 +207,8 @@ class QrEngagementHelper internal constructor(
 
     // Note: The report*() methods are safe to call from any thread.
 
+    // TODO replace executor.execute calls with coroutines
+
     private fun reportDeviceConnecting() {
         Logger.d(TAG, "reportDeviceConnecting")
         val listener = listener
@@ -332,13 +334,13 @@ class QrEngagementHelper internal constructor(
          */
         fun build(): QrEngagementHelper {
             return QrEngagementHelper(
-                context,
-                eDeviceKey,
-                connectionMethods,
-                transports,
-                options,
-                listener,
-                executor
+                context = context,
+                eDeviceKey = eDeviceKey,
+                connectionMethods = connectionMethods,
+                transports = transports,
+                options = options,
+                listener = listener,
+                executor = executor
             )
         }
     }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodTcp.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodTcp.kt
@@ -12,18 +12,14 @@ class ConnectionMethodTcp(val host: String, val port: Int) : ConnectionMethod() 
             CborArray.builder()
                 .add(METHOD_TYPE)
                 .add(METHOD_MAX_VERSION)
-                .add(
-                    CborMap.builder()
-                        .apply {
-                            put(OPTION_KEY_HOST, host)
-                            put(OPTION_KEY_PORT, port.toLong())
-                        }
-                        .end()
-                        .build()
-                )
+                .addMap().apply {
+                    put(OPTION_KEY_HOST, host)
+                    put(OPTION_KEY_PORT, port.toLong())
+                }.end()
                 .end()
                 .build()
         )
+
 
 
     override fun toString(): String = "tcp:host=$host:port=$port"

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodUdp.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodUdp.kt
@@ -12,14 +12,10 @@ class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() 
             CborArray.builder()
                 .add(METHOD_TYPE)
                 .add(METHOD_MAX_VERSION)
-                .add(
-                    CborMap.builder().apply {
-                        put(OPTION_KEY_HOST, host)
-                        put(OPTION_KEY_PORT, port.toLong())
-                    }
-                        .end()
-                        .build()
-                )
+                .addMap().apply {
+                    put(OPTION_KEY_HOST, host)
+                    put(OPTION_KEY_PORT, port.toLong())
+                }.end()
                 .end()
                 .build()
         )

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodUdp.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/ConnectionMethodUdp.kt
@@ -7,23 +7,25 @@ import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 
 class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() {
 
-    override fun toDeviceEngagement(): ByteArray {
-        val mapBuilder = CborMap.builder()
-        mapBuilder.put(OPTION_KEY_HOST, host)
-        mapBuilder.put(OPTION_KEY_PORT, port.toLong())
-        return Cbor.encode(
+    override fun toDeviceEngagement(): ByteArray =
+        Cbor.encode(
             CborArray.builder()
                 .add(METHOD_TYPE)
                 .add(METHOD_MAX_VERSION)
-                .add(mapBuilder.end().build())
+                .add(
+                    CborMap.builder().apply {
+                        put(OPTION_KEY_HOST, host)
+                        put(OPTION_KEY_PORT, port.toLong())
+                    }
+                        .end()
+                        .build()
+                )
                 .end()
                 .build()
         )
-    }
 
-    override fun toString(): String {
-        return "udp:host=$host:port=$port"
-    }
+
+    override fun toString(): String = "udp:host=$host:port=$port"
 
     companion object {
         // NOTE: 18013-5 only allows positive integers, but our codebase also supports negative
@@ -33,19 +35,21 @@ class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() 
 
         private const val OPTION_KEY_HOST = 0L
         private const val OPTION_KEY_PORT = 1L
+
         @JvmStatic
-        fun fromDeviceEngagementUdp(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethodUdp? {
-            val array = Cbor.decode(encodedDeviceRetrievalMethod).asArray
-            val type = array[0].asNumber
-            val version = array[1].asNumber
-            require(type == METHOD_TYPE)
-            if (version > METHOD_MAX_VERSION) {
-                return null
+        fun fromDeviceEngagementUdp(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethodUdp? =
+            Cbor.decode(encodedDeviceRetrievalMethod).asArray.let { array ->
+                val version = array[1].asNumber
+                if (version > METHOD_MAX_VERSION) {
+                    return null
+                }
+                val type = array[0].asNumber
+                require(type == METHOD_TYPE)
+
+                val map = array[2]
+                val host = map[OPTION_KEY_HOST].asTstr
+                val port = map[OPTION_KEY_PORT].asNumber
+                ConnectionMethodUdp(host, port.toInt())
             }
-            val map = array[2]
-            val host = map[OPTION_KEY_HOST].asTstr
-            val port = map[OPTION_KEY_PORT].asNumber
-            return ConnectionMethodUdp(host, port.toInt())
-        }
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
@@ -389,11 +389,14 @@ class DataTransportBleCentralClientMode(
     }
 
     override fun sendMessage(data: ByteArray) {
-        require(data.isNotEmpty()) { "Data to send cannot be empty" }
-
-        l2capClient?.sendMessage(data)
-            ?: _gattServer?.sendMessage(data)
-            ?: _gattClient?.sendMessage(data)
+        require(data.size != 0) { "Data to send cannot be empty" }
+        if (l2capClient != null) {
+            l2capClient!!.sendMessage(data)
+        } else if (_gattServer != null) {
+            gattServer.sendMessage(data)
+        } else if (_gattClient != null) {
+            gattClient.sendMessage(data)
+        }
     }
 
     override fun sendTransportSpecificTerminationMessage() {
@@ -410,12 +413,16 @@ class DataTransportBleCentralClientMode(
         gattServer.sendTransportSpecificTermination()
     }
 
-    override fun supportsTransportSpecificTerminationMessage(): Boolean =
-        if (l2capClient != null) false else
-            _gattServer?.supportsTransportSpecificTerminationMessage()
-                ?: _gattClient?.supportsTransportSpecificTerminationMessage()
-                ?: false
-
+    override fun supportsTransportSpecificTerminationMessage(): Boolean {
+        if (l2capClient != null) {
+            return false
+        } else if (_gattServer != null) {
+            return gattServer.supportsTransportSpecificTerminationMessage()
+        } else if (_gattClient != null) {
+            return gattClient.supportsTransportSpecificTerminationMessage()
+        }
+        return false
+    }
 
     companion object {
         private const val TAG = "DataTransportBleCCM" // limit to <= 23 chars

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
@@ -382,10 +382,14 @@ class DataTransportBlePeripheralServerMode(
     }
 
     override fun sendMessage(data: ByteArray) {
-        require(data.isNotEmpty()) { "Data to send cannot be empty" }
-        l2capClient?.sendMessage(data)
-            ?: gattServer?.sendMessage(data)
-            ?: gattClient?.sendMessage(data)
+        require(data.size != 0) { "Data to send cannot be empty" }
+        if (l2capClient != null) {
+            l2capClient!!.sendMessage(data)
+        } else if (gattServer != null) {
+            gattServer!!.sendMessage(data)
+        } else if (gattClient != null) {
+            gattClient!!.sendMessage(data)
+        }
     }
 
     override fun sendTransportSpecificTerminationMessage() {

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
@@ -45,8 +45,10 @@ class DataTransportBlePeripheralServerMode(
     options: DataTransportOptions
 ) : DataTransportBle(context, role, connectionMethod, options) {
     private var characteristicStateUuid = UUID.fromString("00000001-a123-48ce-896b-4c76973373e6")
-    private var characteristicClient2ServerUuid = UUID.fromString("00000002-a123-48ce-896b-4c76973373e6")
-    private var characteristicServer2ClientUuid = UUID.fromString("00000003-a123-48ce-896b-4c76973373e6")
+    private var characteristicClient2ServerUuid =
+        UUID.fromString("00000002-a123-48ce-896b-4c76973373e6")
+    private var characteristicServer2ClientUuid =
+        UUID.fromString("00000003-a123-48ce-896b-4c76973373e6")
 
     // Note: Ident UUID not used in peripheral server mode
     /**
@@ -56,7 +58,8 @@ class DataTransportBlePeripheralServerMode(
      * UUID 0000000A-A123-48CE896B-4C76973373E6 and the GATT client (for the _mdoc reader_) should
      * connect to that UUID.
      */
-    private var characteristicL2CAPUuidMdoc = UUID.fromString("0000000a-a123-48ce-896b-4c76973373e6")
+    private var characteristicL2CAPUuidMdoc =
+        UUID.fromString("0000000a-a123-48ce-896b-4c76973373e6")
     private var bluetoothManager: BluetoothManager? = null
     private var bluetoothLeAdvertiser: BluetoothLeAdvertiser? = null
     private var gattClient: GattClient? = null
@@ -89,8 +92,10 @@ class DataTransportBlePeripheralServerMode(
             }
             isConnecting = true
             scanningTimeMillis = System.currentTimeMillis() - timeScanningStartedMillis
-            Logger.i(TAG, "Scanned for $scanningTimeMillis" + " milliseconds. "
-                        + "Connecting to device with address ${result.device.address}")
+            Logger.i(
+                TAG, "Scanned for $scanningTimeMillis" + " milliseconds. "
+                        + "Connecting to device with address ${result.device.address}"
+            )
             connectToDevice(result.device)
             if (scanner != null) {
                 Logger.d(TAG, "Stopped scanning for UUID $serviceUuid")
@@ -113,10 +118,10 @@ class DataTransportBlePeripheralServerMode(
             reportError(Error("BLE scan failed with error code $errorCode"))
         }
     }
-    
+
     private var gattServer: GattServer? = null
     private var l2capClient: L2CAPClient? = null
-    
+
     private fun connectToDevice(device: BluetoothDevice) {
         reportConnecting()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q &&
@@ -135,23 +140,25 @@ class DataTransportBlePeripheralServerMode(
 
     @RequiresApi(api = Build.VERSION_CODES.Q)
     private fun connectL2CAP(device: BluetoothDevice, psm: Int) {
-        l2capClient = L2CAPClient(context, object : L2CAPClient.Listener {
-            override fun onPeerConnected() {
-                reportConnected()
-            }
+        l2capClient = L2CAPClient(
+            context = context,
+            listener = object : L2CAPClient.Listener {
+                override fun onPeerConnected() {
+                    reportConnected()
+                }
 
-            override fun onPeerDisconnected() {
-                reportDisconnected()
-            }
+                override fun onPeerDisconnected() {
+                    reportDisconnected()
+                }
 
-            override fun onMessageReceived(data: ByteArray) {
-                reportMessageReceived(data)
-            }
+                override fun onMessageReceived(data: ByteArray) {
+                    reportMessageReceived(data)
+                }
 
-            override fun onError(error: Throwable) {
-                reportError(error)
-            }
-        })
+                override fun onError(error: Throwable) {
+                    reportError(error)
+                }
+            })
         l2capClient!!.connect(device, psm)
     }
 
@@ -161,11 +168,14 @@ class DataTransportBlePeripheralServerMode(
             characteristicL2CAPUuid = characteristicL2CAPUuidMdoc
         }
         gattClient = GattClient(
-            context,
-            serviceUuid!!, encodedEDeviceKeyBytes,
-            characteristicStateUuid, characteristicClient2ServerUuid,
-            characteristicServer2ClientUuid, null,
-            characteristicL2CAPUuid
+            context = context,
+            serviceUuid = serviceUuid!!,
+            encodedEDeviceKeyBytes = encodedEDeviceKeyBytes,
+            characteristicStateUuid = characteristicStateUuid,
+            characteristicClient2ServerUuid = characteristicClient2ServerUuid,
+            characteristicServer2ClientUuid = characteristicServer2ClientUuid,
+            characteristicIdentUuid = null,
+            characteristicL2CAPUuid = characteristicL2CAPUuid
         )
         gattClient!!.listener = object : GattClient.Listener {
             override fun onPeerConnected() {
@@ -217,12 +227,18 @@ class DataTransportBlePeripheralServerMode(
             characteristicL2CAPUuid = characteristicL2CAPUuidMdoc
         }
         gattServer = GattServer(
-            context, bluetoothManager, serviceUuid!!,
-            encodedEDeviceKeyBytes,
-            characteristicStateUuid, characteristicClient2ServerUuid,
-            characteristicServer2ClientUuid, null,
-            characteristicL2CAPUuid
+            context = context,
+            bluetoothManager = bluetoothManager,
+            serviceUuid = serviceUuid!!,
+            encodedEDeviceKeyBytes = encodedEDeviceKeyBytes,
+            characteristicStateUuid = characteristicStateUuid,
+            characteristicClient2ServerUuid = characteristicClient2ServerUuid,
+            characteristicServer2ClientUuid = characteristicServer2ClientUuid,
+            characteristicIdentUuid = null,
+            characteristicL2CAPUuid = characteristicL2CAPUuid
         )
+
+
         gattServer!!.listener = object : GattServer.Listener {
             override fun onPeerConnected() {
                 Logger.d(TAG, "onPeerConnected")
@@ -366,14 +382,10 @@ class DataTransportBlePeripheralServerMode(
     }
 
     override fun sendMessage(data: ByteArray) {
-        require(data.size != 0) { "Data to send cannot be empty" }
-        if (l2capClient != null) {
-            l2capClient!!.sendMessage(data)
-        } else if (gattServer != null) {
-            gattServer!!.sendMessage(data)
-        } else if (gattClient != null) {
-            gattClient!!.sendMessage(data)
-        }
+        require(data.isNotEmpty()) { "Data to send cannot be empty" }
+        l2capClient?.sendMessage(data)
+            ?: gattServer?.sendMessage(data)
+            ?: gattClient?.sendMessage(data)
     }
 
     override fun sendTransportSpecificTerminationMessage() {
@@ -388,14 +400,10 @@ class DataTransportBlePeripheralServerMode(
         gattServer!!.sendTransportSpecificTermination()
     }
 
-    override fun supportsTransportSpecificTerminationMessage(): Boolean {
-        if (gattServer != null) {
-            return gattServer!!.supportsTransportSpecificTerminationMessage()
-        } else if (gattClient != null) {
-            return gattClient!!.supportsTransportSpecificTerminationMessage()
-        }
-        return false
-    }
+    override fun supportsTransportSpecificTerminationMessage(): Boolean =
+        gattServer?.supportsTransportSpecificTerminationMessage()
+            ?: gattClient?.supportsTransportSpecificTerminationMessage()
+            ?: false
 
     companion object {
         private const val TAG = "DataTransportBlePSM" // limit to <= 23 chars

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportOptions.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportOptions.kt
@@ -79,12 +79,11 @@ class DataTransportOptions internal constructor(
          *
          * @return the built [DataTransportOptions] instance.
          */
-        fun build(): DataTransportOptions {
-            return DataTransportOptions(
+        fun build(): DataTransportOptions =
+            DataTransportOptions(
                 bleUseL2CAP,
                 bleClearCache,
                 experimentalBleL2CAPPsmInEngagement
             )
-        }
     }
 }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportUdp.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportUdp.kt
@@ -84,7 +84,7 @@ class DataTransportUdp(
             }
         }
         socketServerThread.start()
-        if (host == null || host!!.length == 0) {
+        if (host == null || host!!.isEmpty()) {
             host = getWifiIpAddress(context)
         }
         if (this.port == 0) {
@@ -175,7 +175,7 @@ class DataTransportUdp(
                         }
                         // An empty message is used to convey that the writing thread should be
                         // shut down.
-                        if (messageToSend.size == 0) {
+                        if (messageToSend.isEmpty()) {
                             Logger.d(TAG, "Empty message, shutting down writer")
                             break
                         }
@@ -279,19 +279,20 @@ class DataTransportUdp(
 
             // From 7.1 Alternative Carrier Record
             //
-            val baos = ByteArrayOutputStream()
-            baos.write(0x01) // CPS: active
-            baos.write(reference.size)
-            try {
-                baos.write(reference)
-            } catch (e: IOException) {
-                throw IllegalStateException(e)
+            val acRecordPayload = ByteArrayOutputStream().run {
+                write(0x01) // CPS: active
+                write(reference.size)
+                try {
+                    write(reference)
+                } catch (e: IOException) {
+                    throw IllegalStateException(e)
+                }
+                write(0x01) // Number of auxiliary references
+                val auxReference = "mdoc".toByteArray()
+                write(auxReference.size)
+                write(auxReference, 0, auxReference.size)
+                toByteArray()
             }
-            baos.write(0x01) // Number of auxiliary references
-            val auxReference = "mdoc".toByteArray()
-            baos.write(auxReference.size)
-            baos.write(auxReference, 0, auxReference.size)
-            val acRecordPayload = baos.toByteArray()
             return Pair(record, acRecordPayload)
         }
     }

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/L2CAPClient.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/L2CAPClient.kt
@@ -112,9 +112,8 @@ internal class L2CAPClient(private val context: Context, val listener: Listener)
             // TODO: This is to work around a bug in L2CAP
             Thread.sleep(1000)
             socket!!.close()
-        } catch (e: IOException) {
-            Logger.e(TAG, "Error closing socket", e)
-        } catch (e: InterruptedException) {
+        } catch (e: Exception) {
+            // could be IOException, InterruptedException
             Logger.e(TAG, "Error closing socket", e)
         }
     }
@@ -159,6 +158,8 @@ internal class L2CAPClient(private val context: Context, val listener: Listener)
     fun sendMessage(data: ByteArray) {
         writerQueue.add(data)
     }
+
+    // TODO have listeners run callbacks in coroutines
 
     fun reportPeerConnected() {
         if (!inhibitCallbacks) {

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/L2CAPServer.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/L2CAPServer.kt
@@ -122,9 +122,8 @@ internal class L2CAPServer(val listener: Listener) {
             // TODO: This is to work aqround a bug in L2CAP
             Thread.sleep(1000)
             socket!!.close()
-        } catch (e: IOException) {
-            Logger.e(TAG, "Error closing socket", e)
-        } catch (e: InterruptedException) {
+        } catch (e: Exception) {
+            // could be IOException, InterruptedException
             Logger.e(TAG, "Error closing socket", e)
         }
     }
@@ -167,6 +166,7 @@ internal class L2CAPServer(val listener: Listener) {
         }
     }
 
+    // TODO have listeners run callbacks in coroutines
     fun sendMessage(data: ByteArray) {
         writerQueue.add(data)
     }

--- a/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
+++ b/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
@@ -35,8 +35,10 @@ class TransferHelper private constructor(
 
         val PREFERENCE_KEY_INCLUDE_PORTRAIT_IN_REQUEST = "include_portrait_in_request"
 
-        val PREFERENCE_KEY_BLE_CENTRAL_CLIENT_DATA_TRANSFER_ENABLED = "ble_central_client_data_transfer_enabled"
-        val PREFERENCE_KEY_BLE_PERIPHERAL_SERVER_DATA_TRANSFER_ENABLED = "ble_peripheral_server_data_transfer_enabled"
+        val PREFERENCE_KEY_BLE_CENTRAL_CLIENT_DATA_TRANSFER_ENABLED =
+            "ble_central_client_data_transfer_enabled"
+        val PREFERENCE_KEY_BLE_PERIPHERAL_SERVER_DATA_TRANSFER_ENABLED =
+            "ble_peripheral_server_data_transfer_enabled"
         val PREFERENCE_KEY_WIFI_AWARE_DATA_TRANSFER_ENABLED = "wifi_aware_data_transfer_enabled"
         val PREFERENCE_KEY_NFC_DATA_TRANSFER_ENABLED = "nfc_data_transfer_enabled"
         val PREFERENCE_KEY_TCP_DATA_TRANSFER_ENABLED = "tcp_data_transfer_enabled"
@@ -56,16 +58,21 @@ class TransferHelper private constructor(
             }
     }
 
-    private var sharedPreferences: SharedPreferences
+    private val sharedPreferences: SharedPreferences by lazy {
+        PreferenceManager.getDefaultSharedPreferences(context)
+    }
+
     private var storageEngine: StorageEngine
     var androidKeystoreSecureArea: AndroidKeystoreSecureArea
-
-    private var verificationHelper: VerificationHelper? = null
     var deviceResponseBytes: ByteArray? = null
     var error: Throwable? = null
     private var connectionMethodUsed: ConnectionMethod? = null
-
     private var state = MutableLiveData<State>()
+
+    private var _verificationHelper: VerificationHelper? = null
+    private val verificationHelper: VerificationHelper
+        get() = _verificationHelper!!
+
 
     enum class State {
         IDLE,
@@ -84,7 +91,7 @@ class TransferHelper private constructor(
         override fun onDeviceEngagementReceived(connectionMethods: List<ConnectionMethod>) {
             Logger.d(TAG, "onDeviceEngagementReceived")
             connectionMethodUsed = connectionMethods.first()
-            verificationHelper!!.connect(connectionMethods.first())
+            verificationHelper.connect(connectionMethods.first())
             state.value = State.CONNECTING
         }
 
@@ -102,15 +109,15 @@ class TransferHelper private constructor(
             close()
         }
 
-        override fun onResponseReceived(deviceResponseBytes_: ByteArray) {
+        override fun onResponseReceived(deviceResponseBytes: ByteArray) {
             Logger.d(TAG, "onResponseReceived")
-            deviceResponseBytes = deviceResponseBytes_
+            this@TransferHelper.deviceResponseBytes = deviceResponseBytes
             state.value = State.TRANSACTION_COMPLETE
         }
 
-        override fun onError(error_: Throwable) {
-            Logger.d(TAG, "onError $error")
-            error = error_
+        override fun onError(error: Throwable) {
+            Logger.d(TAG, "onError ${this@TransferHelper.error}")
+            this@TransferHelper.error = error
             state.value = State.TRANSACTION_COMPLETE
         }
     }
@@ -120,8 +127,15 @@ class TransferHelper private constructor(
         initializeVerificationHelper()
     }
 
+
     private fun initializeVerificationHelper() {
-        val builder = VerificationHelper.Builder(context, listener, context.mainExecutor)
+
+        val builder =
+            VerificationHelper.Builder(
+                context = context,
+                listener = listener,
+                executor = context.mainExecutor
+            )
         val options = DataTransportOptions.Builder()
             .setBleUseL2CAP(getL2CapEnabled())
             .setExperimentalBleL2CAPPsmInEngagement(getExperimentalPsmEnabled())
@@ -129,81 +143,85 @@ class TransferHelper private constructor(
         builder.setDataTransportOptions(options)
 
         val connectionMethods = mutableListOf<ConnectionMethod>()
-        val bleUuid = UUID.randomUUID()
-        if (getBleCentralClientDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodBle(
-                false,
-                true,
-                null,
-                bleUuid))
-        }
-        if (getBlePeripheralServerDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodBle(
-                true,
-                false,
-                bleUuid,
-                null))
-        }
-        if (getWifiAwareDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodWifiAware(null, OptionalLong.empty(), OptionalLong.empty(), null))
-        }
-        if (getNfcDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodNfc(4096, 32768))
-        }
-        if (getTcpDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodTcp("", 0))
-        }
-        if (getUdpDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodUdp("", 0))
-        }
+            .apply {
+                val bleUuid = UUID.randomUUID()
+                if (getBleCentralClientDataTransferEnabled()) {
+                    add(
+                        ConnectionMethodBle(
+                            false,
+                            true,
+                            null,
+                            bleUuid
+                        )
+                    )
+                }
+                if (getBlePeripheralServerDataTransferEnabled()) {
+                    add(
+                        ConnectionMethodBle(
+                            true,
+                            false,
+                            bleUuid,
+                            null
+                        )
+                    )
+                }
+                if (getWifiAwareDataTransferEnabled()) {
+                    add(
+                        ConnectionMethodWifiAware(
+                            null,
+                            OptionalLong.empty(),
+                            OptionalLong.empty(),
+                            null
+                        )
+                    )
+                }
+                if (getNfcDataTransferEnabled()) {
+                    add(ConnectionMethodNfc(4096, 32768))
+                }
+                if (getTcpDataTransferEnabled()) {
+                    add(ConnectionMethodTcp("", 0))
+                }
+                if (getUdpDataTransferEnabled()) {
+                    add(ConnectionMethodUdp("", 0))
+                }
+
+            }
         builder.setNegotiatedHandoverConnectionMethods(connectionMethods)
 
-
-        verificationHelper?.disconnect()
-        verificationHelper = builder.build()
+        verificationHelper.disconnect()
+        _verificationHelper = builder.build()
         deviceResponseBytes = null
         connectionMethodUsed = null
         error = null
         Logger.d(TAG, "Initialized VerificationHelper")
     }
 
-    fun getSessionTranscript(): ByteArray {
-        return verificationHelper!!.sessionTranscript
-    }
+    fun getSessionTranscript(): ByteArray = verificationHelper.sessionTranscript
 
     fun sendRequest(deviceRequestBytes: ByteArray) {
         check(state.value == State.CONNECTED)
-        verificationHelper!!.sendRequest(deviceRequestBytes)
+        verificationHelper.sendRequest(deviceRequestBytes)
         state.value = State.REQUEST_SENT
     }
 
+    fun getTapToEngagementDurationMillis(): Long =
+        verificationHelper.tapToEngagementDurationMillis
 
-    fun getTapToEngagementDurationMillis(): Long {
-        return verificationHelper!!.tapToEngagementDurationMillis
-    }
+    fun getEngagementToRequestDurationMillis(): Long =
+        verificationHelper.engagementToRequestDurationMillis
 
-    fun getEngagementToRequestDurationMillis(): Long {
-        return verificationHelper!!.engagementToRequestDurationMillis
-    }
+    fun getRequestToResponseDurationMillis(): Long =
+        verificationHelper.requestToResponseDurationMillis
 
-    fun getRequestToResponseDurationMillis(): Long {
-        return verificationHelper!!.requestToResponseDurationMillis
-    }
+    fun getScanningDurationMillis(): Long = verificationHelper.scanningTimeMillis
 
-    fun getScanningDurationMillis(): Long {
-        return verificationHelper!!.scanningTimeMillis
-    }
-
-
-    fun getEngagementMethod(): VerificationHelper.EngagementMethod {
-        return verificationHelper!!.engagementMethod
-    }
+    fun getEngagementMethod(): VerificationHelper.EngagementMethod =
+        verificationHelper.engagementMethod
 
     init {
-        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
         val storageDir = File(context.noBackupFilesDir, "identity")
         storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
-        androidKeystoreSecureArea = AndroidKeystoreSecureArea(context, storageEngine);
+        androidKeystoreSecureArea = AndroidKeystoreSecureArea(context, storageEngine)
         state.value = State.IDLE
 
         initializeVerificationHelper()
@@ -213,17 +231,14 @@ class TransferHelper private constructor(
             activity,
             { tag ->
                 if (state.value == State.IDLE) {
-                    verificationHelper!!.nfcProcessOnTagDiscovered(tag)
+                    verificationHelper.nfcProcessOnTagDiscovered(tag)
                 }
                 state.postValue(State.ENGAGING)
             },
             NfcAdapter.FLAG_READER_NFC_A + NfcAdapter.FLAG_READER_NFC_B
                     + NfcAdapter.FLAG_READER_SKIP_NDEF_CHECK + NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS,
-            null)
-    }
-
-    fun getState(): LiveData<State> {
-        return state
+            null
+        )
     }
 
     fun close() {
@@ -235,109 +250,94 @@ class TransferHelper private constructor(
         state.value = State.IDLE
     }
 
-    fun getConnectionMethod(): String {
-        return connectionMethodUsed?.toString() ?: ""
-    }
+    fun getState(): LiveData<State> = state
 
-    fun getIncludePortraitInRequest(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_INCLUDE_PORTRAIT_IN_REQUEST, true)
-    }
+    fun getConnectionMethod(): String = connectionMethodUsed?.toString() ?: ""
 
-    fun setIncludePortraitInRequest(enabled: Boolean) {
+    fun getIncludePortraitInRequest(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_INCLUDE_PORTRAIT_IN_REQUEST, true)
+
+    fun setIncludePortraitInRequest(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_INCLUDE_PORTRAIT_IN_REQUEST, enabled)
         }
-    }
 
-    fun getWifiAwareDataTransferEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_WIFI_AWARE_DATA_TRANSFER_ENABLED, false)
-    }
+    fun getWifiAwareDataTransferEnabled(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_WIFI_AWARE_DATA_TRANSFER_ENABLED, false)
 
-    fun setWifiAwareDataTransferEnabled(enabled: Boolean) {
+    fun setWifiAwareDataTransferEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_WIFI_AWARE_DATA_TRANSFER_ENABLED, enabled)
         }
-    }
 
-    fun getNfcDataTransferEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_NFC_DATA_TRANSFER_ENABLED, false)
-    }
+    fun getNfcDataTransferEnabled(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_NFC_DATA_TRANSFER_ENABLED, false)
 
-    fun setNfcDataTransferEnabled(enabled: Boolean) {
+    fun setNfcDataTransferEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_NFC_DATA_TRANSFER_ENABLED, enabled)
         }
-    }
 
-    fun getTcpDataTransferEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_TCP_DATA_TRANSFER_ENABLED, false)
-    }
+    fun getTcpDataTransferEnabled(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_TCP_DATA_TRANSFER_ENABLED, false)
 
-    fun setTcpDataTransferEnabled(enabled: Boolean) {
+    fun setTcpDataTransferEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_TCP_DATA_TRANSFER_ENABLED, enabled)
         }
-    }
 
-    fun getUdpDataTransferEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_UDP_DATA_TRANSFER_ENABLED, false)
-    }
+    fun getUdpDataTransferEnabled(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_UDP_DATA_TRANSFER_ENABLED, false)
 
-    fun setUdpDataTransferEnabled(enabled: Boolean) {
+    fun setUdpDataTransferEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_UDP_DATA_TRANSFER_ENABLED, enabled)
         }
-    }
 
-    fun getBleCentralClientDataTransferEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_BLE_CENTRAL_CLIENT_DATA_TRANSFER_ENABLED, true)
-    }
+    fun getBleCentralClientDataTransferEnabled(): Boolean =
+        sharedPreferences.getBoolean(
+            PREFERENCE_KEY_BLE_CENTRAL_CLIENT_DATA_TRANSFER_ENABLED,
+            true
+        )
 
-    fun setBleCentralClientDataTransferEnabled(enabled: Boolean) {
+
+    fun setBleCentralClientDataTransferEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_BLE_CENTRAL_CLIENT_DATA_TRANSFER_ENABLED, enabled)
         }
-    }
 
-    fun getBlePeripheralServerDataTransferEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_BLE_PERIPHERAL_SERVER_DATA_TRANSFER_ENABLED, false)
-    }
+    fun getBlePeripheralServerDataTransferEnabled(): Boolean =
+        sharedPreferences.getBoolean(
+            PREFERENCE_KEY_BLE_PERIPHERAL_SERVER_DATA_TRANSFER_ENABLED,
+            false
+        )
 
-    fun setBlePeripheralServerDataTransferEnabled(enabled: Boolean) {
+    fun setBlePeripheralServerDataTransferEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_BLE_PERIPHERAL_SERVER_DATA_TRANSFER_ENABLED, enabled)
         }
-    }
 
-    fun getExperimentalPsmEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_EXPERIMENTAL_PSM_ENABLED, false)
-    }
+    fun getExperimentalPsmEnabled(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_EXPERIMENTAL_PSM_ENABLED, false)
 
-    fun setExperimentalPsmEnabled(enabled: Boolean) {
+    fun setExperimentalPsmEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_EXPERIMENTAL_PSM_ENABLED, enabled)
         }
-    }
 
-    fun getL2CapEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_L2CAP_ENABLED, false)
-    }
+    fun getL2CapEnabled(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_L2CAP_ENABLED, false)
 
-    fun setL2CapEnabled(enabled: Boolean) {
+    fun setL2CapEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_L2CAP_ENABLED, enabled)
         }
-    }
 
-    fun getDebugEnabled(): Boolean {
-        return sharedPreferences.getBoolean(PREFERENCE_KEY_DEBUG_ENABLED, false)
-    }
+    fun getDebugEnabled(): Boolean =
+        sharedPreferences.getBoolean(PREFERENCE_KEY_DEBUG_ENABLED, false)
 
-    fun setDebugEnabled(enabled: Boolean) {
+    fun setDebugEnabled(enabled: Boolean) =
         sharedPreferences.edit {
             putBoolean(PREFERENCE_KEY_DEBUG_ENABLED, enabled)
         }
-    }
-
-
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/NfcEngagementHandler.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/NfcEngagementHandler.kt
@@ -65,9 +65,11 @@ class NfcEngagementHandler : HostApduService() {
         override fun onDeviceConnected(transport: DataTransport) {
             Logger.i(TAG, "onDeviceConnected")
 
-            PresentationActivity.startPresentation(applicationContext, transport,
+            PresentationActivity.startPresentation(
+                applicationContext, transport,
                 engagementHelper!!.handover, eDeviceKey,
-                engagementHelper!!.deviceEngagement)
+                engagementHelper!!.deviceEngagement
+            )
 
             engagementHelper?.close()
             engagementHelper = null
@@ -86,19 +88,20 @@ class NfcEngagementHandler : HostApduService() {
 
         val application: WalletApplication = application as WalletApplication
 
-        if (application.credentialStore.listCredentials().size > 0
-            && !PresentationActivity.isPresentationActive()) {
-
+        if (application.credentialStore.listCredentials().isNotEmpty()
+            && !PresentationActivity.isPresentationActive()
+        ) {
             val options = DataTransportOptions.Builder().build()
-            val builder = NfcEngagementHelper.Builder(
-                applicationContext,
-                eDeviceKey.publicKey,
-                options,
-                nfcEngagementListener,
-                ContextCompat.getMainExecutor(applicationContext)
-            )
-            builder.useNegotiatedHandover()
-            engagementHelper = builder.build()
+            engagementHelper = NfcEngagementHelper
+                .Builder(
+                    context = applicationContext,
+                    eDeviceKey = eDeviceKey.publicKey,
+                    options = options,
+                    listener = nfcEngagementListener,
+                    executor = ContextCompat.getMainExecutor(applicationContext)
+                )
+                .useNegotiatedHandover()
+                .build()
         }
     }
 
@@ -124,9 +127,9 @@ class NfcEngagementHandler : HostApduService() {
         //
         val timeoutSeconds = 15
         Handler(Looper.getMainLooper()).postDelayed({
-            if (engagementHelper != null) {
+            engagementHelper?.run {
                 Logger.w(TAG, "Reader didn't connect inside $timeoutSeconds seconds, closing")
-                engagementHelper!!.close()
+                close()
             }
         }, timeoutSeconds * 1000L)
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
@@ -20,7 +20,7 @@ import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 import java.util.UUID
 
-class QrEngagementViewModel(val context: Application) : AndroidViewModel(context)  {
+class QrEngagementViewModel(val context: Application) : AndroidViewModel(context) {
     companion object {
         private const val TAG = "QrEngagementViewModel"
     }
@@ -46,7 +46,7 @@ class QrEngagementViewModel(val context: Application) : AndroidViewModel(context
         state = State.STARTING
 
         viewModelScope.launch(
-            CoroutineExceptionHandler{ _, exception ->
+            CoroutineExceptionHandler { _, exception ->
                 Logger.e(TAG, "CoroutineExceptionHandler got $exception")
                 stopQrConnection()
                 state = State.ERROR
@@ -63,9 +63,11 @@ class QrEngagementViewModel(val context: Application) : AndroidViewModel(context
                     Logger.i(TAG, "OnDeviceConnected via QR: qrEngagement=$qrEngagementHelper")
 
                     state = State.CONNECTED
-                    PresentationActivity.startPresentation(context, transport,
+                    PresentationActivity.startPresentation(
+                        context, transport,
                         qrEngagementHelper!!.handover, eDeviceKey!!,
-                        qrEngagementHelper!!.deviceEngagement)
+                        qrEngagementHelper!!.deviceEngagement
+                    )
 
                     qrEngagementHelper?.close()
                     qrEngagementHelper = null
@@ -83,18 +85,20 @@ class QrEngagementViewModel(val context: Application) : AndroidViewModel(context
             val bleUuid = UUID.randomUUID()
             connectionMethods.add(
                 ConnectionMethodBle(
-                    false,
-                    true,
-                    null,
-                    bleUuid
+                    supportsPeripheralServerMode = false,
+                    supportsCentralClientMode = true,
+                    peripheralServerModeUuid = null,
+                    centralClientModeUuid = bleUuid
                 )
             )
+
             qrEngagementHelper = QrEngagementHelper.Builder(
-                context,
-                eDeviceKey!!.publicKey,
-                options,
-                qrEngagementListener,
-                ContextCompat.getMainExecutor(context)
+                context = context,
+                eDeviceKey = eDeviceKey!!.publicKey,
+                options = options,
+                listener = qrEngagementListener,
+                // TODO replace ContextCompat.getMainExecutor with coroutines
+                executor = ContextCompat.getMainExecutor(context)
             ).setConnectionMethods(connectionMethods).build()
             state = State.LISTENING
         }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/presentation/TransferHelper.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/presentation/TransferHelper.kt
@@ -120,7 +120,7 @@ class TransferHelper(
                 docRequest.readerCertificateChain!!.javaX509Certificates,
                 customValidators = emptyList()  // not neeeded for reader auth
             )
-            if (result.isTrusted && !result.trustPoints.isEmpty()) {
+            if (result.isTrusted && result.trustPoints.isNotEmpty()) {
                 trustPoint = result.trustPoints.first()
             } else if (result.error != null) {
                 Logger.w(TAG, "Error finding trustpoint for reader auth", result.error!!)
@@ -321,10 +321,6 @@ class TransferHelper(
         }
 
         val credConf = credential.credentialConfiguration
-        if (credConf.mdocDocType != docRequest.docType) {
-            return false
-        }
-
-        return true
+        return credConf.mdocDocType == docRequest.docType
     }
 }


### PR DESCRIPTION
Contains Kotlin-DSL updates extracted from PR https://github.com/openwallet-foundation-labs/identity-credential/pull/517.

Excluding this PR's Kotlin-DSL code, the remaining code in PR #517 is about adding coroutine scope so listeners can issue callbacks in coroutines instead of `context.mainExecutor`. Any logic revolving around listeners in this PR still uses executors and no kotlin-dsl optimizations have been made since they will come from the second PR (of extractions from PR #517 ) updating the logic to use coroutines.

All unit tests pass (520) and manually installed all the apps and ran them