### PR TITLE
DocumentGenerator: Don't include payload in DeviceSigned COSE_Sign1.

### DIFF
--- a/identity-mdoc/src/main/java/com/android/identity/mdoc/response/DocumentGenerator.kt
+++ b/identity-mdoc/src/main/java/com/android/identity/mdoc/response/DocumentGenerator.kt
@@ -117,7 +117,7 @@ class DocumentGenerator
                     secureArea,
                     keyAlias,
                     deviceAuthenticationBytes,
-                    true,
+                    false,
                     signatureAlgorithm,
                     mapOf(
                         Pair(

--- a/identity/src/main/java/com/android/identity/cose/Cose.kt
+++ b/identity/src/main/java/com/android/identity/cose/Cose.kt
@@ -199,6 +199,8 @@ object Cose {
      * @param detachedData detached data, if any.
      * @param signature the COSE_Sign1 object.
      * @param signatureAlgorithm the signature algorithm to use.
+     * @throws IllegalArgumentException if not exactly one of `detachedData` and
+     * `signature.payload` are non-`null`.
      * @return whether the signature is valid and was made with the private key corresponding to the
      * given public key.
      */
@@ -209,6 +211,10 @@ object Cose {
         signature: CoseSign1,
         signatureAlgorithm: Algorithm
     ): Boolean {
+        require(
+            (detachedData != null && signature.payload == null) ||
+                    (detachedData == null && signature.payload != null)
+        )
         val encodedProtectedHeaders =
             if (signature.protectedHeaders.isNotEmpty()) {
                 val phb = CborMap.builder()


### PR DESCRIPTION
ISO/IEC 18013-5:2021 clause 9.1.3.4 specifically said to not do that. This bug was introduced in PR #482 when switching to the new CBOR and COSE libraries. Fix this.

Also add a new check to Cose.coseSign1Check() for this. This check will trigger a unit-test failure if the fix mentioned in the previous paragraph isn't applied.

Test: New test and all unit tests pass.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR