### PR TITLE
Adding KTLint to the project to provide a uniform coding style

### DIFF
--- a/.scripts/install-precommit-git-hook
+++ b/.scripts/install-precommit-git-hook
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+project_path=`pwd | xargs dirname`
+git config --local core.hooksPath $project_path
+ln -s ./pre-commit.ktlint ../.git/hooks/pre-commit.ktlint
+echo -e "\n==== Finished installing the KTLint pre-commit Git hook ==== \n"
+echo "Listing from project's .git/hooks/" 
+cd ../.git/hooks && ls -la | grep ktlint

--- a/.scripts/pre-commit.ktlint
+++ b/.scripts/pre-commit.ktlint
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "Running KTLint"
+./gradlew ktlintFormat

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,15 @@
+
+
+buildscript {
+    repositories {
+        jcenter()      // Bintray's repository - a fast Maven Central mirror & more
+        mavenCentral()
+    }
+    dependencies {
+        classpath libs.ktlint.gradle
+    }
+}
+
 plugins {
     alias libs.plugins.android.application apply false
     alias libs.plugins.android.library apply false
@@ -10,6 +22,11 @@ plugins {
     alias libs.plugins.parcelable apply false
     alias libs.plugins.dokka
     alias libs.plugins.org.jetbrains.kotlin.jvm apply false
+}
+
+allprojects {
+    // add ktlint to all modules
+//    apply plugin: libs.plugins.ktlint.get().pluginId
 }
 
 version = 'YYYYMMDD'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -47,6 +47,7 @@
     junit = "4.13.2"
     org-jetbrains-kotlin-jvm = "1.8.20"
     accompanist-permissions = "0.34.0"
+    ktlint = "12.1.0"
 
 [libraries]
     androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
@@ -126,6 +127,8 @@
 
     accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist-permissions"}
 
+    ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
+
 [bundles]
     androidx-core = ["androidx-core-ktx", "androidx-appcompat", "androidx-material", "androidx-contraint-layout", "androidx-fragment-ktx", "androidx-legacy-v4", "androidx-preference-ktx", "androidx-work"]
     androidx-lifecycle = ["androidx-lifecycle-extensions", "androidx-lifecycle-livedata", "androidx-lifecycle-viewmodel"]
@@ -151,3 +154,4 @@
     parcelable = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
     ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
     org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "org-jetbrains-kotlin-jvm" }
+    ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -84,7 +84,6 @@ dependencies {
 
     implementation libs.net.sf.scuba.scuba.sc.android
     implementation libs.org.jmrtd.jmrtd
-
     implementation libs.androidx.camera.view
 
     androidTestImplementation libs.androidx.test.ext.junit


### PR DESCRIPTION
All project modules whose build.gradle defines the ktlint plugin dependency are included when linting. The current implementation applies the ktlint plugin to all modules in the project from the root build.gradle. It is thus easy to disable linting (for development) by commenting out 1 line of code.

#### Linting has been disabled because ktlint gradle tasks are created once a module is applied the ktlint plugin.

[Gradle tasks](https://github.com/jlleitschuh/ktlint-gradle?tab=readme-ov-file#main-tasks) such as ktlintFormat, ktlintCheck are added.

The standard set of rules (pinterest.github.io/ktlint/0.49.1/rules/standard/) are run with every lint.

See [Android Code Linting](https://docs.google.com/document/d/1ThqPdQIgIusnJGslxF1f9s-Q811pDYv13VNlSoEAko8/edit?resourcekey=0-16wrXQeUGW673RVcItDw9Q&tab=t.0).

#### This PR contains only build.gradle changes and no linting/auto-corrected changes. A future PR will bring those changes in.

#### This PR provides the scripts (in .scripts/) that adds a git pre-commit hook to run ktlint -- however this final integration will occur once all linting errors have been resolved (otherwise no one would be able to commit anything)

All unit tests pass. The wallet, reader, verifier apps run OK.

