### PR TITLE
Refactor Biometric Prompt to return a boolean representing the success of authentication or throw an exception

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -56,6 +56,7 @@ import com.android.identity_credential.wallet.presentation.TransferHelper
 import com.android.identity_credential.wallet.ui.ScreenWithAppBar
 import com.android.identity_credential.wallet.ui.destination.consentprompt.ConsentPrompt
 import com.android.identity_credential.wallet.ui.destination.consentprompt.ConsentPromptData
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
 import kotlinx.coroutines.launch
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
@@ -44,7 +44,7 @@ import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.WalletApplication
-import com.android.identity_credential.wallet.showBiometricPrompt
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import org.json.JSONObject
 
 import com.google.android.gms.identitycredentials.GetCredentialResponse

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentDetailsScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentDetailsScreen.kt
@@ -41,7 +41,7 @@ import com.android.identity_credential.wallet.DocumentInfo
 import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.navigation.WalletDestination
-import com.android.identity_credential.wallet.showBiometricPrompt
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import com.android.identity_credential.wallet.ui.KeyValuePairText
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
 import kotlinx.coroutines.launch

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/biometric/BiometricPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/biometric/BiometricPrompt.kt
@@ -1,4 +1,4 @@
-package com.android.identity_credential.wallet
+package com.android.identity_credential.wallet.ui.prompt.biometric
 
 import android.os.Handler
 import android.os.Looper
@@ -8,11 +8,15 @@ import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.android.identity.android.securearea.UserAuthenticationType
+import com.android.identity_credential.wallet.R
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
- * Prompts user for authentication, and calls the provided functions when authentication is
- * complete. Biometric authentication will be offered first if both [UserAuthenticationType.LSKF]
- * and [UserAuthenticationType.BIOMETRIC] are allowed.
+ * Async function to show Biometric Prompt and return the result as a [Boolean] of whether
+ * authentication was successful, or raises/throws an Exception, such as IllegalStateException,
+ * if an error prevented the Biometric Prompt from showing
  *
  * @param activity the activity hosting the authentication prompt
  * @param title the title for the authentication prompt
@@ -21,10 +25,41 @@ import com.android.identity.android.securearea.UserAuthenticationType
  * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
  *                                least one element
  * @param requireConfirmation option to require explicit user confirmation after a passive biometric
- * @param onSuccess the function which will be called when the user successfully authenticates
- * @param onCanceled the function which will be called when the user cancels
- * @param onError the function which will be called when there is an unexpected error in the user
- *                authentication process - a throwable will be passed into this function
+ * @return a [Boolean] indicating whether biometric authentication was successful
+ * @throws Exception if there were errors showing the prompt
+ */
+suspend fun showBiometricPrompt(
+    activity: FragmentActivity,
+    title: String,
+    subtitle: String,
+    cryptoObject: BiometricPrompt.CryptoObject?,
+    userAuthenticationTypes: Set<UserAuthenticationType>,
+    requireConfirmation: Boolean,
+): Boolean = suspendCancellableCoroutine { continuation ->
+    // wrap around the function that uses callbacks to notify of the prompt's result and
+    // return true, false or raise an Exception
+    showBiometricPrompt(
+        activity = activity,
+        title = title,
+        subtitle = subtitle,
+        cryptoObject = cryptoObject,
+        userAuthenticationTypes = userAuthenticationTypes,
+        requireConfirmation = requireConfirmation,
+        onSuccess = {
+            continuation.resume(true)
+        },
+        onCanceled = {
+            continuation.resume(false)
+        },
+        onError = {
+            continuation.resumeWithException(it)
+        }
+    )
+}
+
+/**
+ * Show biometric prompt and issue callbacks to [onSuccess], [onCanceled] and [onError] to notify
+ * of the prompt's result.
  */
 fun showBiometricPrompt(
     activity: FragmentActivity,
@@ -45,7 +80,7 @@ fun showBiometricPrompt(
         )
     }
 
-    BiometricUserAuthPrompt(
+    BiometricPrompt(
         activity = activity,
         title = title,
         subtitle = subtitle,
@@ -58,7 +93,26 @@ fun showBiometricPrompt(
     ).authenticate()
 }
 
-private class BiometricUserAuthPrompt(
+
+/**
+ * Prompts user for authentication, and calls the provided functions when authentication is
+ * complete. Biometric authentication will be offered first if both [UserAuthenticationType.LSKF]
+ * and [UserAuthenticationType.BIOMETRIC] are allowed.
+ *
+ * @param activity the activity hosting the authentication prompt
+ * @param title the title for the authentication prompt
+ * @param subtitle the subtitle for the authentication prompt
+ * @param cryptoObject a crypto object to be associated with this authentication
+ * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
+ *                                least one element
+ * @param requireConfirmation option to require explicit user confirmation after a passive biometric
+ * @param onSuccess the function which will be called when the user successfully authenticates
+ * @param onCanceled the function which will be called when the user cancels
+ * @param onError the function which will be called when there is an unexpected error in the user
+ *                authentication process - a throwable will be passed into this function
+ */
+
+private class BiometricPrompt(
     private val activity: FragmentActivity,
     private val title: String,
     private val subtitle: String,
@@ -81,9 +135,12 @@ private class BiometricUserAuthPrompt(
             errorString: CharSequence
         ) {
             super.onAuthenticationError(errorCode, errorString)
-            if (setOf(BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+            if (setOf(
+                    BiometricPrompt.ERROR_NEGATIVE_BUTTON,
                     BiometricPrompt.ERROR_NO_BIOMETRICS,
-                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS).contains(errorCode) && lskfOnNegativeBtn) {
+                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS
+                ).contains(errorCode) && lskfOnNegativeBtn
+            ) {
                 // if no delay is injected, then biometric prompt's auth callbacks would not be called
                 Handler(Looper.getMainLooper()).postDelayed({
                     authenticateLskf()
@@ -103,7 +160,7 @@ private class BiometricUserAuthPrompt(
         }
     }
 
-    private var biometricPrompt = BiometricPrompt(
+    private var androidBiometricPrompt = BiometricPrompt(
         activity,
         ContextCompat.getMainExecutor(activity),
         biometricAuthCallback
@@ -132,9 +189,9 @@ private class BiometricUserAuthPrompt(
             .build()
 
         if (cryptoObject != null) {
-            biometricPrompt.authenticate(biometricPromptInfo, cryptoObject!!)
+            androidBiometricPrompt.authenticate(biometricPromptInfo, cryptoObject!!)
         } else {
-            biometricPrompt.authenticate(biometricPromptInfo)
+            androidBiometricPrompt.authenticate(biometricPromptInfo)
         }
     }
 
@@ -149,9 +206,9 @@ private class BiometricUserAuthPrompt(
             .build()
 
         if (cryptoObject != null) {
-            biometricPrompt.authenticate(lskfPromptInfo, cryptoObject!!)
+            androidBiometricPrompt.authenticate(lskfPromptInfo, cryptoObject!!)
         } else {
-            biometricPrompt.authenticate(lskfPromptInfo)
+            androidBiometricPrompt.authenticate(lskfPromptInfo)
         }
     }
 


### PR DESCRIPTION
Additional changes:
- Refactored `BiometricUserAuthPrompt` to `BiometricPrompt`.
- Defined a new package structure **wallet.ui.prompt** to contain all prompts.
- Added `BiometricPrompt` to its own package wallet.ui.prompt.**biometric**.

All tests pass (545) and performed an MDL Presentation successfully between Wallet and AppVerifier