### PR TITLE
Rename AuthenticationKey to Credential

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/document/DocumentManager.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/document/DocumentManager.kt
@@ -342,9 +342,9 @@ class DocumentManager private constructor(private val context: Context) {
         return mapBuilder.end().build()[0]
     }
 
-    fun refreshAuthKeys(documentName: String) {
+    fun refreshCredentials(documentName: String) {
         val documentInformation = requireNotNull(getDocumentInformation(documentName))
         val document = requireNotNull(getDocumentByName(documentName))
-        ProvisioningUtil.getInstance(context).refreshAuthKeys(document, documentInformation.docType)
+        ProvisioningUtil.getInstance(context).refreshCredentials(document, documentInformation.docType)
     }
 }

--- a/appholder/src/main/java/com/android/identity/wallet/documentinfo/DocumentInfoScreen.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/documentinfo/DocumentInfoScreen.kt
@@ -70,7 +70,7 @@ fun DocumentInfoScreen(
 
     DocumentInfoScreenContent(
         screenState = state,
-        onRefreshAuthKeys = viewModel::refreshAuthKeys,
+        onRefreshCredentials = viewModel::refreshCredentials,
         onShowDocumentElements = { onNavigateToDocumentDetails() },
         onDeleteDocument = { viewModel.promptDocumentDelete() },
         onConfirmDocumentDelete = viewModel::confirmDocumentDelete,
@@ -83,7 +83,7 @@ fun DocumentInfoScreen(
 private fun DocumentInfoScreenContent(
     modifier: Modifier = Modifier,
     screenState: DocumentInfoScreenState,
-    onRefreshAuthKeys: () -> Unit,
+    onRefreshCredentials: () -> Unit,
     onShowDocumentElements: () -> Unit,
     onDeleteDocument: () -> Unit,
     onConfirmDocumentDelete: () -> Unit,
@@ -175,7 +175,7 @@ private fun DocumentInfoScreenContent(
                                 modifier = Modifier
                                     .clip(RoundedCornerShape(8.dp))
                                     .weight(1f)
-                                    .clickable { onRefreshAuthKeys() },
+                                    .clickable { onRefreshCredentials() },
                                 horizontalAlignment = CenterHorizontally
                             ) {
                                 Column(
@@ -403,12 +403,11 @@ private fun PreviewDocumentInfoScreenLoading() {
             screenState = DocumentInfoScreenState(
                 isLoading = true
             ),
-            onRefreshAuthKeys = {},
+            onRefreshCredentials = {},
             onShowDocumentElements = {},
             onDeleteDocument = {},
-            onConfirmDocumentDelete = {},
-            onCancelDocumentDelete = {}
-        )
+            onConfirmDocumentDelete = {}
+        ) {}
     }
 }
 
@@ -450,11 +449,10 @@ private fun PreviewDocumentInfoScreen() {
                     )
                 )
             ),
-            onRefreshAuthKeys = {},
+            onRefreshCredentials = {},
             onShowDocumentElements = {},
             onDeleteDocument = {},
-            onConfirmDocumentDelete = {},
-            onCancelDocumentDelete = {}
-        )
+            onConfirmDocumentDelete = {}
+        ) {}
     }
 }

--- a/appholder/src/main/java/com/android/identity/wallet/documentinfo/DocumentInfoViewModel.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/documentinfo/DocumentInfoViewModel.kt
@@ -51,11 +51,11 @@ class DocumentInfoViewModel(
         _state.update { it.copy(isDeletingPromptShown = false) }
     }
 
