### PR TITLE
Bug Fix in AndroidAttestationExtensionParser

### DIFF
--- a/identity-android/src/androidTest/java/com/android/identity/AndroidAttestationExtensionParser.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/AndroidAttestationExtensionParser.kt
@@ -184,7 +184,7 @@ class AndroidAttestationExtensionParser(cert: X509Certificate) {
             val authorizationMap: MutableMap<Int, ASN1Primitive?> = HashMap()
             for (entry in authorizationList) {
                 val taggedEntry = entry as ASN1TaggedObject
-                authorizationMap[taggedEntry.tagNo] = taggedEntry.getObject()
+                authorizationMap[taggedEntry.tagNo] = taggedEntry.baseObject as ASN1Primitive
             }
             return authorizationMap
         }


### PR DESCRIPTION
Replaced taggedEntry.getObject() with taggedEntry.baseObject as ASN1Primitive.

Tested locally.

Fixes #602 