### PR TITLE
wallet: better handling of permissions related to proximitiy presentations.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/SettingsModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SettingsModel.kt
@@ -22,6 +22,7 @@ class SettingsModel(
 
     // Non visible in the Settings screen
     val focusedCardId = MutableLiveData("")
+    val hideMissingProximityPermissionsWarning = MutableLiveData(false)
 
     companion object {
         private const val TAG = "SettingsModel"
@@ -29,6 +30,8 @@ class SettingsModel(
         private const val PREFERENCE_DEVELOPER_MODE_ENABLED = "developer_mode_enabled"
         private const val PREFERENCE_LOGGING_ENABLED = "logging_enabled"
         private const val PREFERENCE_FOCUSED_CARD_ID = "focused_card_id"
+        private const val PREFERENCE_HIDE_MISSING_PROXIMITY_PERMISSIONS_WARNING =
+            "hide_missing_proximity_permissions_warning"
 
         // Logging
         private const val LOG_FOLDER_NAME = "log"
@@ -74,6 +77,17 @@ class SettingsModel(
                 Log.WARN -> if (err == null) Logger.w(tag, msg) else Logger.w(tag, msg, err)
                 Log.ERROR -> if (err == null) Logger.e(tag, msg) else Logger.e(tag, msg, err)
                 else -> throw IllegalArgumentException("Unknown level: $level")
+            }
+        }
+
+        hideMissingProximityPermissionsWarning.value =
+            sharedPreferences.getBoolean(
+                PREFERENCE_HIDE_MISSING_PROXIMITY_PERMISSIONS_WARNING,
+                false
+            )
+        hideMissingProximityPermissionsWarning.observeForever {
+            sharedPreferences.edit {
+                putBoolean(PREFERENCE_HIDE_MISSING_PROXIMITY_PERMISSIONS_WARNING, it)
             }
         }
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -72,11 +72,9 @@ fun WalletNavigation(
         composable(WalletDestination.Main.route) {
             MainScreen(
                 onNavigate = navigateTo,
-                credentialStore = credentialStore,
                 qrEngagementViewModel = qrEngagementViewModel,
                 cardViewModel = cardViewModel,
                 settingsModel = application.settingsModel,
-                permissionTracker = permissionTracker,
                 context = application.applicationContext,
             )
         }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -27,6 +27,20 @@
     <string name="permission_post_notifications_grant_permission_button_text">Grant Permission</string>
     <string name="permission_post_notifications_continue_without_permission_button_text">No Thanks</string>
 
+    <!-- Proximity presentation permissions -->
+    <string name="proximity_permissions_snackbar_text">Permissions required for proximity presentations</string>
+    <string name="proximity_permissions_snackbar_action_label">Grant</string>
+    <string name="proximity_permissions_qr_alert_dialog_title">Missing Permissions</string>
+    <string name="proximity_permissions_qr_alert_dialog_content">
+        Proximity presentation requires permissions to be granted.
+    </string>
+    <string name="proximity_permissions_qr_alert_dialog_dismiss_button">Cancel</string>
+    <string name="proximity_permissions_qr_alert_dialog_confirm_button">Grant Permission</string>
+    <string name="proximity_permissions_nfc_notification_title">Missing Permissions</string>
+    <string name="proximity_permissions_nfc_notification_content">
+        Proximity presentation requires permissions to be granted.
+    </string>
+
     <!-- Notifications about documents -->
     <string name="notifications_document_application_approved_and_ready_to_use">
         The application has been reviewed and your document is ready to use.


### PR DESCRIPTION
This changes how we handle requesting proximity permissions.

Introduce a snackbar in MainScreen shown if there's at least one credential and we lack the BLE permissions to present it. Make the Action button request the permission and also allow the user to dismiss this. Record whether the snackbar was dismissed to avoid painting it in the future, via SharedPreference.

Add logic to check for permissions if "Show code" button is pressed (for QR presentations) and if we lack permissions, show an Alert dialog explaining that permissions need to be granted.

Add logic in `NfcEngagementHandler` to clear the preference for whether to hide the snackbar and post a notification (best effort) explaining to the user that they need to grant permissions. The user clicking the notification will take them to MainScreen which will show the snackbar even if it was previously dismissed. Also return APPLICATION_NOT_FOUND to the remote mdoc reader so it can take the appropriate action.

Test: Manually tested
