### PR TITLE
Crypto: add support for HPKE encryption and decryption.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
@@ -154,10 +154,6 @@ class RequestOptionsFragment() : Fragment() {
 
         // Generate the readerKey.
         val readerKey = Crypto.createEcPrivateKey(EcCurve.P256)
-        val readerKeyPair = KeyPair(
-            readerKey.publicKey.javaPublicKey,
-            readerKey.javaPrivateKey
-        )
 
         // TODO: Right now we just request the first of potentially multiple documents, it
         //  would be nice to request each document in sequence and then display all the
@@ -206,7 +202,14 @@ class RequestOptionsFragment() : Fragment() {
 
                         requireActivity().runOnUiThread {
                             findNavController().navigate(RequestOptionsFragmentDirections
-                                .toShowDeviceResponse(bundle, readerKeyPair))
+                                .toShowDeviceResponse(
+                                    bundle,
+                                    KeyPair(
+                                        readerKey.publicKey.javaPublicKey,
+                                        readerKey.javaPrivateKey
+                                    )
+                                )
+                            )
                         }
                     } catch (e: GetCredentialException) {
                         Logger.e(TAG, "An error occurred", e)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@
     org-jetbrains-kotlin-jvm = "1.8.20"
     accompanist-permissions = "0.34.0"
     ktlint = "12.1.0"
+    tink = "1.9.0"
 
 [libraries]
     androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
@@ -126,6 +127,7 @@
     play-services-tasks = { module = "com.google.android.gms:play-services-tasks", version = "18.0.2" }
 
     accompanist-permissions = { group = "com.google.accompanist", name = "accompanist-permissions", version.ref = "accompanist-permissions"}
+    tink = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink"}
 
     ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
 

--- a/identity-android/build.gradle
+++ b/identity-android/build.gradle
@@ -40,7 +40,6 @@ dependencies {
     implementation libs.volley
     implementation libs.kotlinx.datetime
     implementation libs.kotlinx.io.bytestring
-    implementation 'com.google.crypto.tink:tink-android:1.9.0'
 
     testImplementation libs.androidx.test.espresso
     testImplementation libs.androidx.test.ext.junit

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/util/CredmanUtil.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/util/CredmanUtil.kt
@@ -21,393 +21,137 @@ import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.CborArray
 import com.android.identity.cbor.CborMap
 import com.android.identity.cbor.Simple
-import com.google.crypto.tink.HybridDecrypt
-import com.google.crypto.tink.HybridEncrypt
-import com.google.crypto.tink.InsecureSecretKeyAccess
-import com.google.crypto.tink.KeysetHandle
-import com.google.crypto.tink.TinkProtoKeysetFormat
-import com.google.crypto.tink.config.TinkConfig
-import com.google.crypto.tink.hybrid.HybridConfig
-import com.google.crypto.tink.proto.HpkeAead
-import com.google.crypto.tink.proto.HpkeKdf
-import com.google.crypto.tink.proto.HpkeKem
-import com.google.crypto.tink.proto.HpkeParams
-import com.google.crypto.tink.proto.HpkePrivateKey
-import com.google.crypto.tink.proto.HpkePublicKey
-import com.google.crypto.tink.proto.KeyData
-import com.google.crypto.tink.proto.KeyStatusType
-import com.google.crypto.tink.proto.Keyset
-import com.google.crypto.tink.proto.OutputPrefixType
-import com.google.crypto.tink.shaded.protobuf.ByteString
-import com.google.crypto.tink.subtle.EllipticCurves
-import org.bouncycastle.util.BigIntegers
-import java.io.ByteArrayOutputStream
-import java.io.IOException
-import java.math.BigInteger
-import java.security.AlgorithmParameters
-import java.security.KeyFactory
-import java.security.KeyPair
-import java.security.MessageDigest
-import java.security.NoSuchAlgorithmException
-import java.security.PrivateKey
-import java.security.PublicKey
-import java.security.interfaces.ECPrivateKey
-import java.security.interfaces.ECPublicKey
-import java.security.spec.ECGenParameterSpec
-import java.security.spec.ECParameterSpec
-import java.security.spec.ECPoint
-import java.security.spec.ECPublicKeySpec
-import java.security.spec.InvalidKeySpecException
-import java.security.spec.InvalidParameterSpecException
-import java.util.Arrays
+import com.android.identity.crypto.EcCurve
+import com.android.identity.crypto.EcPublicKey
+import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
+import com.android.identity.mdoc.origininfo.OriginInfoDomain
 
+object CredmanUtil {
+    private const val ANDROID_HANDOVER_V1 = "AndroidHandoverv1"
+    private const val BROWSER_HANDOVER_V1 = "BrowserHandoverv1"
+    private const val ANDROID_CREDENTIAL_DOCUMENT_VERSION = "ANDROID-HPKE-v1"
 
-class CredmanUtil(private val publicKey: PublicKey, private val privateKey: PrivateKey? = null) {
-
-    private lateinit var publicKeysetHandle: KeysetHandle
-    private var privateKeysetHandle: KeysetHandle? = null
-
-    companion object {
-        private const val ANDROID_HANDOVER_V1 = "AndroidHandoverv1"
-        private const val BROWSER_HANDOVER_V1 = "BrowserHandoverv1"
-        private const val ANDROID_CREDENTIAL_DOCUMENT_VERSION = "ANDROID-HPKE-v1"
-        private const val PRIMARY_KEY_ID = 1
-        private const val ENCAPSULATED_KEY_LENGTH = 65
-
-        private const val EC_ALGORITHM = "EC"
-        private const val EC_CURVE = "secp256r1"
-
-        // CredentialDocument = {
-        //    "version": tstr,                                // Set to "ANDROID-HPKE-v1"
-        //    "encryptionParameters": EncryptionParameters,
-        //    "cipherText": bstr                              // The encrypted data
-        // }
-        //
-        // EncryptionParameters = {
-        //   "pkEm" :  bstr,                                  // An ephemeral key
-        // }
-        //
-        // TODO: probably need to stuff some stuff into `EncryptionParameters` to bind to
-        //  the session
-        //
-        fun generateCredentialDocument(cipherText: ByteArray,
-                                       encapsulatedPublicKey: PublicKey
-        ): ByteArray {
-            return Cbor.encode(
-                CborMap.builder()
-                    .put("version", ANDROID_CREDENTIAL_DOCUMENT_VERSION)
-                    .putMap("encryptionParameters")
-                    .put("pkEm", publicKeyToUncompressed(encapsulatedPublicKey))
-                    .end()
-                    .put("cipherText", cipherText)
-                    .end()
-                    .build()
-            )
-        }
-
-        fun parseCredentialDocument(encodedCredentialDocument: ByteArray
-        ): Pair<ByteArray, PublicKey> {
-            val map = Cbor.decode(encodedCredentialDocument)
-            val version = map["version"].asTstr
-            if (!version.equals(ANDROID_CREDENTIAL_DOCUMENT_VERSION)) {
-                throw IllegalArgumentException("Unexpected version $version")
-            }
-            val encryptionParameters = map["encryptionParameters"]
-            val pkEm = encryptionParameters["pkEm"].asBstr
-            val encapsulatedPublicKey = publicKeyFromUncompressed(pkEm)
-            val cipherText = map["cipherText"].asBstr
-            return Pair(cipherText, encapsulatedPublicKey)
-        }
-
-        //    SessionTranscript = [
-        //      null, // DeviceEngagementBytes not available
-        //      null, // EReaderKeyBytes not available
-        //      AndroidHandover // defined below
-        //    ]
-        //
-        //    AndroidHandover = [
-        //      "AndroidHandoverv1", // Version number
-        //      nonce, // nonce that comes from request
-        //      appId, // RP package name
-        //      pkRHash, // The SHA256 hash of the recipient public key.
-        //    ]
-        fun generateAndroidSessionTranscript(
-            nonce: ByteArray,
-            packageName: String,
-            requesterIdHash: ByteArray
-        ): ByteArray {
-            return Cbor.encode(
-                CborArray.builder()
-                    .add(Simple.NULL) // DeviceEngagementBytes
-                    .add(Simple.NULL) // EReaderKeyBytes
-                    .addArray() // AndroidHandover
-                    .add(ANDROID_HANDOVER_V1)
-                    .add(nonce)
-                    .add(packageName.toByteArray())
-                    .add(requesterIdHash)
-                    .end()
-                    .end()
-                    .build()
-            )
-        }
-
-        private fun generateOriginInfoBytes(origin: String): ByteArray {
-            return Cbor.encode(
-                CborMap.builder()
-                    .put("cat", 1)
-                    .put("type", 1)
-                    .putMap("details")
-                    .put("baseUrl", origin)
-                    .end()
-                    .end()
-                    .build()
-            )
-        }
-
-        //    SessionTranscript = [
-        //      null, // DeviceEngagementBytes not available
-        //      null, // EReaderKeyBytes not available
-        //      AndroidHandover // defined below
-        //    ]
-        //
-        //    From https://github.com/WICG/mobile-document-request-api
-        //
-        //    BrowserHandover = [
-        //      "BrowserHandoverv1",
-        //      nonce,
-        //      OriginInfoBytes, // origin of the request as defined in ISO/IEC 18013-7
-        //      RequesterIdentity, // ? (omitting)
-        //      pkRHash
-        //    ]
-        fun generateBrowserSessionTranscript(
-            nonce: ByteArray,
-            origin: String,
-            requesterIdHash: ByteArray
-        ): ByteArray {
-            val originInfoBytes = generateOriginInfoBytes(origin)
-
-            return Cbor.encode(
-                CborArray.builder()
-                    .add(Simple.NULL) // DeviceEngagementBytes
-                    .add(Simple.NULL) // EReaderKeyBytes
-                    .addArray() // BrowserHandover
-                    .add(BROWSER_HANDOVER_V1)
-                    .add(nonce)
-                    .add(originInfoBytes)
-                    .add(requesterIdHash)
-                    .end()
-                    .end()
-                    .build()
-            )
-        }
-
-        fun generateClientIdHash(clientId: String): ByteArray {
-            val md = MessageDigest.getInstance("SHA-256")
-            return md.digest(clientId.encodeToByteArray())
-        }
-
-         fun generatePublicKeyHash(publicKey: PublicKey): ByteArray {
-            publicKey as ECPublicKey
-            val encodedKey = EllipticCurves.pointEncode(
-                EllipticCurves.CurveType.NIST_P256,
-                EllipticCurves.PointFormatType.UNCOMPRESSED,
-                publicKey.w
-            )
-
-            val md = MessageDigest.getInstance("SHA-256")
-            return md.digest(encodedKey)
-        }
-
-        private fun encodePublicKey(publicKey: ECPublicKey): ByteArray = EllipticCurves.pointEncode(
-            EllipticCurves.CurveType.NIST_P256,
-            EllipticCurves.PointFormatType.UNCOMPRESSED,
-            publicKey.w
+    // CredentialDocument = {
+    //    "version": tstr,                                // Set to "ANDROID-HPKE-v1"
+    //    "encryptionParameters": EncryptionParameters,
+    //    "cipherText": bstr                              // The encrypted data
+    // }
+    //
+    // EncryptionParameters = {
+    //   "pkEm" :  bstr,                                  // An ephemeral key
+    // }
+    //
+    // TODO: probably need to stuff some stuff into `EncryptionParameters` to bind to
+    //  the session
+    //
+    fun generateCredentialDocument(cipherText: ByteArray,
+                                   encapsulatedPublicKey: EcPublicKey
+    ): ByteArray {
+        encapsulatedPublicKey as EcPublicKeyDoubleCoordinate
+        return Cbor.encode(
+            CborMap.builder()
+                .put("version", ANDROID_CREDENTIAL_DOCUMENT_VERSION)
+                .putMap("encryptionParameters")
+                .put("pkEm", encapsulatedPublicKey.asUncompressedPointEncoding)
+                .end()
+                .put("cipherText", cipherText)
+                .end()
+                .build()
         )
-
-        private fun decodePublicKey(encoded: ByteArray): ECPublicKey {
-            val w = EllipticCurves.pointDecode(
-                EllipticCurves.CurveType.NIST_P256,
-                EllipticCurves.PointFormatType.UNCOMPRESSED,
-                encoded
-            )
-
-            var paramSpec: ECParameterSpec? = null
-            paramSpec = try {
-                val algorithmParameters =
-                    AlgorithmParameters.getInstance(EC_ALGORITHM)
-                algorithmParameters.init(ECGenParameterSpec(EC_CURVE))
-                algorithmParameters.getParameterSpec(ECParameterSpec::class.java)
-            } catch (e: InvalidParameterSpecException) {
-                throw RuntimeException(e)
-            } catch (e: NoSuchAlgorithmException) {
-                throw RuntimeException(e)
-            }
-
-            return try {
-                val factory =
-                    KeyFactory.getInstance(EC_ALGORITHM)
-                factory.generatePublic(ECPublicKeySpec(w, paramSpec)) as ECPublicKey
-            } catch (e: NoSuchAlgorithmException) {
-                throw RuntimeException(e)
-            } catch (e: InvalidKeySpecException) {
-                throw RuntimeException(e)
-            }
-        }
-
-        /* Encodes an integer according to Section 2.3.5 Field-Element-to-Octet-String Conversion
-        *  * of SEC 1: Elliptic Curve Cryptography (https://www.secg.org/sec1-v2.pdf).
-        *  */
-        private fun sec1EncodeFieldElementAsOctetString(
-            octetStringSize: Int,
-            fieldValue: BigInteger?
-        ): ByteArray = BigIntegers.asUnsignedByteArray(octetStringSize, fieldValue)
-
-        fun publicKeyToUncompressed(publicKey: PublicKey): ByteArray {
-            val ecKey = publicKey as ECPublicKey
-            val w: ECPoint = ecKey.w
-            val x: ByteArray = sec1EncodeFieldElementAsOctetString(32, w.getAffineX())
-            val y: ByteArray = sec1EncodeFieldElementAsOctetString(32, w.getAffineY())
-            val baos = ByteArrayOutputStream()
-            baos.write(0x04)
-            try {
-                baos.write(x)
-                baos.write(y)
-            } catch (e: IOException) {
-                throw java.lang.RuntimeException(e)
-            }
-            return baos.toByteArray()
-        }
-
-        fun publicKeyFromUncompressed(uncompressedPublicKey: ByteArray): PublicKey {
-            require(uncompressedPublicKey.size == 65) { "Unexpected length " + uncompressedPublicKey.size + ", expected 65" }
-            require(uncompressedPublicKey[0].toInt() == 0x04) { "Unexpected byte " + uncompressedPublicKey[0].toInt() + ", expected 0x04" }
-            val encodedX: ByteArray = Arrays.copyOfRange(uncompressedPublicKey, 1, 33)
-            val encodedY: ByteArray = Arrays.copyOfRange(uncompressedPublicKey, 33, 65)
-            val x = BigInteger(1, encodedX)
-            val y = BigInteger(1, encodedY)
-            return try {
-                val params =
-                    AlgorithmParameters.getInstance("EC")
-                params.init(ECGenParameterSpec("secp256r1"))
-                val ecParameters =
-                    params.getParameterSpec(
-                        ECParameterSpec::class.java
-                    )
-                val ecPoint = ECPoint(x, y)
-                val keySpec =
-                    ECPublicKeySpec(ecPoint, ecParameters)
-                val kf = KeyFactory.getInstance("EC")
-                kf.generatePublic(keySpec) as ECPublicKey
-            } catch (e: NoSuchAlgorithmException) {
-                throw IllegalStateException("Unexpected error", e)
-            } catch (e: InvalidParameterSpecException) {
-                throw IllegalStateException("Unexpected error", e)
-            } catch (e: InvalidKeySpecException) {
-                throw IllegalStateException("Unexpected error", e)
-            }
-        }
-
     }
 
-    constructor(keyPair: KeyPair) : this(keyPair.public, keyPair.private)
-
-    init {
-        TinkConfig.register()
-        HybridConfig.register()
-        initializeKeysetHandles()
+    fun parseCredentialDocument(encodedCredentialDocument: ByteArray
+    ): Pair<ByteArray, EcPublicKey> {
+        val map = Cbor.decode(encodedCredentialDocument)
+        val version = map["version"].asTstr
+        if (!version.equals(ANDROID_CREDENTIAL_DOCUMENT_VERSION)) {
+            throw IllegalArgumentException("Unexpected version $version")
+        }
+        val encryptionParameters = map["encryptionParameters"]
+        val pkEm = encryptionParameters["pkEm"].asBstr
+        val encapsulatedPublicKey =
+            EcPublicKeyDoubleCoordinate.fromUncompressedPointEncoding(EcCurve.P256, pkEm)
+        val cipherText = map["cipherText"].asBstr
+        return Pair(cipherText, encapsulatedPublicKey)
     }
 
-    private fun initializeKeysetHandles() {
-        val params = HpkeParams.newBuilder()
-            .setAead(HpkeAead.AES_128_GCM)
-            .setKdf(HpkeKdf.HKDF_SHA256)
-            .setKem(HpkeKem.DHKEM_P256_HKDF_SHA256)
-            .build()
-
-        publicKey as ECPublicKey
-        val encodedKey = EllipticCurves.pointEncode(
-            EllipticCurves.CurveType.NIST_P256,
-            EllipticCurves.PointFormatType.UNCOMPRESSED,
-            publicKey.w
+    //    SessionTranscript = [
+    //      null, // DeviceEngagementBytes not available
+    //      null, // EReaderKeyBytes not available
+    //      AndroidHandover // defined below
+    //    ]
+    //
+    //    AndroidHandover = [
+    //      "AndroidHandoverv1", // Version number
+    //      nonce, // nonce that comes from request
+    //      appId, // RP package name
+    //      pkRHash, // The SHA256 hash of the recipient public key.
+    //    ]
+    fun generateAndroidSessionTranscript(
+        nonce: ByteArray,
+        packageName: String,
+        requesterIdHash: ByteArray
+    ): ByteArray {
+        return Cbor.encode(
+            CborArray.builder()
+                .add(Simple.NULL) // DeviceEngagementBytes
+                .add(Simple.NULL) // EReaderKeyBytes
+                .addArray() // AndroidHandover
+                .add(ANDROID_HANDOVER_V1)
+                .add(nonce)
+                .add(packageName.toByteArray())
+                .add(requesterIdHash)
+                .end()
+                .end()
+                .build()
         )
+    }
 
-        val hpkePublicKey = HpkePublicKey.newBuilder()
-            .setVersion(0)
-            .setPublicKey(ByteString.copyFrom(encodedKey))
-            .setParams(params)
-            .build()
-
-        val publicKeyData = KeyData.newBuilder()
-            .setKeyMaterialType(KeyData.KeyMaterialType.ASYMMETRIC_PUBLIC)
-            .setTypeUrl("type.googleapis.com/google.crypto.tink.HpkePublicKey")
-            .setValue(hpkePublicKey.toByteString())
-            .build()
-
-        val publicKeysetKey = Keyset.Key.newBuilder()
-            .setKeyId(PRIMARY_KEY_ID)
-            .setKeyData(publicKeyData)
-            .setOutputPrefixType(OutputPrefixType.RAW)
-            .setStatus(KeyStatusType.ENABLED)
-            .build()
-
-        val publicKeyset = Keyset.newBuilder()
-            .setPrimaryKeyId(PRIMARY_KEY_ID)
-            .addKey(publicKeysetKey)
-            .build()
-
-        publicKeysetHandle = TinkProtoKeysetFormat.parseKeyset(
-            publicKeyset.toByteArray(),
-            InsecureSecretKeyAccess.get()
+    //    SessionTranscript = [
+    //      null, // DeviceEngagementBytes not available
+    //      null, // EReaderKeyBytes not available
+    //      AndroidHandover // defined below
+    //    ]
+    //
+    //    From https://github.com/WICG/mobile-document-request-api
+    //
+    //    BrowserHandover = [
+    //      "BrowserHandoverv1",
+    //      nonce,
+    //      OriginInfoBytes, // origin of the request as defined in ISO/IEC 18013-7
+    //      RequesterIdentity, // ? (omitting)
+    //      pkRHash
+    //    ]
+    fun generateBrowserSessionTranscript(
+        nonce: ByteArray,
+        origin: String,
+        requesterIdHash: ByteArray
+    ): ByteArray {
+        // TODO: Instead of hand-rolling this, we should use OriginInfoDomain which
+        //   uses `domain` instead of `baseUrl` which is what the latest version of 18013-7
+        //   calls for.
+        val originInfoBytes = Cbor.encode(
+            CborMap.builder()
+                .put("cat", 1)
+                .put("type", 1)
+                .putMap("details")
+                .put("baseUrl", origin)
+                .end()
+                .end()
+                .build()
         )
-
-        if (privateKey != null) {
-            privateKey as ECPrivateKey
-            val hpkePrivateKey = HpkePrivateKey.newBuilder()
-                .setPublicKey(hpkePublicKey)
-                .setPrivateKey(ByteString.copyFrom(privateKey.s.toByteArray()))
+        return Cbor.encode(
+            CborArray.builder()
+                .add(Simple.NULL) // DeviceEngagementBytes
+                .add(Simple.NULL) // EReaderKeyBytes
+                .addArray() // BrowserHandover
+                .add(BROWSER_HANDOVER_V1)
+                .add(nonce)
+                .add(originInfoBytes)
+                .add(requesterIdHash)
+                .end()
+                .end()
                 .build()
-
-            val privateKeyData = KeyData.newBuilder()
-                .setKeyMaterialType(KeyData.KeyMaterialType.ASYMMETRIC_PRIVATE)
-                .setTypeUrl("type.googleapis.com/google.crypto.tink.HpkePrivateKey")
-                .setValue(hpkePrivateKey.toByteString())
-                .build()
-
-            val privateKeysetKey = Keyset.Key.newBuilder()
-                .setKeyId(PRIMARY_KEY_ID)
-                .setKeyData(privateKeyData)
-                .setOutputPrefixType(OutputPrefixType.RAW)
-                .setStatus(KeyStatusType.ENABLED)
-                .build()
-            val privateKeyset = Keyset.newBuilder()
-                .setPrimaryKeyId(PRIMARY_KEY_ID)
-                .addKey(privateKeysetKey)
-                .build()
-            privateKeysetHandle = TinkProtoKeysetFormat.parseKeyset(
-                privateKeyset.toByteArray(),
-                InsecureSecretKeyAccess.get()
-            )
-        }
+        )
     }
-
-    fun encrypt(plainText: ByteArray, aad: ByteArray): Pair<ByteArray, ECPublicKey> {
-        val encryptor = publicKeysetHandle.getPrimitive(HybridEncrypt::class.java)
-
-        val output = encryptor.encrypt(plainText, aad)
-
-        val encapsulatedKeyBytes = output.sliceArray(0 until ENCAPSULATED_KEY_LENGTH)
-        val encapsulatedKey = decodePublicKey(encapsulatedKeyBytes)
-
-        val encryptedData = output.sliceArray(ENCAPSULATED_KEY_LENGTH until output.size)
-
-        return Pair(encryptedData, encapsulatedKey)
-    }
-
-    fun decrypt(cipherText: ByteArray, encapsulatedKey: ECPublicKey, aad: ByteArray): ByteArray {
-        check(privateKeysetHandle != null)
-
-        val decryptor = privateKeysetHandle!!.getPrimitive(HybridDecrypt::class.java)
-        return decryptor.decrypt(encodePublicKey(encapsulatedKey) + cipherText, aad)
-    }
-
 }

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     implementation libs.kotlinx.io.bytestring
     implementation libs.kotlinx.datetime
     implementation libs.kotlinx.coroutines.core
+    implementation libs.tink
 
     testImplementation libs.bundles.unit.testing
     testImplementation libs.bouncy.castle.bcprov

--- a/identity/src/main/java/com/android/identity/crypto/Algorithm.kt
+++ b/identity/src/main/java/com/android/identity/crypto/Algorithm.kt
@@ -49,6 +49,16 @@ enum class Algorithm(val coseAlgorithmIdentifier: Int) {
     /** AES-GCM mode w/ 256-bit key, 128-bit tag */
     A256GCM(3),
 
+    /**
+     * Cipher suite for COSE-HPKE in Base Mode that uses the DHKEM(P-256, HKDF-SHA256) KEM,
+     * the HKDF-SHA256 KDF and the AES-128-GCM AEAD.
+     *
+     * Note that this value is still TBD and the proposed value is from
+     * [Use of Hybrid Public-Key Encryption (HPKE) with CBOR Object Signing and Encryption (COSE)](https://www.ietf.org/archive/id/draft-ietf-cose-hpke-07.html#IANA)
+     *
+     */
+    HPKE_BASE_P256_SHA256_AES128GCM(35),
+
     ;
 
     companion object {

--- a/identity/src/test/java/com/android/identity/crypto/CryptoTests.kt
+++ b/identity/src/test/java/com/android/identity/crypto/CryptoTests.kt
@@ -198,18 +198,75 @@ class CryptoTests {
         val privateKey2 = EcPrivateKey.fromPem(pemPrivateKey, publicKey)
         Assert.assertEquals(privateKey2, privateKey)
     }
-    
-    @Test fun testPemEncodeDecode_P256() = testPemEncodeDecode(EcCurve.P256)
-    @Test fun testPemEncodeDecode_P384() = testPemEncodeDecode(EcCurve.P384)
-    @Test fun testPemEncodeDecode_P521() = testPemEncodeDecode(EcCurve.P521)
-    @Test fun testPemEncodeDecode_BRAINPOOLP256R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP256R1)
-    @Test fun testPemEncodeDecode_BRAINPOOLP320R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP320R1)
-    @Test fun testPemEncodeDecode_BRAINPOOLP384R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP384R1)
-    @Test fun testPemEncodeDecode_BRAINPOOLP512R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP512R1)
-    @Test fun testPemEncodeDecode_ED25519() = testPemEncodeDecode(EcCurve.ED25519)
-    @Test fun testPemEncodeDecode_X25519() = testPemEncodeDecode(EcCurve.X25519)
-    @Test fun testPemEncodeDecode_ED448() = testPemEncodeDecode(EcCurve.ED448)
-    @Test fun testPemEncodeDecode_X448() = testPemEncodeDecode(EcCurve.X448)
+
+    @Test
+    fun testPemEncodeDecode_P256() = testPemEncodeDecode(EcCurve.P256)
+    @Test
+    fun testPemEncodeDecode_P384() = testPemEncodeDecode(EcCurve.P384)
+    @Test
+    fun testPemEncodeDecode_P521() = testPemEncodeDecode(EcCurve.P521)
+    @Test
+    fun testPemEncodeDecode_BRAINPOOLP256R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP256R1)
+    @Test
+    fun testPemEncodeDecode_BRAINPOOLP320R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP320R1)
+    @Test
+    fun testPemEncodeDecode_BRAINPOOLP384R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP384R1)
+    @Test
+    fun testPemEncodeDecode_BRAINPOOLP512R1() = testPemEncodeDecode(EcCurve.BRAINPOOLP512R1)
+    @Test
+    fun testPemEncodeDecode_ED25519() = testPemEncodeDecode(EcCurve.ED25519)
+    @Test
+    fun testPemEncodeDecode_X25519() = testPemEncodeDecode(EcCurve.X25519)
+    @Test
+    fun testPemEncodeDecode_ED448() = testPemEncodeDecode(EcCurve.ED448)
+    @Test
+    fun testPemEncodeDecode_X448() = testPemEncodeDecode(EcCurve.X448)
+
+    fun testUncompressedFromTo(curve: EcCurve) {
+        val privateKey = Crypto.createEcPrivateKey(curve)
+        val publicKey = privateKey.publicKey as EcPublicKeyDoubleCoordinate
+
+        val uncompressedForm = publicKey.asUncompressedPointEncoding
+        val key = EcPublicKeyDoubleCoordinate.fromUncompressedPointEncoding(curve, uncompressedForm)
+
+        Assert.assertEquals(key, publicKey)
+    }
+
+    @Test
+    fun testUncompressedFromTo_P256() = testUncompressedFromTo(EcCurve.P256)
+    @Test
+    fun testUncompressedFromTo_P384() = testUncompressedFromTo(EcCurve.P384)
+    @Test
+    fun testUncompressedFromTo_P521() = testUncompressedFromTo(EcCurve.P521)
+    @Test
+    fun testUncompressedFromTo_BRAINPOOLP256R1() = testUncompressedFromTo(EcCurve.BRAINPOOLP256R1)
+    @Test
+    fun testUncompressedFromTo_BRAINPOOLP320R1() = testUncompressedFromTo(EcCurve.BRAINPOOLP320R1)
+    @Test
+    fun testUncompressedFromTo_BRAINPOOLP384R1() = testUncompressedFromTo(EcCurve.BRAINPOOLP384R1)
+    @Test
+    fun testUncompressedFromTo_BRAINPOOLP512R1() = testUncompressedFromTo(EcCurve.BRAINPOOLP512R1)
 
 
+    @Test
+    fun testHpkeRoundtrip() {
+        val receiver = Crypto.createEcPrivateKey(EcCurve.P256)
+        val plainText = "Hello World".toByteArray()
+        val aad = "123".toByteArray()
+
+        val (cipherText, encKey) = Crypto.hpkeEncrypt(
+            Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
+            receiver.publicKey,
+            plainText,
+            aad)
+
+        val decryptedText = Crypto.hpkeDecrypt(
+            Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
+            receiver,
+            cipherText,
+            aad,
+            encKey)
+
+        Assert.assertArrayEquals(decryptedText, plainText)
+    }
 }


### PR DESCRIPTION
This is based on the HPKE encryption routines in CredmanUtils. It's presently using Tink but in the future we may switch to the HPKE implementation in BC to avoid the extra dependency (or we may switch to using just Tink and not BC at all.)

Also port our Credman integration to use these new routines.

Test: New unit tests and all unit tests pass.
Test: Manually tested Credman presentations from appholder
  and wallet to both appverifier and https://www.identitycredential.dev/
