### PR TITLE
Changes to KTLint gradle and configs: disabling rules 

### DIFF
--- a/.config/git-hooks/post-merge
+++ b/.config/git-hooks/post-merge
@@ -1,0 +1,6 @@
+#!/bin/bash
+# script runs after doing a git merge - when there's a diff between local and remote branches
+
+echo "Distributing KTLint .editorconfig files to all modules"
+./gradlew ktlintRemoveEditorConfigFromModule
+./gradlew ktlintGenerateEditorConfigForModule

--- a/.config/git-hooks/pre-commit
+++ b/.config/git-hooks/pre-commit
@@ -1,0 +1,8 @@
+#!/bin/bash
+# Run this script before doing a git commit
+
+echo "Running KTLint"
+# uncomment below when we are ready to fully using linting before commits.
+#./gradlew ktlintRemoveEditorConfigFromModule
+#./gradlew ktlintGenerateEditorConfigForModule
+#./gradlew ktlintFormat --continue

--- a/.config/install-project-git-hooks
+++ b/.config/install-project-git-hooks
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+
+project_path=`pwd | xargs dirname`
+project_git_hooks_path=$project_path/.config/git-hooks/
+
+# ensure git uses this project's git hooks instead
+git config --local core.hooksPath `echo $project_git_hooks_path`
+
+echo -e "\n==== Finished installing the KTLint pre-commit Git hook ==== \n"
+echo "Current git hook path:"
+git config --local core.hooksPath
+
+echo -e "\nGit hooks of this project: \n(ls -la $project_git_hooks_path)\n"
+ls -la $project_git_hooks_path
+

--- a/.config/ktlint-editorconfig
+++ b/.config/ktlint-editorconfig
@@ -1,0 +1,13 @@
+# Source for .editorconfig lives in the root project path in .config/ktlint-editorconfig
+
+root = true
+
+[*.{kt,kts}]
+ktlint_function_naming_ignore_when_annotated_with=Composable
+ktlint_standard_function-naming = disabled
+ktlint_standard_package-name = disabled
+ktlint_standard_no-wildcard-imports = disabled
+ktlint_standard_filename = disabled
+ktlint_standard_comment-wrapping = disabled
+ktlint_standard_discouraged-comment-location = enabled
+ktlint_standard_max-line-length = disabled

