### PR TITLE
VerificationHelper: Fix BLEIdent when using Negotiated Handover.

### DIFF
--- a/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/deviceretrieval/VerificationHelper.kt
@@ -664,6 +664,14 @@ class VerificationHelper internal constructor(
                     checkNotNull(encodedDeviceEngagement) { "Device Engagement not found in HS message" }
                     check(parsedCms.size >= 1) { "No Alternative Carriers in HS message" }
 
+                    // Now that we have DeviceEngagement, pass eDeviceKeyBytes to the transport
+                    // since it's needed for the Ident characteristic as per ISO/IEC 18013-5:2021
+                    // clause 8.3.3.1.1.3 Connection setup
+                    val engagement = EngagementParser(encodedDeviceEngagement).parse()
+                    for (t in negotiatedHandoverListeningTransports) {
+                        t.setEDeviceKeyBytes(engagement.eSenderKeyBytes)
+                    }
+
                     // TODO: use selected CMs to pick from the list we offered... why would we
                     //  have to do this? Because some mDL / wallets don't return the UUID in
                     //  the HS message.

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
@@ -196,6 +196,7 @@ class DataTransportBleCentralClientMode(
 
     override fun setEDeviceKeyBytes(encodedEDeviceKeyBytes: ByteArray) {
         this.encodedEDeviceKeyBytes = encodedEDeviceKeyBytes
+        gattServer?.setEDeviceKeyBytes(encodedEDeviceKeyBytes)
     }
 
     // TODO: Check if BLE is enabled and error out if not so...

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
@@ -74,13 +74,17 @@ internal class GattServer(
     private var identValue: ByteArray? = null
     private var usingL2CAP = false
 
+    fun setEDeviceKeyBytes(encodedEDeviceKeyBytes: ByteArray) {
+        val ikm: ByteArray = encodedEDeviceKeyBytes
+        val info = "BLEIdent".toByteArray()
+        val salt = byteArrayOf()
+        identValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+    }
+
     @SuppressLint("NewApi")
     fun start(): Boolean {
         if (encodedEDeviceKeyBytes != null) {
-            val ikm: ByteArray = encodedEDeviceKeyBytes
-            val info = "BLEIdent".toByteArray()
-            val salt = byteArrayOf()
-            identValue = Crypto.hkdf(Algorithm.HMAC_SHA256, ikm, salt, info, 16)
+            setEDeviceKeyBytes(encodedEDeviceKeyBytes)
         }
         gattServer = try {
             bluetoothManager.openGattServer(context, this)


### PR DESCRIPTION
At while ago (PR #434) we introduced the concept of warmed-up transports when using Negotiated Handover to speed up presentations. Unfortunately this introduced a bug where we didn't set the right BLEIdent on the GATT Server when using mdoc BLE central client mode. This caused a problem with some mdoc implementations which fails if the BLEIdent value isn't what they expect.

Our own mdoc implementation will only warn if the BLEIdent read from the GATT server isn't what is expects. This behavior has existed for a while but it originally used to error out. Implementations using an old version of our code thus may not currently work with our current VerificationHelper if they're using Negotiated Handover.

Fix this by setting the BLEIdent on a warmed-up connection right after receiving Handover Select. Tested this fix against an implementation known to fail if the BLEIdent isn't it should be.

Test: Manually tested.
