### PR TITLE
Allow device authenticaton retry.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/GetCredentialActivity.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/GetCredentialActivity.kt
@@ -104,7 +104,6 @@ class GetCredentialActivity : FragmentActivity() {
                 override fun onAuthenticationFailed() {
                     super.onAuthenticationFailed()
                     Logger.d("TAG", "onAuthenticationFailed")
-                    onBiometricAuthCompleted(null)
                 }
             })
 


### PR DESCRIPTION
Remove the early exit upon onAuthenticationFailed callback since it is expected to happen occasionally e.g. when a user fingerprint isn't recognized in the first few attempts. This allows the user to retry biometric prompt until it reaches the built in limit, in which case onAuthenticationError will then be invoked.