--- a/.config/ktlint.gradle
+++ b/.config/ktlint.gradle
@@ -1,0 +1,67 @@
+// KTLint gradle configuration
+
+allprojects {
+    // add ktlint plugin to all modules
+    apply plugin: libs.plugins.ktlint.get().pluginId
+
+    // provide compose-rules ruleset
+    dependencies {
+        ktlintRuleset libs.ktlint.compose.rules
+    }
+}
+
+ktlint {
+    ignoreFailures = true
+    reporters {
+        reporter "plain_group_by_file"
+    }
+
+// Tasks managing the .editorconfig file in all modules
+
+// Main ktlint .editorconfig source file that is copied (and renamed) onto every module
+    def editorconfigSourceFile = rootProject.file('.config/ktlint-editorconfig')
+
+// Loop through all valid sub-projects (that have a build.gradle rather than be a parent to more subprojects)
+    project.subprojects.each { subproject ->
+        // Define the task for generating the .editorconfig file (from ktlint-editorconfig) to all modules
+        subproject.task("ktlintGenerateEditorConfigForModule") {
+            println "==[Generating .editorconfig to subproject module '${subproject.name}']=="
+            // make sure we're in a real module (that has a build.gradle)
+            def buildGradleExists = subproject.file("build.gradle")
+            if (buildGradleExists.exists()) {
+                group = 'ktlint_prep'
+                description = "Generates KTLint .editorconfig file to module '${subproject.name}'"
+
+                inputs.property 'configFile', editorconfigSourceFile
+                outputs.file subproject.file('.editorconfig') // create a new .editorconfig file
+
+                // open a stream and reference the module's .editorconfig file
+                def editorConfigModuleFile = new File(subproject.file('.editorconfig').path)
+
+                doFirst {
+                    // copy the main source .editorconfig's contents to a module's folder
+                    editorConfigModuleFile.text = editorconfigSourceFile.text
+                }
+                println "Added .editorconfig to ${subproject.name}"
+            }
+        }
+    }
+
+// Task for removing .editorconfig file from all modules
+    project.subprojects.each { subproject ->
+        // define the task
+        subproject.task("ktlintRemoveEditorConfigFromModule") {
+            println "==[Removing .editorconfig from subproject modules '${subproject.name}']=="
+            group = 'ktlint_clean'
+            description = "If it exists, removes .editorconfig file from module '${subproject.name}'"
+
+            doFirst {
+                def editorconfig = subproject.file(".editorconfig")
+                if (editorconfig.exists()) {
+                    editorconfig.delete()
+                    println "Deleted .editorconfig from module '${subproject.name}'"
+                }
+            }
+        }
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ fastlane/report.xml
 /mdl-ref-server/mdl-server-db.sqlite3
 /version*
 wwwverifier/build/*
+.editorconfig

--- a/.scripts/install-precommit-git-hook
+++ b/.scripts/install-precommit-git-hook
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-project_path=`pwd | xargs dirname`
-git config --local core.hooksPath $project_path
-ln -s ./pre-commit.ktlint ../.git/hooks/pre-commit.ktlint
-echo -e "\n==== Finished installing the KTLint pre-commit Git hook ==== \n"
-echo "Listing from project's .git/hooks/" 
-cd ../.git/hooks && ls -la | grep ktlint

--- a/.scripts/pre-commit.ktlint
+++ b/.scripts/pre-commit.ktlint
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-echo "Running KTLint"
-./gradlew ktlintFormat

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-
-
 buildscript {
     repositories {
         jcenter()      // Bintray's repository - a fast Maven Central mirror & more
@@ -24,10 +22,6 @@ plugins {
     alias libs.plugins.org.jetbrains.kotlin.jvm apply false
 }
 
-allprojects {
-    // add ktlint to all modules
-//    apply plugin: libs.plugins.ktlint.get().pluginId
-}
 
 version = 'YYYYMMDD'
 
@@ -36,3 +30,6 @@ tasks.dokkaHtmlMultiModule {
     // This has it output to the root directory. Default is to put it in build/dokka.
     // outputDirectory.set(file(version+"/documentation"))
 }
+
+// add KTLint to all subprojects/modules
+apply from: '.config/ktlint.gradle'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -49,7 +49,9 @@
     org-jetbrains-kotlin-jvm = "1.8.20"
     accompanist-permissions = "0.34.0"
     ktlint = "12.1.0"
+    ktlint-compose-rules = "0.0.26"
     tink = "1.9.0"
+
 
 [libraries]
     androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
@@ -133,6 +135,7 @@
     tink = { group = "com.google.crypto.tink", name = "tink-android", version.ref = "tink"}
 
     ktlint-gradle = { module = "org.jlleitschuh.gradle:ktlint-gradle", version.ref = "ktlint" }
+    ktlint-compose-rules = { module = "com.twitter.compose.rules:ktlint", version.ref = "ktlint-compose-rules" }
 
 [bundles]
     androidx-core = ["androidx-core-ktx", "androidx-appcompat", "androidx-material", "androidx-contraint-layout", "androidx-fragment-ktx", "androidx-legacy-v4", "androidx-preference-ktx", "androidx-work"]


### PR DESCRIPTION
- It turns out it's possible to disable KTLint rules (and KTLint configurations) by defining an `.editorconfig` file (previously I had learned that we'd have to define the rules we want to include during linting and that would run on the Application class, rather than disabling specific rules through a config)

## Top 30 violations from KTLint with all the rules enabled

trailing-comma-on-call-site | 5287
indent | 5233
function-signature | 3554
multiline-expression-wrapping | 2380
wrapping | 1237
trailing-comma-on-declaration-site | 1222
argument-list-wrapping | 1030
final-newline | 889
no-blank-line-in-class-body | 862
parameter-list-wrapping | 802
no-consecutive-blank-lines | 504
function-naming | 427
no-empty-first-line-in-class-body | 420
chain-wrapping | 327
no-multi-spaces | 307
package-name | 307
no-blank-line-before-rbrace | 243
blank-line-before-declaration | 240
import-ordering | 224
curly-spacing | 203
no-blank-line-in-list | 184
property-naming | 149
no-unused-imports | 130
colon-spacing | 124
discouraged-comment-location | 93
comment-spacing | 85
no-semi | 82
if-else-wrapping | 80
no-blank-line-in-method-block | 80
op-spacing | 70

## Top 30 violations from KTLint with disabled rules defined in `.editorconfig`

standard:multiline-expression-wrapping | 834
standard:trailing-comma-on-call-site | 513
standard:indent | 350
standard:argument-list-wrapping | 308
standard:wrapping | 242
standard:parameter-list-wrapping | 224
standard:function-signature | 175
standard:trailing-comma-on-declaration-site | 143
standard:property-naming | 54
standard:comma-spacing | 37
standard:blank-line-before-declaration | 36
standard:chain-wrapping | 36
standard:final-newline | 32
standard:no-multi-spaces | 24
standard:if-else-wrapping | 23
standard:no-empty-first-line-in-class-body | 18
standard:no-consecutive-blank-lines | 15
standard:no-trailing-spaces | 14
standard:no-empty-first-line-in-method-block | 10
standard:spacing-between-declarations-with-annotations | 10
standard:discouraged-comment-location | 8
standard:if-else-bracing | 8
standard:import-ordering | 7
standard:comment-spacing | 6
standard:no-single-line-block-comment | 3
standard:no-blank-line-before-rbrace | 2
standard:statement-wrapping | 2
standard:colon-spacing | 1
standard:keyword-spacing | 1
standard:no-semi | 1

I wrote a few python scripts to help parse the `./gradlew ktlintCheck` output to confirm `.editorconfig` rules were working as expected on all subproject modules.


- After extensive trial and error it seems the root-most `.editorconfig` rules are not propagated to modules -- this was a very costly task since each `ktlintCheck` or `ktlintFormat` task takes time and effort to compute and parse results. 
  - I tested manually adding the file - the modules that had this file produced fewer lint violations
  - I tested gradle script for generating this file to all moduels - it worked great
  - I tested making changes only to a `ktlint { .. }` gradle block (relying on defining an editorconfig override instead of copying `.editorconfig` to all modules) but this did not produce results and took a lot of time to figure out the correct parameters.

- Rather than adding an `.editorconfig` file to all modules and thus on git (and would have to maintain it for every module), I've opted to providing global ktlint rules in `ktlint-editorconfig` located in root project `.config/` dir that gets copied to all modules through a gradle script. 
  - this ensures that all `.editorconfig` files are in sync and easier to maintain should we add/remove a rule.
  
- Added 2 gradle tasks for managing `.editorconfig` distributions, `ktlintGenerateEditorConfigForModule` and `ktlintRemoveEditorConfigFromModule`.  These tasks are run on **pre-commit** and **post-merge** git hooks in the following order:
  - remove existing (potentially stale) editorconfigs from all modules
  - generate new editorconfig files for all modules copied from `.config/ktlint-editorconfig`
  - run gradle task `ktlintFormat --continue` (is not executed from within the **post-merge** git hook)
 
- Cleaned up git hooks and installation of them
  - git hooks can be installed by running ./config/install-project-git-hooks which tells git to look for hooks defined for this project inside `.config/git-hooks/` folder.
