### PR TITLE
Support more error types in BiometricPrompt

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/BiometricUserAuthPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/BiometricUserAuthPrompt.kt
@@ -81,7 +81,9 @@ private class BiometricUserAuthPrompt(
             errorString: CharSequence
         ) {
             super.onAuthenticationError(errorCode, errorString)
-            if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON && lskfOnNegativeBtn) {
+            if (setOf(BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+                    BiometricPrompt.ERROR_NO_BIOMETRICS,
+                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS).contains(errorCode) && lskfOnNegativeBtn) {
                 // if no delay is injected, then biometric prompt's auth callbacks would not be called
                 Handler(Looper.getMainLooper()).postDelayed({
                     authenticateLskf()


### PR DESCRIPTION
In the case of no enrolled biometrics, allow users with secure lock screen to use LSKF only to unlock auth keys. Also improves user experience by allowing for a retry when the biometrics are not clear (ie, when the prompt tells you to press your finger firmly against the sensor) - before, the presentation would be cancelled after a single failure but the prompt would remain on-screen.

Tested manually as a user with only PIN and no biometrics and when pressing finger lightly enough to need a retry.

Fixes #550 