### PR TITLE
Tweaks to CBOR annotation processor:

### DIFF
--- a/cbor-processor/src/main/kotlin/com/android/identity/cbor/processor/CodeBuilder.kt
+++ b/cbor-processor/src/main/kotlin/com/android/identity/cbor/processor/CodeBuilder.kt
@@ -26,14 +26,14 @@ class CodeBuilder(
      *
      * Duplicate simple names will cause [IllegalArgumentException]
      */
-    fun importClass(clazz: KSClassDeclaration) {
-        importClass(clazz.qualifiedName!!.asString())
+    fun importQualifiedName(clazz: KSClassDeclaration) {
+        importQualifiedName(clazz.qualifiedName!!.asString())
     }
 
     /**
-     * Import class using its fully-qualified name.
+     * Import class or function using its fully-qualified name.
      */
-    fun importClass(qualifiedName: String) {
+    fun importQualifiedName(qualifiedName: String) {
         val simpleName = qualifiedName.substring(qualifiedName.lastIndexOf('.') + 1)
         if (classesToImport.contains(simpleName)) {
             if (classesToImport[simpleName] == qualifiedName) {

--- a/identity/src/main/java/com/android/identity/cbor/DataItem.kt
+++ b/identity/src/main/java/com/android/identity/cbor/DataItem.kt
@@ -7,6 +7,7 @@ import com.android.identity.cose.CoseMac0
 import com.android.identity.crypto.Certificate
 import com.android.identity.crypto.CertificateChain
 import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 import kotlinx.io.bytestring.ByteStringBuilder
 
 /**
@@ -176,6 +177,20 @@ sealed class DataItem(
             require(this.tagNumber == Tagged.DATE_TIME_STRING)
             require(this.taggedItem is Tstr)
             return Instant.parse(this.taggedItem.value)
+        }
+
+    /**
+     * The date-time from a tstr with tag [Tagged.FULL_DATE_STRING].
+     *
+     * @throws IllegalArgumentException if the data item isn't a tag with tag [Tagged.FULL_DATE_STRING]
+     * containing a tstr with valid date format.
+     */
+    val asDateString: LocalDate
+        get() {
+            require(this is Tagged)
+            require(this.tagNumber == Tagged.FULL_DATE_STRING)
+            require(this.taggedItem is Tstr)
+            return LocalDate.parse(this.taggedItem.value)
         }
 
     /**

--- a/identity/src/test/java/com/android/identity/processor/ProcessorTests.kt
+++ b/identity/src/test/java/com/android/identity/processor/ProcessorTests.kt
@@ -5,6 +5,15 @@ import com.android.identity.cbor.Tstr
 import org.junit.Assert
 import org.junit.Test
 import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.cbor.toDataItem
+import com.android.identity.cose.Cose
+import com.android.identity.cose.CoseKey
+import com.android.identity.cose.toCoseLabel
+import com.android.identity.crypto.EcCurve
+import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
+import com.android.identity.util.fromHex
+import kotlinx.datetime.Instant
+import kotlinx.datetime.LocalDate
 
 enum class TestEnum {
     ONE,
@@ -25,17 +34,32 @@ data class VariantString(val value: String) : Variant()
 data class Container(
     val intField: Int,
     val longField: Long,
+    val floatField: Float,
+    val doubleField: Double,
     val booleanField: Boolean,
     val stringField: String,
     val nullableField: String?,
     val variantField: Variant,
     val dataItemField: DataItem,
+    val instantField: Instant,
+    val dateField: LocalDate,
     val enumField: TestEnum,
     val mapField: Map<String, Variant>?,
-    val listField: List<Variant>?
+    val listField: List<Variant>?,
 ) {
     companion object
 }
+
+@CborSerializable
+class CoseContainer(val coseKey:CoseKey) {
+    companion object
+}
+
+const val ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X =
+    "96313d6c63e24e3372742bfdb1a33ba2c897dcd68ab8c753e4fbd48dca6b7f9a"
+const val ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y =
+    "1fb3269edd418857de1b39a4e4a44b92fa484caa722c228288f01d0c03a2c3d6"
+
 
 // TODO: add more tests once the CBOR annotation processor takes shape
 class ProcessorTests {
@@ -44,18 +68,37 @@ class ProcessorTests {
         val original = Container(
             intField = Int.MIN_VALUE,
             longField = Long.MAX_VALUE,
+            floatField = Math.PI.toFloat(),
+            doubleField = Math.E,
             booleanField = true,
             stringField = "foobar",
             nullableField = null,
             variantField = VariantString("variant"),
             dataItemField = Tstr("tstr"),
+            instantField = Instant.parse("1969-07-20T20:17:00Z"),
+            dateField = LocalDate.parse("1961-04-12"),
             enumField = TestEnum.TWO,
             mapField = mapOf(
                 "string" to VariantString("bar"),
                 "boolean" to VariantBoolean(false)
             ),
             listField = listOf(VariantLong(Long.MIN_VALUE)))
-        val roundtripped = Container.fromCborDataItem(original.toCborDataItem())
+        val roundtripped = Container.fromDataItem(original.toDataItem)
         Assert.assertEquals(original, roundtripped)
+    }
+
+    @Test
+    fun roundtrip_cose() {
+        val key = EcPublicKeyDoubleCoordinate(
+            EcCurve.P256,
+            ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X.fromHex,
+            ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_Y.fromHex
+        )
+        val coseKey = key.toCoseKey(
+            mapOf(Cose.COSE_KEY_KID.toCoseLabel to "name@example.com".toByteArray().toDataItem)
+        )
+        val original = CoseContainer(coseKey)
+        val roundtripped = CoseContainer.fromDataItem(original.toDataItem)
+        Assert.assertEquals(original.coseKey.ecPublicKey, roundtripped.coseKey.ecPublicKey)
     }
 }

--- a/wallet/src/main/java/com/android/identity/issuance/evidence/EvidenceRequest.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/evidence/EvidenceRequest.kt
@@ -9,12 +9,12 @@ import com.android.identity.cbor.Cbor
 @CborSerializable
 sealed class EvidenceRequest {
     fun toCbor(): ByteArray {
-        return Cbor.encode(toCborDataItem())
+        return Cbor.encode(toDataItem)
     }
 
     companion object {
         fun fromCbor(encodedValue: ByteArray): EvidenceRequest {
-            return fromCborDataItem(Cbor.decode(encodedValue))
+            return fromDataItem(Cbor.decode(encodedValue))
         }
     }
 }

--- a/wallet/src/main/java/com/android/identity/issuance/evidence/EvidenceResponse.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/evidence/EvidenceResponse.kt
@@ -9,12 +9,12 @@ import com.android.identity.cbor.Cbor
 @CborSerializable
 sealed class EvidenceResponse {
     fun toCbor(): ByteArray {
-        return Cbor.encode(toCborDataItem())
+        return Cbor.encode(toDataItem)
     }
 
     companion object {
         fun fromCbor(encodedValue: ByteArray): EvidenceResponse {
-            return fromCborDataItem(Cbor.decode(encodedValue))
+            return fromDataItem(Cbor.decode(encodedValue))
         }
     }
 }


### PR DESCRIPTION
 - named serializer/deserializer to be consistent with the CBOR library, toDataItem is now a property
 - add correct import statement for classes that supply their own serializers
 - support for Float, Double, Instant, and LocalDate

Updated the (currently minimalistic) unit text

Fixes #541 - need to understand better what (if anything) would need to be done for EcPublicKey and friends. It seems that generic toDataItem/fromDataItem should work fine.
