### PR TITLE
Request all the permissions that are needed, not one-by-one.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/main/MainScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/main/MainScreen.kt
@@ -188,12 +188,9 @@ fun MainScreenContent(
                     snackbar = {
                         Snackbar {
                             Column {
-                                permissionTracker.PermissionRequests(blePermissions)
-                                Row(
-                                    modifier = Modifier.fillMaxWidth(),
-                                    horizontalArrangement = Arrangement.Center
-                                ) {
+                                permissionTracker.PermissionRequests(blePermissions) {
                                     Button(
+                                        modifier = Modifier.padding(8.dp),
                                         onClick = { it.dismiss() }) {
                                         Text(stringResource(R.string.wallet_screen_permissions_dismiss))
                                     }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -10,7 +10,8 @@
     <string name="permission_bluetooth_advertise">This application needs to advertise itself on bluetooth to send credential data</string>
     <string name="permission_bluetooth_connect">Access to bluetooth connection is needed to send credential data</string>
     <string name="permission_bluetooth_scan">Access to bluetooth scanning is needed to send credential data</string>
-    <string name="permission_button_grant">Grant Permission</string>
+    <string name="permission_button_grant_permission">Grant Permission</string>
+    <string name="permission_button_grant_permissions">Grant Permissions</string>
 
     <!-- Wallet drawer -->
     <string name="wallet_drawer_title">Wallet</string>


### PR DESCRIPTION
Request all the permissions that are needed, not one-by-one. On Pixel this means that there is only a single button to push and a single system dialog to confirm (in theory other OS may display multiple dialogs - but that's highly unlikely). This PR also rearranges buttons on the main screen permission request snackbar, so that they are in a single row.

Fixes #555
