### PR TITLE
Misc wallet server changes.

### DIFF
--- a/identity-android-legacy/build.gradle
+++ b/identity-android-legacy/build.gradle
@@ -28,6 +28,13 @@ android {
     lint {
         lintConfig file('lint.xml')
     }
+
+    packagingOptions {
+        resources {
+            excludes += '/META-INF/{AL2.0,LGPL2.1}'
+            excludes += '/META-INF/versions/9/OSGI-INF/MANIFEST.MF'
+        }
+    }
 }
 
 dependencies {

--- a/identity-android/build.gradle
+++ b/identity-android/build.gradle
@@ -28,6 +28,13 @@ android {
     lint {
         lintConfig file('lint.xml')
     }
+
+    packagingOptions {
+        resources {
+            excludes += '/META-INF/{AL2.0,LGPL2.1}'
+            excludes += '/META-INF/versions/9/OSGI-INF/MANIFEST.MF'
+        }
+    }
 }
 
 dependencies {

--- a/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
@@ -16,7 +16,7 @@
 package com.android.identity.android.document
 
 import androidx.test.InstrumentationRegistry
-import com.android.identity.AndroidAttestationExtensionParser
+import com.android.identity.util.AndroidAttestationExtensionParser
 import com.android.identity.android.securearea.AndroidKeystoreCreateKeySettings
 import com.android.identity.android.securearea.AndroidKeystoreSecureArea
 import com.android.identity.android.securearea.UserAuthenticationType

--- a/identity-android/src/androidTest/java/com/android/identity/android/securearea/AndroidKeystoreSecureAreaTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/securearea/AndroidKeystoreSecureAreaTest.kt
@@ -24,7 +24,7 @@ import android.os.Build
 import android.security.keystore.KeyGenParameterSpec
 import android.security.keystore.KeyProperties
 import androidx.test.InstrumentationRegistry
-import com.android.identity.AndroidAttestationExtensionParser
+import com.android.identity.util.AndroidAttestationExtensionParser
 import com.android.identity.android.storage.AndroidStorageEngine
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
@@ -702,13 +702,13 @@ class AndroidKeystoreSecureAreaTest {
         // tag 400: https://source.android.com/docs/security/features/keystore/tags#active_datetime
         Assert.assertEquals(
             validFrom.toEpochMilli(),
-            parser.getSoftwareAuthorizationLong(400).get()
+            parser.getSoftwareAuthorizationLong(400)
         )
 
         // tag 401: https://source.android.com/docs/security/features/keystore/tags#origination_expire_datetime
         Assert.assertEquals(
             validUntil.toEpochMilli(),
-            parser.getSoftwareAuthorizationLong(401).get()
+            parser.getSoftwareAuthorizationLong(401)
         )
     }
 

--- a/identity/build.gradle
+++ b/identity/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation libs.kotlinx.io.bytestring
     implementation libs.kotlinx.datetime
     implementation libs.kotlinx.coroutines.core
+    implementation libs.kotlinx.serialization
     implementation libs.tink
 
     testImplementation libs.bundles.unit.testing

--- a/identity/src/main/java/com/android/identity/flow/environment/Configuration.kt
+++ b/identity/src/main/java/com/android/identity/flow/environment/Configuration.kt
@@ -1,5 +1,11 @@
 package com.android.identity.flow.environment
 
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+
+import com.android.identity.util.Logger
+import kotlinx.serialization.json.jsonPrimitive
+
 /**
  * Simple interface to access configuration parameters.
  *
@@ -7,5 +13,33 @@ package com.android.identity.flow.environment
  * nodes in that tree, i.e. "componentClass.componentName.valueName".
  */
 interface Configuration {
+    companion object {
+        private val TAG = "Configuration"
+    }
+
     fun getProperty(name: String): String?
+
+    fun getBool(name: String, defaultValue: Boolean = false): Boolean {
+        val value = getProperty(name)
+        if (value == null) {
+            Logger.d(TAG, "getBool: No value configuration value with key $name, return default value $defaultValue")
+            return defaultValue
+        }
+        if (value == "true") {
+            return true
+        } else if (value == "false") {
+            return false
+        }
+        Logger.d(TAG, "getBool: Unexpected value '$value' with key $name, return default value $defaultValue")
+        return defaultValue
+    }
+
+    fun getStringList(key: String): List<String> {
+        val value = getProperty(key)
+        if (value == null) {
+            Logger.d(TAG, "getStringList: No value configuration value with key $key")
+            return emptyList()
+        }
+        return Json.parseToJsonElement(value).jsonArray.map { elem -> elem.jsonPrimitive.content }
+    }
 }

--- a/wallet-issuance/src/main/java/com/android/identity/issuance/authenticationUtilities.kt
+++ b/wallet-issuance/src/main/java/com/android/identity/issuance/authenticationUtilities.kt
@@ -1,8 +1,12 @@
 package com.android.identity.issuance
 
-import com.android.identity.crypto.Certificate
 import com.android.identity.crypto.CertificateChain
 import com.android.identity.crypto.javaX509Certificate
+import com.android.identity.crypto.javaX509Certificates
+import com.android.identity.util.AndroidAttestationExtensionParser
+import com.android.identity.util.Logger
+import com.android.identity.util.fromHex
+import com.android.identity.util.toHex
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.bytestring.append
@@ -12,7 +16,9 @@ import org.bouncycastle.asn1.ASN1Sequence
 
 private val salt = byteArrayOf((0xe7).toByte(), 0x7c, (0xf8).toByte(), (0xec).toByte())
 
-const val KEY_DESCRIPTION_OID: String = "1.3.6.1.4.1.11129.2.1.17"
+private const val KEY_DESCRIPTION_OID: String = "1.3.6.1.4.1.11129.2.1.17"
+
+private const val TAG = "authenticationUtilities"
 
 fun authenticationMessage(clientId: String, nonce: ByteString): ByteString {
     val buffer = ByteStringBuilder()
@@ -30,47 +36,73 @@ fun extractAttestationSequence(chain: CertificateChain): ASN1Sequence {
     return seqInputStream.readObject() as ASN1Sequence
 }
 
-fun validateKeyAttestation(chain: CertificateChain, clientId: String) {
-    // TODO: use AndroidAttestationExtensionParser.kt instead once it is available
-    val last = chain.certificates.lastIndex - 1
-    for (i in 1..last) {
-        if (!chain.certificates[i - 1].verify((chain.certificates[i]))) {
-            throw IllegalArgumentException("Key attestation error: invalid chain")
+fun validateKeyAttestation(
+    chain: CertificateChain,
+    clientId: String,
+    requireGmsAttestation: Boolean,
+    requireVerifiedBootGreen: Boolean,
+    requireAppSignatureCertificateDigests: List<String>,
+) {
+    val x509certs = chain.javaX509Certificates
+
+    // First check that all the certificates sign each other...
+    for (n in 0 until x509certs.size - 1) {
+        val cert = x509certs[n]
+        val nextCert = x509certs[n + 1]
+        try {
+            cert.verify(nextCert.publicKey)
+        } catch (e: Throwable) {
+            throw IllegalArgumentException("Key attestation error: error validating chain", e)
         }
     }
-    if (!chain.certificates[last].verify(androidRootCertificate)) {
-        throw IllegalArgumentException("Key attestation error: root")
+    val rootCertificatePublicKey = x509certs[x509certs.size - 1].publicKey
+
+    if (requireGmsAttestation) {
+        // Must match the well-known Google root
+        check(
+            GOOGLE_ROOT_ATTESTATION_KEY contentEquals rootCertificatePublicKey.encoded
+        ) { "Unexpected attestation root" }
     }
-    val seq = extractAttestationSequence(chain)
-    if (clientId != String(ASN1OctetString.getInstance(seq.getObjectAt(4)).octets)) {
-        throw IllegalArgumentException("Key attestation error: clientId ")
+
+    // Finally, check the Attestation Extension...
+    try {
+        val parser = AndroidAttestationExtensionParser(x509certs[0])
+
+        // Challenge must match...
+        check(clientId.toByteArray() contentEquals parser.attestationChallenge)
+        { "Challenge didn't match what was expected" }
+
+        if (requireVerifiedBootGreen) {
+            // Verified Boot state must VERIFIED
+            check(
+                parser.verifiedBootState ==
+                        AndroidAttestationExtensionParser.VerifiedBootState.GREEN
+            ) { "Verified boot state is not GREEN" }
+        }
+
+        if (requireAppSignatureCertificateDigests.size > 0) {
+            check (parser.applicationSignatureDigests.size == requireAppSignatureCertificateDigests.size)
+            { "Number Signing certificates mismatch" }
+            for (n in 0..<parser.applicationSignatureDigests.size) {
+                check (parser.applicationSignatureDigests[n] contentEquals requireAppSignatureCertificateDigests[n].fromHex)
+                { "Signing certificate $n mismatch" }
+            }
+        }
+
+        // Log the digests for easy copy-pasting into config file.
+        Logger.d(TAG, "Accepting Android client with ${parser.applicationSignatureDigests.size} " +
+                "signing certificates digests")
+        for (n in 0..<parser.applicationSignatureDigests.size) {
+            Logger.d(TAG, "Digest $n: ${parser.applicationSignatureDigests[n].toHex}")
+        }
+
+    } catch (e: Exception) {
+        throw IllegalStateException("Error parsing Android Attestation Extension", e)
     }
 }
 
-private val androidRootCertificate = Certificate.fromPem("""-----BEGIN CERTIFICATE-----
-MIIFHDCCAwSgAwIBAgIJANUP8luj8tazMA0GCSqGSIb3DQEBCwUAMBsxGTAXBgNVBAUTEGY5MjAw
-OWU4NTNiNmIwNDUwHhcNMTkxMTIyMjAzNzU4WhcNMzQxMTE4MjAzNzU4WjAbMRkwFwYDVQQFExBm
-OTIwMDllODUzYjZiMDQ1MIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr7bHgiuxpwHs
-K7Qui8xUFmOr75gvMsd/dTEDDJdSSxtf6An7xyqpRR90PL2abxM1dEqlXnf2tqw1Ne4Xwl5jlRfd
-nJLmN0pTy/4lj4/7tv0Sk3iiKkypnEUtR6WfMgH0QZfKHM1+di+y9TFRtv6y//0rb+T+W8a9nsNL
-/ggjnar86461qO0rOs2cXjp3kOG1FEJ5MVmFmBGtnrKpa73XpXyTqRxB/M0n1n/W9nGqC4FSYa04
-T6N5RIZGBN2z2MT5IKGbFlbC8UrW0DxW7AYImQQcHtGl/m00QLVWutHQoVJYnFPlXTcHYvASLu+R
-hhsbDmxMgJJ0mcDpvsC4PjvB+TxywElgS70vE0XmLD+OJtvsBslHZvPBKCOdT0MS+tgSOIfga+z1
-Z1g7+DVagf7quvmag8jfPioyKvxnK/EgsTUVi2ghzq8wm27ud/mIM7AY2qEORR8Go3TVB4HzWQgp
-Zrt3i5MIlCaY504LzSRiigHCzAPlHws+W0rB5N+er5/2pJKnfBSDiCiFAVtCLOZ7gLiMm0jhO2B6
-tUXHI/+MRPjy02i59lINMRRev56GKtcd9qO/0kUJWdZTdA2XoS82ixPvZtXQpUpuL12ab+9EaDK8
-Z4RHJYYfCT3Q5vNAXaiWQ+8PTWm2QgBR/bkwSWc+NpUFgNPN9PvQi8WEg5UmAGMCAwEAAaNjMGEw
-HQYDVR0OBBYEFDZh4QB8iAUJUYtEbEf/GkzJ6k8SMB8GA1UdIwQYMBaAFDZh4QB8iAUJUYtEbEf/
-GkzJ6k8SMA8GA1UdEwEB/wQFMAMBAf8wDgYDVR0PAQH/BAQDAgIEMA0GCSqGSIb3DQEBCwUAA4IC
-AQBOMaBc8oumXb2voc7XCWnuXKhBBK3e2KMGz39t7lA3XXRe2ZLLAkLM5y3J7tURkf5a1SutfdOy
-XAmeE6SRo83Uh6WszodmMkxK5GM4JGrnt4pBisu5igXEydaW7qq2CdC6DOGjG+mEkN8/TA6p3cno
-L/sPyz6evdjLlSeJ8rFBH6xWyIZCbrcpYEJzXaUOEaxxXxgYz5/cTiVKN2M1G2okQBUIYSY6bjEL
-4aUN5cfo7ogP3UvliEo3Eo0YgwuzR2v0KR6C1cZqZJSTnghIC/vAD32KdNQ+c3N+vl2OTsUVMC1G
-iWkngNx1OO1+kXW+YTnnTUOtOIswUP/Vqd5SYgAImMAfY8U9/iIgkQj6T2W6FsScy94IN9fFhE1U
-tzmLoBIuUFsVXJMTz+Jucth+IqoWFua9v1R93/k98p41pjtFX+H8DslVgfP097vju4KDlqN64xV1
-grw3ZLl4CiOe/A91oeLm2UHOq6wn3esB4r2EIQKb6jTVGu5sYCcdWpXr0AUVqcABPdgL+H7qJguB
-w09ojm6xNIrw2OocrDKsudk/okr/AwqEyPKw9WnMlQgLIKw1rODG2NvU9oR3GVGdMkUBZutL8VuF
-kERQGt6vQ2OCw0sV47VMkuYbacK/xyZFiRcrPJPb41zgbQj9XAEyLKCHex0SdDrx+tWUDqG8At2J
-HA==
------END CERTIFICATE-----
-""")
+
+// This public key is from https://developer.android.com/training/articles/security-key-attestation
+private val GOOGLE_ROOT_ATTESTATION_KEY =
+    "30820222300d06092a864886f70d01010105000382020f003082020a0282020100afb6c7822bb1a701ec2bb42e8bcc541663abef982f32c77f7531030c97524b1b5fe809fbc72aa9451f743cbd9a6f1335744aa55e77f6b6ac3535ee17c25e639517dd9c92e6374a53cbfe258f8ffbb6fd129378a22a4ca99c452d47a59f3201f44197ca1ccd7e762fb2f53151b6feb2fffd2b6fe4fe5bc6bd9ec34bfe08239daafceb8eb5a8ed2b3acd9c5e3a7790e1b51442793159859811ad9eb2a96bbdd7a57c93a91c41fccd27d67fd6f671aa0b815261ad384fa37944864604ddb3d8c4f920a19b1656c2f14ad6d03c56ec060899041c1ed1a5fe6d3440b556bad1d0a152589c53e55d370762f0122eef91861b1b0e6c4c80927499c0e9bec0b83e3bc1f93c72c049604bbd2f1345e62c3f8e26dbec06c94766f3c128239d4f4312fad8123887e06becf567583bf8355a81feeabaf99a83c8df3e2a322afc672bf120b135158b6821ceaf309b6eee77f98833b018daa10e451f06a374d50781f359082966bb778b9308942698e74e0bcd24628a01c2cc03e51f0b3e5b4ac1e4df9eaf9ff6a492a77c1483882885015b422ce67b80b88c9b48e13b607ab545c723ff8c44f8f2d368b9f6520d31145ebf9e862ad71df6a3bfd2450959d653740d97a12f368b13ef66d5d0a54a6e2f5d9a6fef446832bc67844725861f093dd0e6f3405da89643ef0f4d69b6420051fdb93049673e36950580d3cdf4fbd08bc58483952600630203010001"
+        .fromHex

--- a/wallet-server/environment/settings.json
+++ b/wallet-server/environment/settings.json
@@ -1,5 +1,9 @@
 {
-  "message_key": "bgoBBmDy1dYj8y2fXV9DKg==",
+  "android": {
+    "requireGmsAttestation": false,
+    "requireVerifiedBootGreen": false,
+    "requireAppSignatureCertificateDigests": []
+  },
   "issuing_authority_list": ["utopia", "eldorado"],
   "issuing_authorities": {
     "utopia": {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -141,10 +141,19 @@ class WalletApplication : Application() {
 
         val walletServerProvider = WalletServerProvider(this,
             androidKeystoreSecureArea,
-            // Adjust it or proxy local server to device using adb 'adb reverse tcp:8080 tcp:8080'
+            // There are multiple options for the default here. For now we use
+            // http://10.0.2.2:8080/wallet-server which makes it work out of the
+            // box when using the emulator.
+            //
+            // The developer may adjust it to suit their environment. In the future the
+            // default will point to a publicly available instance of the wallet server.
+            //
+            // Another option is to use http://127.0.0.1:8080/wallet-server and then
+            // run 'adb reverse tcp:8080 tcp:8080' on the host to proxy through adb.
+            //
             // Alternatively use "dev:" to connect to the server code running in-app.
-            // TODO: expose this in a setting, will need to reconnect if the setting changes.
-            "http://localhost:8080/wallet-server"
+            //
+            "http://10.0.2.2:8080/wallet-server"
         )
 
         // init IssuingAuthorityRepository


### PR DESCRIPTION
- Introduce settings to require GMS attestation, Verified Boot Green, or a particular digest of an app signing key. For now just set these to false, for production these should be true and bound to a particluar application.

- Change default wallet server URL so things work out-of-the-box in the emulator. An upcoming PR will add UI to change this.

- Don't store message-encryption key in Configuration, use Storage instead.

Also fix some build errors for unit-tests in identity-android and identity-android-legacy.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR