### PR TITLE
Pass more data from passport to mDoc

### DIFF
--- a/appverifier/build.gradle
+++ b/appverifier/build.gradle
@@ -64,6 +64,7 @@ dependencies {
     implementation project(':identity-doctypes')
     implementation project(':identity-mdoc')
     implementation project(':identity-android')
+    implementation project(':jpeg2k')
 
     implementation files('../third-party/play-services-identity-credentials-0.0.1-eap01.aar')
     implementation libs.bundles.google.play.services

--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -1,7 +1,6 @@
 package com.android.mdl.appreader.fragment
 
 import android.content.res.Resources
-import android.graphics.BitmapFactory
 import android.icu.text.SimpleDateFormat
 import android.icu.util.GregorianCalendar
 import android.icu.util.TimeZone
@@ -21,6 +20,7 @@ import com.android.identity.documenttype.DocumentAttributeType
 import com.android.identity.documenttype.MdocDataElement
 import com.android.identity.crypto.javaPublicKey
 import com.android.identity.crypto.javaX509Certificate
+import com.android.identity.jpeg2k.Jpeg2kConverter
 import com.android.identity.mdoc.response.DeviceResponseParser
 import com.android.mdl.appreader.R
 import com.android.mdl.appreader.VerifierApp
@@ -77,7 +77,7 @@ class ShowDocumentFragment : Fragment() {
         portraitBytes?.let { pb ->
             logDebug("Showing portrait " + pb.size + " bytes")
             binding.ivPortrait.setImageBitmap(
-                BitmapFactory.decodeByteArray(portraitBytes, 0, pb.size)
+                Jpeg2kConverter.decodeByteArray(requireContext(), portraitBytes!!)
             )
             binding.ivPortrait.visibility = View.VISIBLE
         }
@@ -85,7 +85,7 @@ class ShowDocumentFragment : Fragment() {
         signatureBytes?.let { signature ->
             logDebug("Showing signature " + signature.size + " bytes")
             binding.ivSignature.setImageBitmap(
-                BitmapFactory.decodeByteArray(signatureBytes, 0, signature.size)
+                Jpeg2kConverter.decodeByteArray(requireContext(), signatureBytes!!)
             )
             binding.ivSignature.visibility = View.VISIBLE
         }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -42,7 +42,7 @@
     kotlinx-coroutines = "1.8.0-RC2"
     kotlinx-io-core = "0.3.1"
     kotlinx-io-bytestring = "0.3.1"
-    kotlinx-datetime = "0.5.0"
+    kotlinx-datetime = "0.6.0-RC"
     ksp = "1.8.20-1.0.11"
     junit = "4.13.2"
     org-jetbrains-kotlin-jvm = "1.8.20"

--- a/jpeg2k/build.gradle
+++ b/jpeg2k/build.gradle
@@ -8,7 +8,7 @@ android {
     compileSdk 34
 
     defaultConfig {
-        minSdk 27
+        minSdk 26
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/mrtd-reader/build.gradle
+++ b/mrtd-reader/build.gradle
@@ -30,8 +30,6 @@ android {
 }
 
 dependencies {
-    implementation project(':jpeg2k')
-
     implementation libs.androidx.core.ktx
     implementation libs.androidx.appcompat
     implementation libs.androidx.material

--- a/mrtd-reader/src/main/java/com/android/identity_credential/mrtd/MrtdDecodedData.kt
+++ b/mrtd-reader/src/main/java/com/android/identity_credential/mrtd/MrtdDecodedData.kt
@@ -1,7 +1,5 @@
 package com.android.identity_credential.mrtd
 
-import android.graphics.Bitmap
-
 /**
  * Data read from the passport or ID card.
  *
@@ -9,10 +7,74 @@ import android.graphics.Bitmap
  */
 data class MrtdDecodedData(
     val firstName: String,
+    val firstNameComponents: List<String>,
     val lastName: String,
-    val state: String,
+    val issuingState: String,
     val nationality: String,
     val gender: String,
-    val photo: Bitmap?,
-    val signature: Bitmap?
-)
+    val documentCode: String,
+    val documentNumber: String,
+    val dateOfBirth: String,  // YYMMDD
+    val dateOfExpiry: String,  // YYMMDD
+    val personalNumber: String?,
+    val optionalData1: String?,
+    val optionalData2: String?,
+    val photoMediaType: String?,
+    val photo: ByteArray?,  // JPEG or JPEG2000 bytes
+    val signatureMediaType: String?,
+    val signature: ByteArray? // JPEG or JPEG2000 bytes
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as MrtdDecodedData
+
+        if (firstName != other.firstName) return false
+        if (firstNameComponents != other.firstNameComponents) return false
+        if (lastName != other.lastName) return false
+        if (issuingState != other.issuingState) return false
+        if (nationality != other.nationality) return false
+        if (gender != other.gender) return false
+        if (documentCode != other.documentCode) return false
+        if (documentNumber != other.documentNumber) return false
+        if (dateOfBirth != other.dateOfBirth) return false
+        if (dateOfExpiry != other.dateOfExpiry) return false
+        if (personalNumber != other.personalNumber) return false
+        if (optionalData1 != other.optionalData1) return false
+        if (optionalData2 != other.optionalData2) return false
+        if (photoMediaType != other.photoMediaType) return false
+        if (photo != null) {
+            if (other.photo == null) return false
+            if (!photo.contentEquals(other.photo)) return false
+        } else if (other.photo != null) return false
+        if (signatureMediaType != other.signatureMediaType) return false
+        if (signature != null) {
+            if (other.signature == null) return false
+            if (!signature.contentEquals(other.signature)) return false
+        } else if (other.signature != null) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = firstName.hashCode()
+        result = 31 * result + firstNameComponents.hashCode()
+        result = 31 * result + lastName.hashCode()
+        result = 31 * result + issuingState.hashCode()
+        result = 31 * result + nationality.hashCode()
+        result = 31 * result + gender.hashCode()
+        result = 31 * result + documentCode.hashCode()
+        result = 31 * result + documentNumber.hashCode()
+        result = 31 * result + dateOfBirth.hashCode()
+        result = 31 * result + dateOfExpiry.hashCode()
+        result = 31 * result + (personalNumber?.hashCode() ?: 0)
+        result = 31 * result + (optionalData1?.hashCode() ?: 0)
+        result = 31 * result + (optionalData2?.hashCode() ?: 0)
+        result = 31 * result + (photoMediaType?.hashCode() ?: 0)
+        result = 31 * result + (photo?.contentHashCode() ?: 0)
+        result = 31 * result + (signatureMediaType?.hashCode() ?: 0)
+        result = 31 * result + (signature?.contentHashCode() ?: 0)
+        return result
+    }
+}

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -58,6 +58,7 @@ dependencies {
     implementation project(':identity-android')
     implementation project(':mrtd-reader')
     implementation project(':cbor-processor')
+    implementation project(':jpeg2k')
 
     ksp project(':cbor-processor')
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/DocumentDetails.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/DocumentDetails.kt
@@ -2,7 +2,6 @@ package com.android.identity_credential.wallet
 
 import android.content.Context
 import android.graphics.Bitmap
-import android.graphics.BitmapFactory
 import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.DiagnosticOption
 import com.android.identity.document.Document
@@ -10,6 +9,7 @@ import com.android.identity.documenttype.DocumentAttributeType
 import com.android.identity.documenttype.DocumentTypeRepository
 import com.android.identity.documenttype.MdocDocumentType
 import com.android.identity.documenttype.knowntypes.DrivingLicense
+import com.android.identity.jpeg2k.Jpeg2kConverter
 import com.android.identity.mdoc.mso.MobileSecurityObjectParser
 import com.android.identity.mdoc.mso.StaticAuthDataParser
 
@@ -127,18 +127,11 @@ fun Document.renderDocumentDetails(
             digestIdMapping
         )
         if (result.portrait != null) {
-            portrait = BitmapFactory.decodeByteArray(
-                result.portrait,
-                0,
-                result.portrait.size
-            )
+            portrait = Jpeg2kConverter.decodeByteArray(context, result.portrait)
         }
         if (result.signatureOrUsualMark != null) {
-            signatureOrUsualMark = BitmapFactory.decodeByteArray(
-                result.signatureOrUsualMark,
-                0,
-                result.signatureOrUsualMark.size
-            )
+            signatureOrUsualMark = Jpeg2kConverter.decodeByteArray(
+                context, result.signatureOrUsualMark)
         }
         kvPairs += result.keysAndValues
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdocIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdocIssuingAuthority.kt
@@ -159,13 +159,12 @@ abstract class SelfSignedMdocIssuingAuthority(
 
     }
 
-    protected fun bitmapData(bitmap: Bitmap?, defaultResourceId: Int): ByteArray {
+    protected fun bitmapData(defaultResourceId: Int): ByteArray {
         val baos = ByteArrayOutputStream()
-        (bitmap
-            ?: BitmapFactory.decodeResource(
-                application.applicationContext.resources,
-                defaultResourceId
-            )).compress(Bitmap.CompressFormat.JPEG, 90, baos)
+        BitmapFactory.decodeResource(
+            application.applicationContext.resources,
+            defaultResourceId
+        ).compress(Bitmap.CompressFormat.JPEG, 90, baos)
         return baos.toByteArray()
     }
 


### PR DESCRIPTION
Read all the data from the MRTD "DG1" data group. Also, avoid converting portrait to Android Bitmap, instead pass it as is to the Issuing Authority. Display JPEG2k correctly both in wallet and appverifier. Set date of bith along with "over 18/21" in mDoc/mDL from the MRTD data.

Fixes #565
