### PR TITLE
Add items to manifest to allow connections to http (only localhost for development).

### DIFF
--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -25,6 +25,8 @@
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 
+    <uses-permission android:name="android.permission.INTERNET"/>
+
     <application
         android:name=".WalletApplication"
         android:allowBackup="true"
@@ -32,6 +34,7 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:theme="@style/Theme.IdentityCredential">
         <activity
             android:name=".MainActivity"

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
@@ -195,6 +195,9 @@ private fun SetWalletServerUrlDialog(
                 LinkText(stringResource(R.string.settings_screen_set_wallet_server_url_link_emulator)) {
                     url = "http://10.0.2.2:8080/wallet-server"
                 }
+                LinkText(stringResource(R.string.settings_screen_set_wallet_server_url_tunneled)) {
+                    url = "http://localhost:8080/wallet-server"
+                }
             }
         },
         confirmButton = {

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -107,6 +107,7 @@
     <string name="settings_screen_set_wallet_server_url_label">URL</string>
     <string name="settings_screen_set_wallet_server_url_link_built_in">Built-in Wallet Server</string>
     <string name="settings_screen_set_wallet_server_url_link_emulator">Emulator with Wallet Server running on developer host</string>
+    <string name="settings_screen_set_wallet_server_url_tunneled">Wallet Server tunneled to device with \'adb reverse tcp:8080 tcp:8080\'</string>
     <string name="settings_screen_confirm_set_wallet_server_url_dialog_title">Confirm setting Wallet Server URL</string>
     <string name="settings_screen_confirm_set_wallet_server_url_dialog_message">
         All existing documents will be deleted if you change the Wallet Server URL.

--- a/wallet/src/main/res/xml/network_security_config.xml
+++ b/wallet/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">localhost</domain>
+        <domain includeSubdomains="false">127.0.0.1</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
This should resolve issues with tunneling local dev server to the wallet app.

Fixes #619
