### PR TITLE
SecureAreaCredential and MdocCredential fixes.

### DIFF
--- a/appholder/src/main/java/com/android/identity/wallet/util/ProvisioningUtil.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/ProvisioningUtil.kt
@@ -122,6 +122,7 @@ class ProvisioningUtil private constructor(
             document,
             CREDENTIAL_DOMAIN,
             {toBeReplaced -> MdocCredential(
+                document,
                 toBeReplaced,
                 CREDENTIAL_DOMAIN,
                 secureArea,

--- a/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
@@ -71,6 +71,7 @@ class AndroidKeystoreSecureAreaDocumentStoreTest {
         // Create pending credential and check its attestation
         val authKeyChallenge = byteArrayOf(20, 21, 22)
         val pendingCredential = SecureAreaBoundCredential(
+            document,
             null,
             CREDENTIAL_DOMAIN,
             secureArea,
@@ -81,7 +82,6 @@ class AndroidKeystoreSecureAreaDocumentStoreTest {
                 )
                 .build(),
         )
-        document.addCredential(pendingCredential)
         Assert.assertFalse(pendingCredential.isCertified)
         val parser =
             AndroidAttestationExtensionParser(pendingCredential.attestation.certificates[0].javaX509Certificate)

--- a/identity-mdoc/src/main/java/com/android/identity/mdoc/credential/MdocCredential.kt
+++ b/identity-mdoc/src/main/java/com/android/identity/mdoc/credential/MdocCredential.kt
@@ -26,16 +26,21 @@ import com.android.identity.securearea.SecureArea
 
 /**
  * An mdoc credential, according to [ISO/IEC 18013-5:2021](https://www.iso.org/standard/69084.html).
- * The credential plays the role of *DeviceKey* and the issuer-signed
- * data includes the *Mobile Security Object* which includes the authentication
+ *
+ * In this type, the key in [SecureAreaBoundCredential] plays the role of *DeviceKey* and the
+ * issuer-signed data includes the *Mobile Security Object* which includes the authentication
  * key and is signed by the issuer. This is used for anti-cloning and to return data signed
  * by the device.
  */
-class MdocCredential() : SecureAreaBoundCredential() {
+class MdocCredential : SecureAreaBoundCredential {
+    companion object {
+        private const val TAG = "MdocCredential"
+    }
 
     /**
-     * Creates a new [MdocCredential].
+     * Constructs a new [MdocCredential].
      *
+     * @param document the document to add the credential to.
      * @param asReplacementFor the credential this credential will replace, if not null
      * @param domain the domain of the credential
      * @param secureArea the secure area for the authentication key associated with this credential.
@@ -43,57 +48,41 @@ class MdocCredential() : SecureAreaBoundCredential() {
      * @param docType the docType of the credential
      */
     constructor(
+        document: Document,
         asReplacementFor: Credential?,
         domain: String,
         secureArea: SecureArea,
         createKeySettings: CreateKeySettings,
         docType: String
-    ) : this() {
-        MdocCredential.apply { create(
-            asReplacementFor,
-            domain,
-            secureArea,
-            createKeySettings,
-            docType
-        ) }
+    ) : super(document, asReplacementFor, domain, secureArea, createKeySettings) {
+        this.docType = docType
+        // Only the leaf constructor should add the credential to the document.
+        if (this::class == MdocCredential::class) {
+            addToDocument()
+        }
     }
 
-    companion object {
-        const val TAG = "MdocCredential"
-
-        fun fromCbor(
-            dataItem: DataItem,
-            document: Document
-        ) = MdocCredential().apply { deserialize(dataItem, document) }
+    /**
+     * Constructs a Credential from serialized data.
+     *
+     * @param document the [Document] that the credential belongs to.
+     * @param dataItem the serialized data.
+     */
+    constructor(
+        document: Document,
+        dataItem: DataItem,
+    ) : super(document, dataItem) {
+        docType = dataItem["docType"].asTstr
     }
 
     /**
      * The docType of the credential as defined in
      * [ISO/IEC 18013-5:2021](https://www.iso.org/standard/69084.html).
      */
-    lateinit var docType: String
-        protected set
+    val docType: String
 
-    protected fun create(
-        asReplacementFor: Credential?,
-        domain: String,
-        secureArea: SecureArea,
-        createKeySettings: CreateKeySettings,
-        docType: String
-    ): MdocCredential {
-        super.create(asReplacementFor, domain, secureArea, createKeySettings)
-        this.docType = docType
-        return this
-    }
-
-    override fun addSerializedData(mapBuilder: MapBuilder<CborBuilder>) {
-        super.addSerializedData(mapBuilder)
-        mapBuilder.put("docType", docType)
-    }
-
-    override fun deserialize(dataItem: DataItem, document: Document): MdocCredential {
-        super.deserialize(dataItem, document)
-        val docType = dataItem["docType"].asTstr
-        return this
+    override fun addSerializedData(builder: MapBuilder<CborBuilder>) {
+        super.addSerializedData(builder)
+        builder.put("docType", docType)
     }
 }

--- a/identity-mdoc/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.kt
+++ b/identity-mdoc/src/test/java/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.kt
@@ -124,6 +124,7 @@ class DeviceResponseGeneratorTest {
         timeValidityBegin = Timestamp.ofEpochMilli(nowMillis + 3600 * 1000)
         timeValidityEnd = Timestamp.ofEpochMilli(nowMillis + 10 * 86400 * 1000)
         mdocCredential = MdocCredential(
+            document,
             null,
             AUTH_KEY_DOMAIN,
             secureArea,
@@ -132,7 +133,6 @@ class DeviceResponseGeneratorTest {
                 .build(),
             "org.iso.18013.5.1.mDL"
         )
-        document.addCredential(mdocCredential)
         Assert.assertFalse(mdocCredential.isCertified)
 
         // Generate an MSO and issuer-signed data for this authentication key.

--- a/identity/src/main/java/com/android/identity/credential/CredentialFactory.kt
+++ b/identity/src/main/java/com/android/identity/credential/CredentialFactory.kt
@@ -49,15 +49,20 @@ class CredentialFactory {
     /**
      * Creates a [Credential] from serialized data.
      *
-     * @param dataItem The serialized credential
      * @param document The document associated with the credential
+     * @param dataItem The serialized credential
      * @return a credential instance
      */
-    fun createCredential(dataItem: DataItem, document: Document): Credential {
+    fun createCredential(document: Document, dataItem: DataItem): Credential {
         val credentialType = dataItem["credentialType"].asTstr
         val credClass = credentials.first { it.simpleName == credentialType}
-        val fromCbor = credClass.companionObject?.declaredMemberFunctions?.first { it.name == "fromCbor" }
-        check(fromCbor != null)
-        return fromCbor.call(credClass.companionObject?.objectInstance, dataItem, document) as Credential
+
+        // Pick the constructor(document: Document, dataItem: DataItem) and invoke.
+        val constructor = credClass.constructors.first {
+            it.parameters.size == 2 &&
+            it.parameters[0].type.classifier == Document::class &&
+            it.parameters[1].type.classifier == DataItem::class
+        }
+        return constructor.call(document, dataItem)
     }
 }

--- a/identity/src/main/java/com/android/identity/document/Document.kt
+++ b/identity/src/main/java/com/android/identity/document/Document.kt
@@ -178,11 +178,11 @@ class Document private constructor(
 
         _pendingCredentials = ArrayList()
         for (item in map["pendingCredentials"].asArray) {
-            _pendingCredentials.add(credentialFactory.createCredential(item, this))
+            _pendingCredentials.add(credentialFactory.createCredential(this, item))
         }
         _certifiedCredentials = ArrayList()
         for (item in map["certifiedCredentials"].asArray) {
-            _certifiedCredentials.add(credentialFactory.createCredential(item, this))
+            _certifiedCredentials.add(credentialFactory.createCredential(this, item))
         }
         credentialCounter = map["credentialCounter"].asNumber
         addedToStore = true
@@ -228,27 +228,13 @@ class Document private constructor(
         return candidate
     }
 
-    /**
-     * Adds a new credential to the document. Should be called immediately after [Credential]
-     * instantiation.
-     *
-     * For a higher-level way of managing credentials, see
-     * [DocumentUtil.managedCredentialHelper].
-     *
-     * @param credential The credential to be added.
-     * @throws IllegalArgumentException if `asReplacementFor` is not null and the given
-     * credential already has a pending credential intending to replace it.
-     */
-    fun addCredential(
+    // Adds a newly created [Credential] to the document, returns the assigned credential counter
+    internal fun addCredential(
         credential: Credential,
-    ) {
-        check(_pendingCredentials.none { it.identifier == credential.identifier }) {
-            "There is already a pending credential with the same identifier as the given credential"
-        }
-        credentialCounter++
-        credential.document = this
+    ) : Long {
+        val assignedCounter = credentialCounter++
         _pendingCredentials.add(credential)
-        saveDocument()
+        return assignedCounter
     }
 
     /**

--- a/identity/src/main/java/com/android/identity/document/DocumentUtil.kt
+++ b/identity/src/main/java/com/android/identity/document/DocumentUtil.kt
@@ -83,8 +83,7 @@ object DocumentUtil {
             if (credentialExceededUseCount || credentialBeyondExpirationDate) {
                 if (authCredential.replacement == null) {
                     if (!dryRun) {
-                        val pendingCredential = createCredential!!.invoke(authCredential)
-                        document.addCredential(pendingCredential)
+                        createCredential!!.invoke(authCredential)
                     }
                     numReplacementsGenerated++
                     continue
@@ -107,7 +106,6 @@ object DocumentUtil {
             if (numNonReplacementsToGenerate > 0) {
                 for (n in 0 until numNonReplacementsToGenerate) {
                     val pendingCredential = createCredential!!.invoke(null)
-                    document.addCredential(pendingCredential)
                     pendingCredential.applicationData.setBoolean(domain, true)
                 }
             }

--- a/identity/src/test/java/com/android/identity/document/DocumentUtilTest.kt
+++ b/identity/src/test/java/com/android/identity/document/DocumentUtilTest.kt
@@ -74,6 +74,7 @@ class DocumentUtilTest {
             document,
             managedCredDomain,
             createCredential = {credentialToReplace -> SecureAreaBoundCredential(
+                document,
                 credentialToReplace,
                 managedCredDomain,
                 secureArea,
@@ -108,6 +109,7 @@ class DocumentUtilTest {
             document,
             managedCredDomain,
             createCredential = {credentialToReplace -> SecureAreaBoundCredential(
+                document,
                 credentialToReplace,
                 managedCredDomain,
                 secureArea,
@@ -132,6 +134,7 @@ class DocumentUtilTest {
             document,
             managedCredDomain,
             createCredential = {credentialToReplace -> SecureAreaBoundCredential(
+                document,
                 credentialToReplace,
                 managedCredDomain,
                 secureArea,
@@ -159,6 +162,7 @@ class DocumentUtilTest {
             document,
             managedCredDomain,
             createCredential = {credentialToReplace -> SecureAreaBoundCredential(
+                document,
                 credentialToReplace,
                 managedCredDomain,
                 secureArea,
@@ -210,6 +214,7 @@ class DocumentUtilTest {
             document,
             managedCredDomain,
             createCredential = {credentialToReplace -> SecureAreaBoundCredential(
+                document,
                 credentialToReplace,
                 managedCredDomain,
                 secureArea,

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/MainActivity.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/MainActivity.kt
@@ -143,13 +143,13 @@ class MainActivity : ComponentActivity() {
         // Create three credentials and certify them
         for (n in 0..2) {
             val pendingCredential = MdocCredential(
+                document,
                 null,
                 AUTH_KEY_DOMAIN,
                 transferHelper.androidKeystoreSecureArea,
                 CreateKeySettings("".toByteArray()),
                 MDL_DOCTYPE
             )
-            document.addCredential(pendingCredential)
 
             // Generate an MSO and issuer-signed data for this credentials.
             val msoGenerator = MobileSecurityObjectGenerator(

--- a/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
@@ -635,6 +635,7 @@ class DocumentModel(
                     document,
                     credDomain,
                     {toBeReplaced -> MdocCredential(
+                        document,
                         toBeReplaced,
                         credDomain,
                         secureArea,


### PR DESCRIPTION
The previous commit which introduced a new hierarchy of Credential classes introduced a couple of small subtle bugs.

First problem was that MdocCredential.doctype wasn't read back properly. This manifested itself in an error when using the "Check for update" facility in the wallet app.

The second problem was that all SecureAreaCredential had the same alias. This is because Credential.identifier isn't assigned until it was added to the Document. This manifested itself in only a single credential being visible in the wallet app.

This PR fixes these problems.

Test: Manually tested with wallet app.
