### PR TITLE
KTLint Violation Fix - const val names should follow screaming snake case

### DIFF
--- a/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/DrivingLicense.kt
+++ b/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/DrivingLicense.kt
@@ -52,7 +52,7 @@ object DrivingLicense {
                 "Last name, surname, or primary identifier, of the mDL holder.",
                 true,
                 MDL_NAMESPACE,
-                SampleData.familyName.toDataItem
+                SampleData.FAMILY_NAME.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -61,7 +61,7 @@ object DrivingLicense {
                 "First name(s), other name(s), or secondary identifier, of the mDL holder",
                 true,
                 MDL_NAMESPACE,
-                SampleData.givenName.toDataItem
+                SampleData.GIVEN_NAME.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Date,
@@ -97,7 +97,7 @@ object DrivingLicense {
                 "Alpha-2 country code, as defined in ISO 3166-1, of the issuing authority’s country or territory",
                 true,
                 MDL_NAMESPACE,
-                SampleData.issuingCountry.toDataItem
+                SampleData.ISSUING_COUNTRY.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -106,7 +106,7 @@ object DrivingLicense {
                 "Issuing authority name.",
                 true,
                 MDL_NAMESPACE,
-                SampleData.issuingAuthorityMdl.toDataItem
+                SampleData.ISSUING_AUTHORITY_MDL.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -115,7 +115,7 @@ object DrivingLicense {
                 "The number assigned or calculated by the issuing authority.",
                 true,
                 MDL_NAMESPACE,
-                SampleData.documentNumber.toDataItem
+                SampleData.DOCUMENT_NUMBER.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Picture,
@@ -154,7 +154,7 @@ object DrivingLicense {
                 "Distinguishing sign of the issuing country",
                 true,
                 MDL_NAMESPACE,
-                SampleData.unDistinguishingSign.toDataItem
+                SampleData.UN_DISTINGUISHING_SIGN.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -163,7 +163,7 @@ object DrivingLicense {
                 "An audit control number assigned by the issuing authority",
                 false,
                 MDL_NAMESPACE,
-                SampleData.administrativeNumber.toDataItem
+                SampleData.ADMINISTRATIVE_NUMBER.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
@@ -172,7 +172,7 @@ object DrivingLicense {
                 "mDL holder’s sex",
                 false,
                 MDL_NAMESPACE,
-                SampleData.sexIso5218.toDataItem
+                SampleData.SEX_ISO218.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Number,
@@ -181,7 +181,7 @@ object DrivingLicense {
                 "mDL holder’s height in centimetres",
                 false,
                 MDL_NAMESPACE,
-                SampleData.heightCm.toDataItem
+                SampleData.HEIGHT_CM.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Number,
@@ -190,7 +190,7 @@ object DrivingLicense {
                 "mDL holder’s weight in kilograms",
                 false,
                 MDL_NAMESPACE,
-                SampleData.weightKg.toDataItem
+                SampleData.WEIGHT_KG.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.StringOptions(
@@ -245,7 +245,7 @@ object DrivingLicense {
                 "Country and municipality or state/province where the mDL holder was born",
                 false,
                 MDL_NAMESPACE,
-                SampleData.birthPlace.toDataItem
+                SampleData.BIRTH_PLACE.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -254,7 +254,7 @@ object DrivingLicense {
                 "The place where the mDL holder resides and/or may be contacted (street/house number, municipality etc.)",
                 false,
                 MDL_NAMESPACE,
-                SampleData.residentAddress.toDataItem
+                SampleData.RESIDENT_ADDRESS.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Date,
@@ -272,7 +272,7 @@ object DrivingLicense {
                 "The age of the mDL holder",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageInYears.toDataItem
+                SampleData.AGE_IN_YEARS.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Number,
@@ -281,7 +281,7 @@ object DrivingLicense {
                 "The year when the mDL holder was born",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageBirthYear.toDataItem
+                SampleData.AGE_BIRTH_YEAR.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.Boolean,
@@ -290,7 +290,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 13",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver13.toDataItem
+                SampleData.AGE_OVER_13.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.Boolean,
@@ -299,7 +299,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 16",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver16.toDataItem
+                SampleData.AGE_OVER_16.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Boolean,
@@ -308,7 +308,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 18",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver18.toDataItem
+                SampleData.AGE_OVER_18.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Boolean,
@@ -317,7 +317,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 21",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver21.toDataItem
+                SampleData.AGE_OVER_21.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Boolean,
@@ -326,7 +326,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 25",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver25.toDataItem
+                SampleData.AGE_OVER_25.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Boolean,
@@ -335,7 +335,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 60",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver60.toDataItem
+                SampleData.AGE_OVER_60.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Boolean,
@@ -344,7 +344,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 62",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver62.toDataItem
+                SampleData.AGE_OVER_62.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Boolean,
@@ -353,7 +353,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 65",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver65.toDataItem
+                SampleData.AGE_OVER_65.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Boolean,
@@ -362,7 +362,7 @@ object DrivingLicense {
                 "Indication whether the mDL holder is as old or older than 68",
                 false,
                 MDL_NAMESPACE,
-                SampleData.ageOver68.toDataItem
+                SampleData.AGE_OVER_68.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -371,7 +371,7 @@ object DrivingLicense {
                 "Country subdivision code of the jurisdiction that issued the mDL",
                 false,
                 MDL_NAMESPACE,
-                SampleData.issuingJurisdiction.toDataItem
+                SampleData.ISSUING_JURISDICTION.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
@@ -380,7 +380,7 @@ object DrivingLicense {
                 "Nationality of the mDL holder",
                 false,
                 MDL_NAMESPACE,
-                SampleData.nationality.toDataItem
+                SampleData.NATIONALITY.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -389,7 +389,7 @@ object DrivingLicense {
                 "The city where the mDL holder lives",
                 false,
                 MDL_NAMESPACE,
-                SampleData.residentCity.toDataItem
+                SampleData.RESIDENT_CITY.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -398,7 +398,7 @@ object DrivingLicense {
                 "The state/province/district where the mDL holder lives",
                 false,
                 MDL_NAMESPACE,
-                SampleData.residentState.toDataItem
+                SampleData.RESIDENT_STATE.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -407,7 +407,7 @@ object DrivingLicense {
                 "The postal code of the mDL holder",
                 false,
                 MDL_NAMESPACE,
-                SampleData.residentPostalCode.toDataItem
+                SampleData.RESIDENT_POSTAL_CODE.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
@@ -416,7 +416,7 @@ object DrivingLicense {
                 "The country where the mDL holder lives",
                 false,
                 MDL_NAMESPACE,
-                SampleData.residentCountry.toDataItem
+                SampleData.RESIDENT_COUNTRY.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -425,7 +425,7 @@ object DrivingLicense {
                 "The family name of the mDL holder",
                 false,
                 MDL_NAMESPACE,
-                SampleData.familyNameNationalCharacter.toDataItem
+                SampleData.FAMILY_NAME_NATIONAL_CHARACTER.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.String,
@@ -434,7 +434,7 @@ object DrivingLicense {
                 "The given name of the mDL holder",
                 false,
                 MDL_NAMESPACE,
-                SampleData.givenNamesNationalCharacter.toDataItem
+                SampleData.GIVEN_NAMES_NATIONAL_CHARACTER.toDataItem
             )
             .addAttribute(
                 DocumentAttributeType.Picture,
@@ -679,7 +679,7 @@ object DrivingLicense {
                 "mDL holder’s sex",
                 true,
                 AAMVA_NAMESPACE,
-                SampleData.sexIso5218.toDataItem
+                SampleData.SEX_ISO218.toDataItem
             )
             /*
              * Then the attributes that exist only in the mDL Credential Type and not in the VC Credential Type

--- a/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/EUPersonalID.kt
+++ b/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/EUPersonalID.kt
@@ -43,7 +43,7 @@ object EUPersonalID {
                 "Current last name(s), surname(s), or primary identifier of the PID holder",
                 true,
                 EUPID_NAMESPACE,
-                SampleData.familyName.toDataItem
+                SampleData.FAMILY_NAME.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -52,7 +52,7 @@ object EUPersonalID {
                 "Current first name(s), other name(s), or secondary identifier of the PID holder",
                 true,
                 EUPID_NAMESPACE,
-                SampleData.givenName.toDataItem
+                SampleData.GIVEN_NAME.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.Date,
@@ -70,7 +70,7 @@ object EUPersonalID {
                 "The age of the PID holder in years",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.ageInYears.toDataItem
+                SampleData.AGE_IN_YEARS.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.Number,
@@ -79,7 +79,7 @@ object EUPersonalID {
                 "The year when the PID holder was born",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.ageBirthYear.toDataItem
+                SampleData.AGE_BIRTH_YEAR.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.Boolean,
@@ -88,7 +88,7 @@ object EUPersonalID {
                 "Age over 18?",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.ageOver18.toDataItem
+                SampleData.AGE_OVER_18.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.Boolean,
@@ -97,7 +97,7 @@ object EUPersonalID {
                 "Age over 21?",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.ageOver21.toDataItem
+                SampleData.AGE_OVER_21.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -106,7 +106,7 @@ object EUPersonalID {
                 "Last name(s), surname(s), or primary identifier of the PID holder at birth",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.familyNameBirth.toDataItem
+                SampleData.FAMILY_NAME_BIRTH.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -115,7 +115,7 @@ object EUPersonalID {
                 "First name(s), other name(s), or secondary identifier of the PID holder at birth",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.givenNameBirth.toDataItem
+                SampleData.GIVEN_NAME_BIRTH.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -124,7 +124,7 @@ object EUPersonalID {
                 "Country and municipality or state/province where the PID holder was born",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.birthPlace.toDataItem
+                SampleData.BIRTH_PLACE.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
@@ -133,7 +133,7 @@ object EUPersonalID {
                 "The country where the PID User was born, as an Alpha-2 country code as specified in ISO 3166-1",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.birthCountry.toDataItem
+                SampleData.BIRTH_COUNTRY.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -142,7 +142,7 @@ object EUPersonalID {
                 "The state, province, district, or local area where the PID User was born",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.birthState.toDataItem
+                SampleData.BIRTH_STATE.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -151,7 +151,7 @@ object EUPersonalID {
                 "The municipality, city, town, or village where the PID User was born",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.birthCity.toDataItem
+                SampleData.BIRTH_CITY.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -160,7 +160,7 @@ object EUPersonalID {
                 "The full address of the place where the PID holder currently resides and/or may be contacted (street/house number, municipality etc.)",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.residentAddress.toDataItem
+                SampleData.RESIDENT_ADDRESS.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
@@ -169,7 +169,7 @@ object EUPersonalID {
                 "The country where the PID User currently resides, as an Alpha-2 country code as specified in ISO 3166-1",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.residentCountry.toDataItem
+                SampleData.RESIDENT_COUNTRY.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -178,7 +178,7 @@ object EUPersonalID {
                 "The state, province, district, or local area where the PID User currently resides.",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.residentState.toDataItem
+                SampleData.RESIDENT_STATE.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -187,7 +187,7 @@ object EUPersonalID {
                 "The city where the PID holder currently resides",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.residentCity.toDataItem
+                SampleData.RESIDENT_CITY.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -196,7 +196,7 @@ object EUPersonalID {
                 "The postal code of the place where the PID holder currently resides",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.residentPostalCode.toDataItem
+                SampleData.RESIDENT_POSTAL_CODE.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -205,7 +205,7 @@ object EUPersonalID {
                 "The name of the street where the PID User currently resides.",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.residentStreet.toDataItem
+                SampleData.RESIDENT_STREET.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -214,7 +214,7 @@ object EUPersonalID {
                 "The house number where the PID User currently resides, including any affix or suffix",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.residentHouseNumber.toDataItem
+                SampleData.RESIDENT_HOUSE_NUMBER.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
@@ -223,7 +223,7 @@ object EUPersonalID {
                 "PID holder’s gender",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.sexIso5218.toDataItem
+                SampleData.SEX_ISO218.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
@@ -232,7 +232,7 @@ object EUPersonalID {
                 "Alpha-2 country code as specified in ISO 3166-1, representing the nationality of the PID User.",
                 true,
                 EUPID_NAMESPACE,
-                SampleData.nationality.toDataItem
+                SampleData.NATIONALITY.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.Date,
@@ -261,7 +261,7 @@ object EUPersonalID {
                         "no separate authority authorized to issue PIDs.",
                 true,
                 EUPID_NAMESPACE,
-                SampleData.issuingAuthorityEuPid.toDataItem
+                SampleData.ISSUING_AUTHORITY_EU_PID.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -270,7 +270,7 @@ object EUPersonalID {
                 "A number for the PID, assigned by the PID Provider.",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.documentNumber.toDataItem
+                SampleData.DOCUMENT_NUMBER.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -279,7 +279,7 @@ object EUPersonalID {
                 "A number assigned by the PID Provider for audit control or other purposes.",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.administrativeNumber.toDataItem
+                SampleData.ADMINISTRATIVE_NUMBER.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.String,
@@ -290,7 +290,7 @@ object EUPersonalID {
                         "as the value for issuing_country.",
                 false,
                 EUPID_NAMESPACE,
-                SampleData.issuingJurisdiction.toDataItem
+                SampleData.ISSUING_JURISDICTION.toDataItem
             )
             .addMdocAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
@@ -300,7 +300,7 @@ object EUPersonalID {
                         "country or territory",
                 true,
                 EUPID_NAMESPACE,
-                SampleData.issuingCountry.toDataItem
+                SampleData.ISSUING_COUNTRY.toDataItem
             )
             .build()
     }

--- a/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/SampleData.kt
+++ b/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/SampleData.kt
@@ -14,51 +14,51 @@ import kotlinx.datetime.LocalDate
  */
 internal object SampleData {
 
-    const val givenName = "Erika"
-    const val familyName = "Mustermann"
-    const val givenNameBirth = "Erika"
-    const val familyNameBirth = "Mustermann"
-    const val givenNamesNationalCharacter = "Ерика"
-    const val familyNameNationalCharacter = "Бабіак"
+    const val GIVEN_NAME = "Erika"
+    const val FAMILY_NAME = "Mustermann"
+    const val GIVEN_NAME_BIRTH = "Erika"
+    const val FAMILY_NAME_BIRTH = "Mustermann"
+    const val GIVEN_NAMES_NATIONAL_CHARACTER = "Ерика"
+    const val FAMILY_NAME_NATIONAL_CHARACTER = "Бабіак"
 
     val birthDate = LocalDate.parse("1971-09-01")
-    const val birthCountry = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
+    const val BIRTH_COUNTRY = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
     val issueDate = LocalDate.parse("2024-03-15")
     val expiryDate = LocalDate.parse("2028-09-01")
-    const val issuingCountry = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
-    const val issuingAuthorityMdl = "Utopia Department of Motor Vehicles"
-    const val issuingAuthorityEuPid = "Utopia Central Registry"
-    const val documentNumber = "987654321"
+    const val ISSUING_COUNTRY = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
+    const val ISSUING_AUTHORITY_MDL = "Utopia Department of Motor Vehicles"
+    const val ISSUING_AUTHORITY_EU_PID = "Utopia Central Registry"
+    const val DOCUMENT_NUMBER = "987654321"
 
-    const val unDistinguishingSign = "UTO"
-    const val administrativeNumber = "123456789"
-    const val sexIso5218 = 2
-    const val heightCm = 175
-    const val weightKg = 68
-    const val birthPlace = "Sample City"
-    const val birthState = "Sample State"
-    const val birthCity = "Sample City"
-    const val residentAddress = "Sample Street 123, 12345 Sample City, Sample State, Utopia"
+    const val UN_DISTINGUISHING_SIGN = "UTO"
+    const val ADMINISTRATIVE_NUMBER = "123456789"
+    const val SEX_ISO218 = 2
+    const val HEIGHT_CM = 175
+    const val WEIGHT_KG = 68
+    const val BIRTH_PLACE = "Sample City"
+    const val BIRTH_STATE = "Sample State"
+    const val BIRTH_CITY = "Sample City"
+    const val RESIDENT_ADDRESS = "Sample Street 123, 12345 Sample City, Sample State, Utopia"
     val portraitCaptureDate = LocalDate.parse("2020-03-14")
-    const val ageInYears = 53
-    const val ageBirthYear = 1971
-    const val ageOver13 = true
-    const val ageOver16 = true
-    const val ageOver18 = true
-    const val ageOver21 = true
-    const val ageOver25 = true
-    const val ageOver60 = false
-    const val ageOver62 = false
-    const val ageOver65 = false
-    const val ageOver68 = false
-    const val issuingJurisdiction = "State of Utopia"
-    const val nationality = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
-    const val residentStreet = "Sample Street"
-    const val residentHouseNumber = "123"
-    const val residentPostalCode = "12345"
-    const val residentCity = "Sample City"
-    const val residentState = "Sample State"
-    const val residentCountry = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
+    const val AGE_IN_YEARS = 53
+    const val AGE_BIRTH_YEAR = 1971
+    const val AGE_OVER_13 = true
+    const val AGE_OVER_16 = true
+    const val AGE_OVER_18 = true
+    const val AGE_OVER_21 = true
+    const val AGE_OVER_25 = true
+    const val AGE_OVER_60 = false
+    const val AGE_OVER_62 = false
+    const val AGE_OVER_65 = false
+    const val AGE_OVER_68 = false
+    const val ISSUING_JURISDICTION = "State of Utopia"
+    const val NATIONALITY = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
+    const val RESIDENT_STREET = "Sample Street"
+    const val RESIDENT_HOUSE_NUMBER = "123"
+    const val RESIDENT_POSTAL_CODE = "12345"
+    const val RESIDENT_CITY = "Sample City"
+    const val RESIDENT_STATE = "Sample State"
+    const val RESIDENT_COUNTRY = "UT"  // Note: UT doesn't exist in ISO-3166-1 Alpha-2
 
     // TODO
     //val portrait

--- a/jpeg2k/src/main/java/com/android/identity/jpeg2k/Jpeg2kConverter.kt
+++ b/jpeg2k/src/main/java/com/android/identity/jpeg2k/Jpeg2kConverter.kt
@@ -99,17 +99,17 @@ class Jpeg2kConverter(private val tmpDir: File) {
         val buffer = ByteArrayOutputStream()
         var i = 0
         var xrefOffset = -1
-        while (i < pdfTemplate.length) {
-            val c = pdfTemplate[i++]
+        while (i < PDF_TEMPLATE.length) {
+            val c = PDF_TEMPLATE[i++]
             if (c != '@') {
                 buffer.write(c.code)
                 continue
             }
-            if (pdfTemplate[i++] != '{') {
+            if (PDF_TEMPLATE[i++] != '{') {
                 throw IllegalStateException("Invalid template")
             }
-            val k = pdfTemplate.indexOf('}', i)
-            val name = pdfTemplate.substring(i, k)
+            val k = PDF_TEMPLATE.indexOf('}', i)
+            val name = PDF_TEMPLATE.substring(i, k)
             i = k + 1
             when (name) {
                 "width" -> putAscii(buffer, widthStr)
@@ -149,7 +149,7 @@ class Jpeg2kConverter(private val tmpDir: File) {
             }
         }
 
-        private const val pdfTemplate = """%PDF-1.5
+        private const val PDF_TEMPLATE = """%PDF-1.5
 1 0 obj
 << /Pages 2 0 R /Type /Catalog >>
 endobj


### PR DESCRIPTION
Addresses some of the violations from the `property-naming` rule - namely, this PR provides fixes for lines that violate `Property name should use the screaming snake case notation when the value can not be changed (standard:property-naming)`

KTLint progress
https://docs.google.com/document/d/15sudT38S_EMyEANG2td4uDj1i5AlPsWh89JEci9ztgU/edit?resourcekey=0-FYwTd3Tp8f-RZnyEvUdfHQ&tab=t.0#heading=h.7ekjxflvdla5

All tests pass and ran app holder + verifier for sanity test.