-    fun refreshAuthKeys() {
+    fun refreshCredentials() {
         _state.update { it.copy(isLoading = true) }
         viewModelScope.launch {
             withContext(Dispatchers.IO) {
-                documentManager.refreshAuthKeys(args.documentName)
+                documentManager.refreshCredentials(args.documentName)
             }
             loadDocument(args.documentName)
         }

--- a/appholder/src/main/java/com/android/identity/wallet/support/AndroidKeystoreSecureAreaSupport.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/support/AndroidKeystoreSecureAreaSupport.kt
@@ -21,7 +21,7 @@ import com.android.identity.android.securearea.UserAuthenticationType
 import com.android.identity.android.securearea.userAuthenticationTypeSet
 import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.CborMap
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.crypto.Algorithm
 import com.android.identity.securearea.CreateKeySettings
 import com.android.identity.crypto.EcCurve
@@ -51,7 +51,7 @@ class AndroidKeystoreSecureAreaSupport(
     )
 
     override fun Fragment.unlockKey(
-        authKey: AuthenticationKey,
+        authKey: Credential,
         onKeyUnlocked: (unlockData: KeyUnlockData?) -> Unit,
         onUnlockFailure: (wasCancelled: Boolean) -> Unit
     ) {

--- a/appholder/src/main/java/com/android/identity/wallet/support/SecureAreaSupport.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/support/SecureAreaSupport.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import androidx.compose.runtime.Composable
 import androidx.fragment.app.Fragment
 import com.android.identity.android.securearea.AndroidKeystoreSecureArea
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.document.Document
 import com.android.identity.securearea.CreateKeySettings
 import com.android.identity.securearea.KeyUnlockData
@@ -35,7 +35,7 @@ interface SecureAreaSupport {
      * there is a provided way to navigate using the [findNavController] function.
      */
     fun Fragment.unlockKey(
-        authKey: AuthenticationKey,
+        authKey: Credential,
         onKeyUnlocked: (unlockData: KeyUnlockData?) -> Unit,
         onUnlockFailure: (wasCancelled: Boolean) -> Unit
     )

--- a/appholder/src/main/java/com/android/identity/wallet/support/SecureAreaSupportNull.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/support/SecureAreaSupportNull.kt
@@ -11,7 +11,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.Fragment
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.securearea.CreateKeySettings
 import com.android.identity.securearea.KeyUnlockData
 import com.android.identity.util.Timestamp
@@ -40,7 +40,7 @@ class SecureAreaSupportNull : SecureAreaSupport {
     }
 
     override fun Fragment.unlockKey(
-        authKey: AuthenticationKey,
+        authKey: Credential,
         onKeyUnlocked: (unlockData: KeyUnlockData?) -> Unit,
         onUnlockFailure: (wasCancelled: Boolean) -> Unit
     ) {

--- a/appholder/src/main/java/com/android/identity/wallet/support/SoftwareKeystoreSecureAreaSupport.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/support/SoftwareKeystoreSecureAreaSupport.kt
@@ -20,7 +20,7 @@ import androidx.lifecycle.repeatOnLifecycle
 import androidx.navigation.fragment.findNavController
 import co.nstant.`in`.cbor.CborBuilder
 import com.android.identity.cbor.Cbor
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.CertificateChain
 import com.android.identity.crypto.Crypto
@@ -56,7 +56,7 @@ class SoftwareKeystoreSecureAreaSupport : SecureAreaSupport {
     private val screenState = SoftwareKeystoreSecureAreaSupportState()
 
     override fun Fragment.unlockKey(
-        authKey: AuthenticationKey,
+        authKey: Credential,
         onKeyUnlocked: (unlockData: KeyUnlockData?) -> Unit,
         onUnlockFailure: (wasCancelled: Boolean) -> Unit
     ) {

--- a/appholder/src/main/java/com/android/identity/wallet/transfer/AddDocumentToResponseResult.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/transfer/AddDocumentToResponseResult.kt
@@ -1,6 +1,6 @@
 package com.android.identity.wallet.transfer
 
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 
 sealed class AddDocumentToResponseResult {
 
@@ -9,6 +9,6 @@ sealed class AddDocumentToResponseResult {
     ) : AddDocumentToResponseResult()
 
     data class DocumentLocked(
-        val authKey: AuthenticationKey
+        val authKey: Credential
     ) : AddDocumentToResponseResult()
 }

--- a/appholder/src/main/java/com/android/identity/wallet/util/RefreshKeysWorker.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/RefreshKeysWorker.kt
@@ -16,7 +16,7 @@ class RefreshKeysWorker(
     override fun doWork(): Result {
         documentManager.getDocuments().forEach { documentInformation ->
             val document = documentManager.getDocumentByName(documentInformation.docName)
-            document?.let { provisioningUtil.refreshAuthKeys(it, documentInformation.docType) }
+            document?.let { provisioningUtil.refreshCredentials(it, documentInformation.docType) }
         }
         return Result.success()
     }

--- a/appholder/src/main/java/com/android/identity/wallet/viewmodel/TransferDocumentViewModel.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/viewmodel/TransferDocumentViewModel.kt
@@ -8,7 +8,7 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.viewModelScope
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.mdoc.request.DeviceRequestParser
 import com.android.identity.mdoc.response.DeviceResponseGenerator
 import com.android.identity.securearea.KeyUnlockData
@@ -102,7 +102,7 @@ class TransferDocumentViewModel(val app: Application) : AndroidViewModel(app) {
 
     fun sendResponseForSelection(
         onResultReady: (result: AddDocumentToResponseResult) -> Unit,
-        authKey: AuthenticationKey? = null,
+        authKey: Credential? = null,
         authKeyUnlockData: KeyUnlockData? = null
     ) {
         val elementsToSend = signedElements.collect()

--- a/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
@@ -37,7 +37,7 @@ import java.io.File
 //
 class AndroidKeystoreSecureAreaDocumentStoreTest {
     companion object {
-        private const val AUTH_KEY_DOMAIN = "domain"
+        private const val CREDENTIAL_DOMAIN = "domain"
     }
 
     private lateinit var storageEngine: StorageEngine
@@ -63,10 +63,10 @@ class AndroidKeystoreSecureAreaDocumentStoreTest {
         documentStore.addDocument(document!!)
         Assert.assertEquals("testDocument", document!!.name)
 
-        // Create pending authentication key and check its attestation
+        // Create pending credential and check its attestation
         val authKeyChallenge = byteArrayOf(20, 21, 22)
-        val pendingAuthenticationKey = document.createAuthenticationKey(
-            AUTH_KEY_DOMAIN,
+        val pendingCredential = document.createCredential(
+            CREDENTIAL_DOMAIN,
             secureArea,
             AndroidKeystoreCreateKeySettings.Builder(authKeyChallenge)
                 .setUserAuthenticationRequired(
@@ -76,9 +76,9 @@ class AndroidKeystoreSecureAreaDocumentStoreTest {
                 .build(),
             null
         )
-        Assert.assertFalse(pendingAuthenticationKey.isCertified)
+        Assert.assertFalse(pendingCredential.isCertified)
         val parser =
-            AndroidAttestationExtensionParser(pendingAuthenticationKey.attestation.certificates[0].javaX509Certificate)
+            AndroidAttestationExtensionParser(pendingCredential.attestation.certificates[0].javaX509Certificate)
         Assert.assertArrayEquals(
             authKeyChallenge,
             parser.attestationChallenge

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.kt
@@ -24,7 +24,7 @@ import com.android.identity.cbor.toDataItem
 import com.android.identity.cose.Cose
 import com.android.identity.cose.CoseLabel
 import com.android.identity.cose.CoseNumberLabel
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.document.Document
 import com.android.identity.document.DocumentRequest
 import com.android.identity.document.DocumentRequest.DataElement
@@ -62,7 +62,7 @@ class DeviceResponseGeneratorTest {
     private lateinit var secureArea: SecureArea
     private lateinit var secureAreaRepository: SecureAreaRepository
 
-    private lateinit  var authKey: AuthenticationKey
+    private lateinit  var authKey: Credential
     private lateinit  var document: Document
     private lateinit  var timeSigned: Timestamp
     private lateinit  var timeValidityBegin: Timestamp
@@ -117,7 +117,7 @@ class DeviceResponseGeneratorTest {
         timeSigned = Timestamp.ofEpochMilli(nowMillis)
         timeValidityBegin = Timestamp.ofEpochMilli(nowMillis + 3600 * 1000)
         timeValidityEnd = Timestamp.ofEpochMilli(nowMillis + 10 * 86400 * 1000)
-        authKey = document.createAuthenticationKey(
+        authKey = document.createCredential(
             AUTH_KEY_DOMAIN,
             secureArea,
             SoftwareCreateKeySettings.Builder(ByteArray(0))

--- a/identity/src/main/java/com/android/identity/util/ApplicationData.kt
+++ b/identity/src/main/java/com/android/identity/util/ApplicationData.kt
@@ -22,7 +22,7 @@ import com.android.identity.document.NameSpacedData
  *
  * This interface exists to support applications which wish to store additional data it wants to
  * associate with any object, such as a [com.android.identity.document.Document] or
- * [com.android.identity.document.AuthenticationKey].
+ * [com.android.identity.document.Credential].
  *
  * For example, on a [com.android.identity.document.Document] object one could use this to store the
  * document type (e.g. DocType for 18013-5 documents), user-visible name, logos/background, state,

--- a/identity/src/test/java/com/android/identity/document/DocumentStoreTest.kt
+++ b/identity/src/test/java/com/android/identity/document/DocumentStoreTest.kt
@@ -36,7 +36,7 @@ class DocumentStoreTest {
     private lateinit var secureAreaRepository: SecureAreaRepository
 
     // This isn't really used, we only use a single domain.
-    private val AUTH_KEY_DOMAIN = "domain"
+    private val CREDENTIAL_DOMAIN = "domain"
 
     @Before
     fun setup() {
@@ -198,7 +198,7 @@ class DocumentStoreTest {
     }
 
     @Test
-    fun testAuthenticationKeyUsage() {
+    fun testCredentialUsage() {
         val documentStore = DocumentStore(
             storageEngine,
             secureAreaRepository
@@ -211,153 +211,153 @@ class DocumentStoreTest {
         val timeValidityEnd = Timestamp.ofEpochMilli(150)
         val timeAfterValidity = Timestamp.ofEpochMilli(200)
 
-        // By default, we don't have any auth keys nor any pending auth keys.
-        Assert.assertEquals(0, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.authenticationKeyCounter)
+        // By default, we don't have any credentials nor any pending credentials.
+        Assert.assertEquals(0, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
+        Assert.assertEquals(0, document.credentialCounter)
 
         // Since none are certified or even pending yet, we can't present anything.
-        Assert.assertNull(document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeDuringValidity))
+        Assert.assertNull(document.findCredential(CREDENTIAL_DOMAIN, timeDuringValidity))
 
-        // Create ten authentication keys...
+        // Create ten credentials...
         for (n in 0..9) {
-            document.createAuthenticationKey(
-                AUTH_KEY_DOMAIN,
+            document.createCredential(
+                CREDENTIAL_DOMAIN,
                 secureArea,
                 CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
                 null
             )
         }
-        Assert.assertEquals(0, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(10, document.pendingAuthenticationKeys.size.toLong())
-        Assert.assertEquals(10, document.authenticationKeyCounter)
+        Assert.assertEquals(0, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(10, document.pendingCredentials.size.toLong())
+        Assert.assertEquals(10, document.credentialCounter)
 
         // ... and certify all of them
         var n = 0
-        for (pendingAuthenticationKey in document.pendingAuthenticationKeys) {
+        for (pendingCredential in document.pendingCredentials) {
             val issuerProvidedAuthenticationData = byteArrayOf(1, 2, n++.toByte())
-            pendingAuthenticationKey.certify(
+            pendingCredential.certify(
                 issuerProvidedAuthenticationData,
                 timeValidityBegin,
                 timeValidityEnd
             )
-            Assert.assertEquals(n.toLong(), pendingAuthenticationKey.authenticationKeyCounter)
+            Assert.assertEquals(n.toLong(), pendingCredential.credentialCounter)
         }
-        Assert.assertEquals(10, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(10, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
 
         // If at a time before anything is valid, should not be able to present
-        Assert.assertNull(document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeBeforeValidity))
+        Assert.assertNull(document.findCredential(CREDENTIAL_DOMAIN, timeBeforeValidity))
 
         // Ditto for right after
-        Assert.assertNull(document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeAfterValidity))
+        Assert.assertNull(document.findCredential(CREDENTIAL_DOMAIN, timeAfterValidity))
 
-        // Check we're able to present at a time when the auth keys are valid
-        var authKey = document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeDuringValidity)
-        Assert.assertNotNull(authKey)
-        Assert.assertEquals(0, authKey!!.usageCount.toLong())
+        // Check we're able to present at a time when the credentials are valid
+        var credential = document.findCredential(CREDENTIAL_DOMAIN, timeDuringValidity)
+        Assert.assertNotNull(credential)
+        Assert.assertEquals(0, credential!!.usageCount.toLong())
 
-        // B/c of how findAuthenticationKey(AUTH_KEY_DOMAIN) we know we get the first key. Match
+        // B/c of how findCredential(CREDENTIAL_DOMAIN) we know we get the first credential. Match
         // up with expected issuer signed data as per above.
-        Assert.assertEquals(0.toByte().toLong(), authKey.issuerProvidedData[2].toLong())
-        Assert.assertEquals(0, authKey.usageCount.toLong())
-        authKey.increaseUsageCount()
-        Assert.assertEquals(1, authKey.usageCount.toLong())
+        Assert.assertEquals(0.toByte().toLong(), credential.issuerProvidedData[2].toLong())
+        Assert.assertEquals(0, credential.usageCount.toLong())
+        credential.increaseUsageCount()
+        Assert.assertEquals(1, credential.usageCount.toLong())
 
         // Simulate nine more presentations, all of them should now be used up
         n = 0
         while (n < 9) {
-            authKey = document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeDuringValidity)
-            Assert.assertNotNull(authKey)
+            credential = document.findCredential(CREDENTIAL_DOMAIN, timeDuringValidity)
+            Assert.assertNotNull(credential)
 
-            // B/c of how findAuthenticationKey(AUTH_KEY_DOMAIN) we know we get the keys after
+            // B/c of how findCredential(CREDENTIAL_DOMAIN) we know we get the credentials after
             // the first one in order. Match up with expected issuer signed data as per above.
             Assert.assertEquals(
-                (n + 1).toByte().toLong(), authKey!!.issuerProvidedData[2].toLong()
+                (n + 1).toByte().toLong(), credential!!.issuerProvidedData[2].toLong()
             )
-            authKey.increaseUsageCount()
+            credential.increaseUsageCount()
             n++
         }
 
-        // All ten auth keys should now have a use count of 1.
-        for (authenticationKey in document.certifiedAuthenticationKeys) {
-            Assert.assertEquals(1, authenticationKey.usageCount.toLong())
+        // All ten credentials should now have a use count of 1.
+        for (credential in document.certifiedCredentials) {
+            Assert.assertEquals(1, credential.usageCount.toLong())
         }
 
         // Simulate ten more presentations
         n = 0
         while (n < 10) {
-            authKey = document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeDuringValidity)
-            Assert.assertNotNull(authKey)
-            authKey!!.increaseUsageCount()
+            credential = document.findCredential(CREDENTIAL_DOMAIN, timeDuringValidity)
+            Assert.assertNotNull(credential)
+            credential!!.increaseUsageCount()
             n++
         }
 
-        // All ten auth keys should now have a use count of 2.
-        for (authenticationKey in document.certifiedAuthenticationKeys) {
-            Assert.assertEquals(2, authenticationKey.usageCount.toLong())
+        // All ten credentials should now have a use count of 2.
+        for (credential in document.certifiedCredentials) {
+            Assert.assertEquals(2, credential.usageCount.toLong())
         }
 
         // Create and certify five replacements
         n = 0
         while (n < 5) {
-            document.createAuthenticationKey(
-                AUTH_KEY_DOMAIN,
+            document.createCredential(
+                CREDENTIAL_DOMAIN,
                 secureArea,
                 CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
                 null
             )
             n++
         }
-        Assert.assertEquals(10, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(5, document.pendingAuthenticationKeys.size.toLong())
-        Assert.assertEquals(15, document.authenticationKeyCounter)
+        Assert.assertEquals(10, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(5, document.pendingCredentials.size.toLong())
+        Assert.assertEquals(15, document.credentialCounter)
         n = 11
-        for (pendingAuthenticationKey in document.pendingAuthenticationKeys) {
-            pendingAuthenticationKey.certify(
+        for (pendingCredential in document.pendingCredentials) {
+            pendingCredential.certify(
                 ByteArray(0),
                 timeValidityBegin,
                 timeValidityEnd
             )
-            Assert.assertEquals(n.toLong(), pendingAuthenticationKey.authenticationKeyCounter)
+            Assert.assertEquals(n.toLong(), pendingCredential.credentialCounter)
             n++
         }
-        Assert.assertEquals(15, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(15, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
 
         // Simulate ten presentations and check we get the newly created ones
         n = 0
         while (n < 10) {
-            authKey = document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeDuringValidity)
-            Assert.assertNotNull(authKey)
-            Assert.assertEquals(0, authKey!!.issuerProvidedData.size.toLong())
-            authKey.increaseUsageCount()
+            credential = document.findCredential(CREDENTIAL_DOMAIN, timeDuringValidity)
+            Assert.assertNotNull(credential)
+            Assert.assertEquals(0, credential!!.issuerProvidedData.size.toLong())
+            credential.increaseUsageCount()
             n++
         }
 
-        // All fifteen auth keys should now have a use count of 2.
-        for (authenticationKey in document.certifiedAuthenticationKeys) {
-            Assert.assertEquals(2, authenticationKey.usageCount.toLong())
+        // All fifteen credentials should now have a use count of 2.
+        for (credential in document.certifiedCredentials) {
+            Assert.assertEquals(2, credential.usageCount.toLong())
         }
 
         // Simulate 15 more presentations
         n = 0
         while (n < 15) {
-            authKey = document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeDuringValidity)
-            Assert.assertNotNull(authKey)
-            authKey!!.increaseUsageCount()
+            credential = document.findCredential(CREDENTIAL_DOMAIN, timeDuringValidity)
+            Assert.assertNotNull(credential)
+            credential!!.increaseUsageCount()
             n++
         }
 
-        // All fifteen auth keys should now have a use count of 3. This shows that
-        // we're hitting the auth keys evenly (both old and new).
-        for (authenticationKey in document.certifiedAuthenticationKeys) {
-            Assert.assertEquals(3, authenticationKey.usageCount.toLong())
+        // All fifteen credentials should now have a use count of 3. This shows that
+        // we're hitting the credentials evenly (both old and new).
+        for (credential in document.certifiedCredentials) {
+            Assert.assertEquals(3, credential.usageCount.toLong())
         }
     }
 
     @Test
-    fun testAuthenticationKeyPersistence() {
+    fun testCredentialPersistence() {
         var n: Int
         val timeValidityBegin = Timestamp.ofEpochMilli(50)
         val timeValidityEnd = Timestamp.ofEpochMilli(150)
@@ -367,86 +367,86 @@ class DocumentStoreTest {
         )
         val document = documentStore.createDocument("testDocument")
         documentStore.addDocument(document)
-        Assert.assertEquals(0, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(0, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
 
-        // Create ten pending auth keys and certify four of them
+        // Create ten pending credentials and certify four of them
         n = 0
         while (n < 4) {
-            document.createAuthenticationKey(
-                AUTH_KEY_DOMAIN,
+            document.createCredential(
+                CREDENTIAL_DOMAIN,
                 secureArea,
                 CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
                 null
             )
             n++
         }
-        Assert.assertEquals(0, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(4, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(0, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(4, document.pendingCredentials.size.toLong())
         n = 0
-        for (authenticationKey in document.pendingAuthenticationKeys) {
+        for (credential in document.pendingCredentials) {
             // Because we check that we serialize things correctly below, make sure
-            // the data and validity times vary for each key...
-            authenticationKey.certify(
+            // the data and validity times vary for each credential...
+            credential.certify(
                 byteArrayOf(1, 2, n.toByte()),
                 Timestamp.ofEpochMilli(timeValidityBegin.toEpochMilli() + n),
                 Timestamp.ofEpochMilli(timeValidityEnd.toEpochMilli() + 2 * n)
             )
             for (m in 0 until n) {
-                authenticationKey.increaseUsageCount()
+                credential.increaseUsageCount()
             }
-            Assert.assertEquals(n.toLong(), authenticationKey.usageCount.toLong())
+            Assert.assertEquals(n.toLong(), credential.usageCount.toLong())
             n++
         }
-        Assert.assertEquals(4, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(4, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
         n = 0
         while (n < 6) {
-            document.createAuthenticationKey(
-                AUTH_KEY_DOMAIN,
+            document.createCredential(
+                CREDENTIAL_DOMAIN,
                 secureArea,
                 CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
                 null
             )
             n++
         }
-        Assert.assertEquals(4, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(6, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(4, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(6, document.pendingCredentials.size.toLong())
         val document2 = documentStore.lookupDocument("testDocument")
         Assert.assertNotNull(document2)
-        Assert.assertEquals(4, document2!!.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(6, document2.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(4, document2!!.certifiedCredentials.size.toLong())
+        Assert.assertEquals(6, document2.pendingCredentials.size.toLong())
 
         // Now check that what we loaded matches what we created in-memory just above. We
-        // use the fact that the order of the keys are preserved across save/load.
-        val it1 = document.certifiedAuthenticationKeys.iterator()
-        val it2 = document2.certifiedAuthenticationKeys.iterator()
+        // use the fact that the order of the credentials are preserved across save/load.
+        val it1 = document.certifiedCredentials.iterator()
+        val it2 = document2.certifiedCredentials.iterator()
         n = 0
         while (n < 4) {
-            val key1 = it1.next()
-            val key2 = it2.next()
-            Assert.assertEquals(key1.alias, key2.alias)
-            Assert.assertEquals(key1.validFrom, key2.validFrom)
-            Assert.assertEquals(key1.validUntil, key2.validUntil)
-            Assert.assertEquals(key1.usageCount.toLong(), key2.usageCount.toLong())
-            Assert.assertArrayEquals(key1.issuerProvidedData, key2.issuerProvidedData)
-            Assert.assertEquals(key1.attestation, key2.attestation)
+            val cred1 = it1.next()
+            val cred2 = it2.next()
+            Assert.assertEquals(cred1.alias, cred2.alias)
+            Assert.assertEquals(cred1.validFrom, cred2.validFrom)
+            Assert.assertEquals(cred1.validUntil, cred2.validUntil)
+            Assert.assertEquals(cred1.usageCount.toLong(), cred2.usageCount.toLong())
+            Assert.assertArrayEquals(cred1.issuerProvidedData, cred2.issuerProvidedData)
+            Assert.assertEquals(cred1.attestation, cred2.attestation)
             n++
         }
-        val itp1 = document.pendingAuthenticationKeys.iterator()
-        val itp2 = document2.pendingAuthenticationKeys.iterator()
+        val itp1 = document.pendingCredentials.iterator()
+        val itp2 = document2.pendingCredentials.iterator()
         n = 0
         while (n < 6) {
-            val key1 = itp1.next()
-            val key2 = itp2.next()
-            Assert.assertEquals(key1.alias, key2.alias)
-            Assert.assertEquals(key1.attestation, key2.attestation)
+            val cred1 = itp1.next()
+            val cred2 = itp2.next()
+            Assert.assertEquals(cred1.alias, cred2.alias)
+            Assert.assertEquals(cred1.attestation, cred2.attestation)
             n++
         }
     }
 
     @Test
-    fun testAuthenticationKeyValidity() {
+    fun testCredentialValidity() {
         val documentStore = DocumentStore(
             storageEngine,
             secureAreaRepository
@@ -467,25 +467,25 @@ class DocumentStoreTest {
         val timeOfUseAfterBirthday = Timestamp.ofEpochMilli(120)
         val timeValidityEnd = Timestamp.ofEpochMilli(150)
 
-        // Create and certify ten auth keys. Put age_in_years as the issuer provided data so we can
+        // Create and certify ten credentials. Put age_in_years as the issuer provided data so we can
         // check it below.
         var n = 0
         while (n < 10) {
-            document.createAuthenticationKey(
-                AUTH_KEY_DOMAIN,
+            document.createCredential(
+                CREDENTIAL_DOMAIN,
                 secureArea,
                 CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
                 null
             )
             n++
         }
-        Assert.assertEquals(10, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(10, document.pendingCredentials.size.toLong())
         n = 0
-        for (pendingAuthenticationKey in document.pendingAuthenticationKeys) {
+        for (pendingCredential in document.pendingCredentials) {
             if (n < 5) {
-                pendingAuthenticationKey.certify(byteArrayOf(17), timeValidityBegin, timeOfBirthday)
+                pendingCredential.certify(byteArrayOf(17), timeValidityBegin, timeOfBirthday)
             } else {
-                pendingAuthenticationKey.certify(byteArrayOf(18), timeOfBirthday, timeValidityEnd)
+                pendingCredential.certify(byteArrayOf(18), timeOfBirthday, timeValidityEnd)
             }
             n++
         }
@@ -493,39 +493,39 @@ class DocumentStoreTest {
         // Simulate ten presentations before the birthday
         n = 0
         while (n < 10) {
-            val authenticationKey =
-                document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeOfUseBeforeBirthday)
-            Assert.assertNotNull(authenticationKey)
-            // Check we got a key with age 17.
+            val credential =
+                document.findCredential(CREDENTIAL_DOMAIN, timeOfUseBeforeBirthday)
+            Assert.assertNotNull(credential)
+            // Check we got a credential with age 17.
             Assert.assertEquals(
-                17.toByte().toLong(), authenticationKey!!.issuerProvidedData[0].toLong()
+                17.toByte().toLong(), credential!!.issuerProvidedData[0].toLong()
             )
-            authenticationKey.increaseUsageCount()
+            credential.increaseUsageCount()
             n++
         }
 
         // Simulate twenty presentations after the birthday
         n = 0
         while (n < 20) {
-            val authenticationKey =
-                document.findAuthenticationKey(AUTH_KEY_DOMAIN, timeOfUseAfterBirthday)
-            Assert.assertNotNull(authenticationKey)
-            // Check we got a key with age 18.
+            val credential =
+                document.findCredential(CREDENTIAL_DOMAIN, timeOfUseAfterBirthday)
+            Assert.assertNotNull(credential)
+            // Check we got a credential with age 18.
             Assert.assertEquals(
-                18.toByte().toLong(), authenticationKey!!.issuerProvidedData[0].toLong()
+                18.toByte().toLong(), credential!!.issuerProvidedData[0].toLong()
             )
-            authenticationKey.increaseUsageCount()
+            credential.increaseUsageCount()
             n++
         }
 
-        // Examine the authentication keys. The first five should have use count 2, the
+        // Examine the credentials. The first five should have use count 2, the
         // latter five use count 4.
         n = 0
-        for (authenticationKey in document.certifiedAuthenticationKeys) {
+        for (credential in document.certifiedCredentials) {
             if (n++ < 5) {
-                Assert.assertEquals(2, authenticationKey.usageCount.toLong())
+                Assert.assertEquals(2, credential.usageCount.toLong())
             } else {
-                Assert.assertEquals(4, authenticationKey.usageCount.toLong())
+                Assert.assertEquals(4, credential.usageCount.toLong())
             }
         }
     }
@@ -578,7 +578,7 @@ class DocumentStoreTest {
     }
 
     @Test
-    fun testAuthKeyApplicationData() {
+    fun testCredentialApplicationData() {
         val documentStore = DocumentStore(
             storageEngine,
             secureAreaRepository
@@ -586,14 +586,14 @@ class DocumentStoreTest {
         var document: Document? = documentStore.createDocument("testDocument")
         documentStore.addDocument(document!!)
         for (n in 0..9) {
-            val pendingAuthKey = document.createAuthenticationKey(
-                AUTH_KEY_DOMAIN,
+            val pendingCredential = document.createCredential(
+                CREDENTIAL_DOMAIN,
                 secureArea,
                 CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
                 null
             )
             val value = String.format("bar%02d", n)
-            val pendingAppData = pendingAuthKey.applicationData
+            val pendingAppData = pendingCredential.applicationData
             pendingAppData.setString("foo", value)
             pendingAppData.setData("bar", ByteArray(0))
             Assert.assertEquals(value, pendingAppData.getString("foo"))
@@ -601,8 +601,8 @@ class DocumentStoreTest {
             Assert.assertFalse(pendingAppData.keyExists("non-existent"))
             Assert.assertThrows(IllegalArgumentException::class.java) { pendingAppData.getString("non-existent") }
         }
-        Assert.assertEquals(10, document.pendingAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.certifiedAuthenticationKeys.size.toLong())
+        Assert.assertEquals(10, document.pendingCredentials.size.toLong())
+        Assert.assertEquals(0, document.certifiedCredentials.size.toLong())
 
         // Check that it's persisted to disk.
         try {
@@ -611,33 +611,33 @@ class DocumentStoreTest {
             Thread.currentThread().interrupt()
         }
         document = documentStore.lookupDocument("testDocument")
-        Assert.assertEquals(10, document!!.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(10, document!!.pendingCredentials.size.toLong())
         var n = 0
-        for (pendingAuthKey in document.pendingAuthenticationKeys) {
+        for (pendingCredential in document.pendingCredentials) {
             val value = String.format("bar%02d", n++)
-            val pendingAppData = pendingAuthKey.applicationData
+            val pendingAppData = pendingCredential.applicationData
             Assert.assertEquals(value, pendingAppData.getString("foo"))
             Assert.assertEquals(0, pendingAppData.getData("bar").size.toLong())
             Assert.assertFalse(pendingAppData.keyExists("non-existent"))
             Assert.assertThrows(IllegalArgumentException::class.java) { pendingAppData.getString("non-existent") }
         }
 
-        // Certify and check that data carries over from pending AuthenticationKey
-        // to AuthenticationKey
+        // Certify and check that data carries over from pending Credential
+        // to Credential
         n = 0
-        for (authKey in document.pendingAuthenticationKeys) {
+        for (credential in document.pendingCredentials) {
             val value = String.format("bar%02d", n++)
-            val pendingAppData = authKey.applicationData
+            val pendingAppData = credential.applicationData
             Assert.assertEquals(value, pendingAppData.getString("foo"))
             Assert.assertEquals(0, pendingAppData.getData("bar").size.toLong())
             Assert.assertFalse(pendingAppData.keyExists("non-existent"))
             Assert.assertThrows(IllegalArgumentException::class.java) { pendingAppData.getString("non-existent") }
-            authKey.certify(
+            credential.certify(
                 byteArrayOf(0, n.toByte()),
                 Timestamp.ofEpochMilli(100),
                 Timestamp.ofEpochMilli(200)
             )
-            val appData = authKey.applicationData
+            val appData = credential.applicationData
             Assert.assertEquals(value, appData.getString("foo"))
             Assert.assertEquals(0, appData.getData("bar").size.toLong())
             Assert.assertFalse(appData.keyExists("non-existent"))
@@ -646,9 +646,9 @@ class DocumentStoreTest {
 
         // Check it's persisted to disk.
         n = 0
-        for (authKey in document.certifiedAuthenticationKeys) {
+        for (credential in document.certifiedCredentials) {
             val value = String.format("bar%02d", n++)
-            val appData = authKey.applicationData
+            val appData = credential.applicationData
             Assert.assertEquals(value, appData.getString("foo"))
             Assert.assertEquals(0, appData.getData("bar").size.toLong())
             Assert.assertFalse(appData.keyExists("non-existent"))
@@ -657,57 +657,57 @@ class DocumentStoreTest {
     }
 
     @Test
-    fun testAuthKeyReplacement() {
+    fun testCredentialReplacement() {
         val documentStore = DocumentStore(
             storageEngine,
             secureAreaRepository
         )
         val document = documentStore.createDocument("testDocument")
         documentStore.addDocument(document)
-        Assert.assertEquals(0, document.certifiedAuthenticationKeys.size.toLong())
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
+        Assert.assertEquals(0, document.certifiedCredentials.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
         for (n in 0..9) {
-            val pendingAuthKey = document.createAuthenticationKey(
-                AUTH_KEY_DOMAIN,
+            val pendingCredential = document.createCredential(
+                CREDENTIAL_DOMAIN,
                 secureArea,
                 CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
                 null
             )
-            pendingAuthKey.certify(
+            pendingCredential.certify(
                 byteArrayOf(0, n.toByte()),
                 Timestamp.ofEpochMilli(100),
                 Timestamp.ofEpochMilli(200)
             )
         }
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
-        Assert.assertEquals(10, document.certifiedAuthenticationKeys.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
+        Assert.assertEquals(10, document.certifiedCredentials.size.toLong())
 
-        // Now replace the fifth authentication key
-        val keyToReplace = document.certifiedAuthenticationKeys[5]
+        // Now replace the fifth credential
+        val keyToReplace = document.certifiedCredentials[5]
         Assert.assertArrayEquals(byteArrayOf(0, 5), keyToReplace.issuerProvidedData)
-        val pendingAuthKey = document.createAuthenticationKey(
-            AUTH_KEY_DOMAIN,
+        val pendingCredential = document.createCredential(
+            CREDENTIAL_DOMAIN,
             secureArea,
             CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
             keyToReplace
         )
         // ... it's not replaced until certify() is called
-        Assert.assertEquals(1, document.pendingAuthenticationKeys.size.toLong())
-        Assert.assertEquals(10, document.certifiedAuthenticationKeys.size.toLong())
-        pendingAuthKey.certify(
+        Assert.assertEquals(1, document.pendingCredentials.size.toLong())
+        Assert.assertEquals(10, document.certifiedCredentials.size.toLong())
+        pendingCredential.certify(
             byteArrayOf(1, 0),
             Timestamp.ofEpochMilli(100),
             Timestamp.ofEpochMilli(200)
         )
         // ... now it should be gone.
-        Assert.assertEquals(0, document.pendingAuthenticationKeys.size.toLong())
-        Assert.assertEquals(10, document.certifiedAuthenticationKeys.size.toLong())
+        Assert.assertEquals(0, document.pendingCredentials.size.toLong())
+        Assert.assertEquals(10, document.certifiedCredentials.size.toLong())
 
-        // Check that it was indeed the fifth key that was replaced inspecting issuer-provided data.
+        // Check that it was indeed the fifth credential that was replaced inspecting issuer-provided data.
         // We rely on some implementation details on how ordering works... also cross-reference
         // with data passed into certify() functions above.
         var count = 0
-        for (authKey in document.certifiedAuthenticationKeys) {
+        for (credential in document.certifiedCredentials) {
             val expectedData = arrayOf(
                 byteArrayOf(0, 0),
                 byteArrayOf(0, 1),
@@ -720,14 +720,14 @@ class DocumentStoreTest {
                 byteArrayOf(0, 9),
                 byteArrayOf(1, 0)
             )
-            Assert.assertArrayEquals(expectedData[count++], authKey.issuerProvidedData)
+            Assert.assertArrayEquals(expectedData[count++], credential.issuerProvidedData)
         }
 
-        // Test the case where the replacement key is prematurely deleted. The key
+        // Test the case where the replacement credential is prematurely deleted. The credential
         // being replaced should no longer reference it has a replacement...
-        val toBeReplaced = document.certifiedAuthenticationKeys[0]
-        var replacement = document.createAuthenticationKey(
-            AUTH_KEY_DOMAIN,
+        val toBeReplaced = document.certifiedCredentials[0]
+        var replacement = document.createCredential(
+            CREDENTIAL_DOMAIN,
             secureArea,
             CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
             toBeReplaced
@@ -737,10 +737,10 @@ class DocumentStoreTest {
         replacement.delete()
         Assert.assertNull(toBeReplaced.replacement)
 
-        // Similarly, test the case where the key to be replaced is prematurely deleted.
-        // The replacement key should no longer indicate it's a replacement key.
-        replacement = document.createAuthenticationKey(
-            AUTH_KEY_DOMAIN,
+        // Similarly, test the case where the credential to be replaced is prematurely deleted.
+        // The replacement credential should no longer indicate it's a replacement credential.
+        replacement = document.createCredential(
+            CREDENTIAL_DOMAIN,
             secureArea,
             CreateKeySettings(ByteArray(0), setOf(KeyPurpose.SIGN), EcCurve.P256),
             toBeReplaced

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/MainActivity.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/MainActivity.kt
@@ -133,26 +133,26 @@ class MainActivity : ComponentActivity() {
         document.applicationData.setNameSpacedData("documentData", documentData)
         document.applicationData.setString("docType", MDL_DOCTYPE)
 
-        // Create AuthKeys and MSOs, make sure they're valid for a long time
+        // Create Credentials and MSOs, make sure they're valid for a long time
         val timeSigned = now
         val validFrom = now
         val validUntil = Instant.fromEpochMilliseconds(
             validFrom.toEpochMilliseconds() + 365 * 24 * 3600 * 1000L)
 
-        // Create three authentication keys and certify them
+        // Create three credentials and certify them
         for (n in 0..2) {
-            val pendingAuthKey = document.createAuthenticationKey(
+            val pendingCredential = document.createCredential(
                 AUTH_KEY_DOMAIN,
                 transferHelper.androidKeystoreSecureArea,
                 CreateKeySettings("".toByteArray()),
                 null
             )
 
-            // Generate an MSO and issuer-signed data for this authentication key.
+            // Generate an MSO and issuer-signed data for this credentials.
             val msoGenerator = MobileSecurityObjectGenerator(
                 "SHA-256",
                 MDL_DOCTYPE,
-                pendingAuthKey.attestation.certificates[0].publicKey
+                pendingCredential.attestation.certificates[0].publicKey
             )
             msoGenerator.setValidityInfo(
                 Timestamp.ofEpochMilli(timeSigned.toEpochMilliseconds()),
@@ -201,7 +201,7 @@ class MainActivity : ComponentActivity() {
                 encodedIssuerAuth
             ).generate()
 
-            pendingAuthKey.certify(
+            pendingCredential.certify(
                 issuerProvidedAuthenticationData,
                 Timestamp.ofEpochMilli(validFrom.toEpochMilliseconds()),
                 Timestamp.ofEpochMilli(validUntil.toEpochMilliseconds()))

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/PresentationActivity.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/PresentationActivity.kt
@@ -257,9 +257,9 @@ class PresentationActivity : ComponentActivity() {
         val documentRequest = MdocUtil.generateDocumentRequest(docRequest!!)
         val now = Timestamp.now()
         val document = transferHelper.documentStore.lookupDocument(MainActivity.CREDENTIAL_ID)!!
-        val authKey = document.findAuthenticationKey(MainActivity.AUTH_KEY_DOMAIN, now)!!
+        val credential = document.findCredential(MainActivity.AUTH_KEY_DOMAIN, now)!!
 
-        val staticAuthData = StaticAuthDataParser(authKey.issuerProvidedData).parse()
+        val staticAuthData = StaticAuthDataParser(credential.issuerProvidedData).parse()
         val mergedIssuerNamespaces = MdocUtil.mergeIssuerNamesSpaces(
             documentRequest,
             document.applicationData.getNameSpacedData("documentData"),
@@ -272,8 +272,8 @@ class PresentationActivity : ComponentActivity() {
                 .setIssuerNamespaces(mergedIssuerNamespaces)
                 .setDeviceNamespacesSignature(
                     NameSpacedData.Builder().build(),
-                    authKey.secureArea,
-                    authKey.alias,
+                    credential.secureArea,
+                    credential.alias,
                     null,
                     Algorithm.ES256
                 )

--- a/wallet/src/main/java/com/android/identity/issuance/DocumentExtensions.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/DocumentExtensions.kt
@@ -152,7 +152,7 @@ object DocumentExtensions {
         val numAuthKeys = 3
         val minValidTimeMillis = 30 * 24 * 3600L
         val secureArea = secureAreaRepository.getImplementation("AndroidKeystoreSecureArea")!!
-        val authKeyDomain = WalletApplication.AUTH_KEY_DOMAIN
+        val authKeyDomain = WalletApplication.CREDENTIAL_DOMAIN
 
         // OK, let's see if configuration is available
         if (!refreshState(issuingAuthorityRepository)) {
@@ -165,8 +165,8 @@ object DocumentExtensions {
             return -1
         }
         if (state.condition == DocumentCondition.CONFIGURATION_AVAILABLE) {
-            certifiedAuthenticationKeys.forEach { it.delete() }
-            pendingAuthenticationKeys.forEach { it.delete() }
+            certifiedCredentials.forEach { it.delete() }
+            pendingCredentials.forEach { it.delete() }
 
             documentConfiguration = issuer.documentGetConfiguration(documentIdentifier)
 
@@ -197,7 +197,7 @@ object DocumentExtensions {
         if (state.condition == DocumentCondition.READY) {
             val now = Timestamp.now()
             // First do a dry-run to see how many pending authentication keys will be created
-            val numPendingAuthKeysToCreate = DocumentUtil.managedAuthenticationKeyHelper(
+            val numPendingAuthKeysToCreate = DocumentUtil.managedCredentialHelper(
                 this,
                 secureArea,
                 null,
@@ -219,7 +219,7 @@ object DocumentExtensions {
                 } else {
                     CreateKeySettings(authKeyConfig.challenge)
                 }
-                DocumentUtil.managedAuthenticationKeyHelper(
+                DocumentUtil.managedCredentialHelper(
                     this,
                     secureArea,
                     authKeySettings,
@@ -230,7 +230,7 @@ object DocumentExtensions {
                     minValidTimeMillis,
                     false)
                 val documentPresentationRequests = mutableListOf<DocumentPresentationRequest>()
-                for (pendingAuthKey in pendingAuthenticationKeys) {
+                for (pendingAuthKey in pendingCredentials) {
                     documentPresentationRequests.add(
                         DocumentPresentationRequest(
                             DocumentPresentationFormat.MDOC_MSO,
@@ -248,7 +248,7 @@ object DocumentExtensions {
         var numAuthKeysRefreshed = 0
         if (state.numAvailableCPO > 0) {
             for (cpo in issuer.documentGetPresentationObjects(documentIdentifier)) {
-                val pendingAuthKey = pendingAuthenticationKeys.find {
+                val pendingAuthKey = pendingCredentials.find {
                     it.attestation.certificates.first().publicKey.equals(cpo.authenticationKey) }
                 if (pendingAuthKey == null) {
                     Logger.w(TAG, "No pending AuthenticationKey for pubkey ${cpo.authenticationKey}")

--- a/wallet/src/main/java/com/android/identity_credential/wallet/CardViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/CardViewModel.kt
@@ -10,7 +10,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.identity.android.securearea.AndroidKeystoreKeyInfo
 import com.android.identity.cbor.Cbor
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.document.Document
 import com.android.identity.document.DocumentStore
 import com.android.identity.documenttype.DocumentTypeRepository
@@ -121,7 +121,7 @@ class CardViewModel : ViewModel() {
             // TODO: this can be done more elegantly
             //
             refreshDocumentMutex.withLock {
-                val numAuthKeysRefreshed = document.housekeeping(
+                val numCredsRefreshed = document.housekeeping(
                     walletApplication,
                     issuingAuthorityRepository,
                     secureAreaRepository,
@@ -138,8 +138,8 @@ class CardViewModel : ViewModel() {
                         Toast.makeText(
                             context,
                             String.format(
-                                context.resources.getQuantityString(R.plurals.refreshed_authkey, numAuthKeysRefreshed),
-                                numAuthKeysRefreshed
+                                context.resources.getQuantityString(R.plurals.refreshed_cred, numCredsRefreshed),
+                                numCredsRefreshed
                             ),
                             Toast.LENGTH_SHORT
                         ).show()
@@ -239,7 +239,7 @@ class CardViewModel : ViewModel() {
         val data = document.renderDocumentDetails(context, documentTypeRepository)
 
         val keyInfos = mutableStateListOf<CardKeyInfo>()
-        for (authKey in document.certifiedAuthenticationKeys) {
+        for (authKey in document.certifiedCredentials) {
             keyInfos.add(createCardInfoForAuthKey(authKey))
         }
 
@@ -260,7 +260,7 @@ class CardViewModel : ViewModel() {
         )
     }
 
-    private fun createCardInfoForAuthKey(authKey: AuthenticationKey): CardKeyInfo {
+    private fun createCardInfoForAuthKey(authKey: Credential): CardKeyInfo {
 
         val documentData = StaticAuthDataParser(authKey.issuerProvidedData).parse()
         val issuerAuthCoseSign1 = Cbor.decode(documentData.issuerAuth).asCoseSign1

--- a/wallet/src/main/java/com/android/identity_credential/wallet/DocumentDetails.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/DocumentDetails.kt
@@ -101,10 +101,10 @@ fun Document.renderDocumentDetails(
     context: Context,
     documentTypeRepository: DocumentTypeRepository
 ): DocumentDetails {
-    if (certifiedAuthenticationKeys.size == 0) {
+    if (certifiedCredentials.size == 0) {
         return DocumentDetails("Unknown", null, null, mapOf())
     }
-    val authKey = certifiedAuthenticationKeys[0]
+    val authKey = certifiedCredentials[0]
 
     var portrait: Bitmap? = null
     var signatureOrUsualMark: Bitmap? = null

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -43,7 +43,7 @@ import com.android.identity.android.mdoc.transport.DataTransport
 import com.android.identity.android.securearea.AndroidKeystoreKeyInfo
 import com.android.identity.android.securearea.AndroidKeystoreKeyUnlockData
 import com.android.identity.android.securearea.UserAuthenticationType
-import com.android.identity.document.AuthenticationKey
+import com.android.identity.document.Credential
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.EcPrivateKey
 import com.android.identity.crypto.EcPublicKey
@@ -164,7 +164,7 @@ class PresentationActivity : FragmentActivity() {
         finish()
     }
 
-    private fun onAuthenticationKeyLocked(authKey: AuthenticationKey) {
+    private fun onAuthenticationKeyLocked(authKey: Credential) {
         val keyInfo = authKey.secureArea.getKeyInfo(authKey.alias)
         var userAuthenticationTypes = emptySet<UserAuthenticationType>()
         if (keyInfo is AndroidKeystoreKeyInfo) {
@@ -191,7 +191,7 @@ class PresentationActivity : FragmentActivity() {
 
     private fun finishProcessingRequest(
         keyUnlockData: KeyUnlockData? = null,
-        authKey: AuthenticationKey? = null,
+        authKey: Credential? = null,
     ) {
         // finish processing the request on IO thread
         lifecycleScope.launch {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -43,7 +43,7 @@ class WalletApplication : Application() {
 
         private const val NOTIFICATION_ID_FOR_MISSING_PROXIMITY_PRESENTATION_PERMISSIONS = 42
 
-        const val AUTH_KEY_DOMAIN = "mdoc/MSO"
+        const val CREDENTIAL_DOMAIN = "mdoc/MSO"
 
         // The permissions needed to perform 18013-5 presentations. This only include the
         // BLE permissions because that's the only transport we currently support in the

--- a/wallet/src/main/res/values/plurals.xml
+++ b/wallet/src/main/res/values/plurals.xml
@@ -24,8 +24,8 @@
         <item quantity="one">%d minute</item>
         <item quantity="other">%d minutes</item>
     </plurals>
-    <plurals name="refreshed_authkey">
-        <item quantity="one">Refreshed %d Authentication Key</item>
-        <item quantity="other">Refreshed %d Authentication Keys</item>
+    <plurals name="refreshed_cred">
+        <item quantity="one">Refreshed %d Credential</item>
+        <item quantity="other">Refreshed %d Credentials</item>
     </plurals>
 </resources>

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -156,7 +156,7 @@
     <string name="provisioning_unexpected">Unexpected state: %1$s</string>
 
     <!-- Presentation screen -->
-    <string name="presentation_authkey_usage_warning">Reused Authentication Key</string>
+    <string name="presentation_credential_usage_warning">Reused Credential</string>
     <string name="presentation_biometric_prompt_title">Use your screen lock</string>
     <string name="presentation_biometric_prompt_subtitle">Authentication is required to share this information</string>
     <string name="presentation_lskf_warning_dismiss_btn">Ok</string>


### PR DESCRIPTION
Renamed AuthenticationKey.kt and searched for any instances of the word authentication key being used in libraries and apps (including samples) in order to rename to credential as-needed. Excluded identity-android-legacy from this process.

All library tests pass, and changes have been manually tested in all apps and sample apps by going through provisioning and/or presentation (app-dependant).