### PR TITLE
Added ConsentPrompt wrapper class and global function showConsentPrompt(..) that uses the wrapper class to show the prompt and return a boolean

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -56,6 +56,7 @@ import com.android.identity_credential.wallet.presentation.TransferHelper
 import com.android.identity_credential.wallet.ui.ScreenWithAppBar
 import com.android.identity_credential.wallet.ui.destination.consentprompt.ConsentPrompt
 import com.android.identity_credential.wallet.ui.destination.consentprompt.ConsentPromptData
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
 import kotlinx.coroutines.launch
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
@@ -44,7 +44,7 @@ import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.WalletApplication
-import com.android.identity_credential.wallet.showBiometricPrompt
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import org.json.JSONObject
 
 import com.google.android.gms.identitycredentials.GetCredentialResponse

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentDetailsScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentDetailsScreen.kt
@@ -41,7 +41,7 @@ import com.android.identity_credential.wallet.DocumentInfo
 import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.navigation.WalletDestination
-import com.android.identity_credential.wallet.showBiometricPrompt
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import com.android.identity_credential.wallet.ui.KeyValuePairText
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
 import kotlinx.coroutines.launch

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/biometric/BiometricPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/biometric/BiometricPrompt.kt
@@ -1,4 +1,4 @@
-package com.android.identity_credential.wallet
+package com.android.identity_credential.wallet.ui.prompt.biometric
 
 import android.os.Handler
 import android.os.Looper
@@ -8,11 +8,15 @@ import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.android.identity.android.securearea.UserAuthenticationType
+import com.android.identity_credential.wallet.R
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
- * Prompts user for authentication, and calls the provided functions when authentication is
- * complete. Biometric authentication will be offered first if both [UserAuthenticationType.LSKF]
- * and [UserAuthenticationType.BIOMETRIC] are allowed.
+ * Async function to show Biometric Prompt and return the result as a [Boolean] of whether
+ * authentication was successful, or raises/throws an Exception, such as IllegalStateException,
+ * if an error prevented the Biometric Prompt from showing
  *
  * @param activity the activity hosting the authentication prompt
  * @param title the title for the authentication prompt
@@ -21,10 +25,41 @@ import com.android.identity.android.securearea.UserAuthenticationType
  * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
  *                                least one element
  * @param requireConfirmation option to require explicit user confirmation after a passive biometric
- * @param onSuccess the function which will be called when the user successfully authenticates
- * @param onCanceled the function which will be called when the user cancels
- * @param onError the function which will be called when there is an unexpected error in the user
- *                authentication process - a throwable will be passed into this function
+ * @return a [Boolean] indicating whether biometric authentication was successful
+ * @throws Exception if there were errors showing the prompt
+ */
+suspend fun showBiometricPrompt(
+    activity: FragmentActivity,
+    title: String,
+    subtitle: String,
+    cryptoObject: BiometricPrompt.CryptoObject?,
+    userAuthenticationTypes: Set<UserAuthenticationType>,
+    requireConfirmation: Boolean,
+): Boolean = suspendCancellableCoroutine { continuation ->
+    // wrap around the function that uses callbacks to notify of the prompt's result and
+    // return true, false or raise an Exception
+    showBiometricPrompt(
+        activity = activity,
+        title = title,
+        subtitle = subtitle,
+        cryptoObject = cryptoObject,
+        userAuthenticationTypes = userAuthenticationTypes,
+        requireConfirmation = requireConfirmation,
+        onSuccess = {
+            continuation.resume(true)
+        },
+        onCanceled = {
+            continuation.resume(false)
+        },
+        onError = {
+            continuation.resumeWithException(it)
+        }
+    )
+}
+
+/**
+ * Show biometric prompt and issue callbacks to [onSuccess], [onCanceled] and [onError] to notify
+ * of the prompt's result.
  */
 fun showBiometricPrompt(
     activity: FragmentActivity,
@@ -45,7 +80,7 @@ fun showBiometricPrompt(
         )
     }
 
-    BiometricUserAuthPrompt(
+    BiometricPrompt(
         activity = activity,
         title = title,
         subtitle = subtitle,
@@ -58,7 +93,26 @@ fun showBiometricPrompt(
     ).authenticate()
 }
 
-private class BiometricUserAuthPrompt(
+
+/**
+ * Prompts user for authentication, and calls the provided functions when authentication is
+ * complete. Biometric authentication will be offered first if both [UserAuthenticationType.LSKF]
+ * and [UserAuthenticationType.BIOMETRIC] are allowed.
+ *
+ * @param activity the activity hosting the authentication prompt
+ * @param title the title for the authentication prompt
+ * @param subtitle the subtitle for the authentication prompt
+ * @param cryptoObject a crypto object to be associated with this authentication
+ * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
+ *                                least one element
+ * @param requireConfirmation option to require explicit user confirmation after a passive biometric
+ * @param onSuccess the function which will be called when the user successfully authenticates
+ * @param onCanceled the function which will be called when the user cancels
+ * @param onError the function which will be called when there is an unexpected error in the user
+ *                authentication process - a throwable will be passed into this function
+ */
+
+private class BiometricPrompt(
     private val activity: FragmentActivity,
     private val title: String,
     private val subtitle: String,
@@ -81,9 +135,12 @@ private class BiometricUserAuthPrompt(
             errorString: CharSequence
         ) {
             super.onAuthenticationError(errorCode, errorString)
-            if (setOf(BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+            if (setOf(
+                    BiometricPrompt.ERROR_NEGATIVE_BUTTON,
                     BiometricPrompt.ERROR_NO_BIOMETRICS,
-                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS).contains(errorCode) && lskfOnNegativeBtn) {
+                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS
+                ).contains(errorCode) && lskfOnNegativeBtn
+            ) {
                 // if no delay is injected, then biometric prompt's auth callbacks would not be called
                 Handler(Looper.getMainLooper()).postDelayed({
                     authenticateLskf()
@@ -103,7 +160,7 @@ private class BiometricUserAuthPrompt(
         }
     }
 
-    private var biometricPrompt = BiometricPrompt(
+    private var androidBiometricPrompt = BiometricPrompt(
         activity,
         ContextCompat.getMainExecutor(activity),
         biometricAuthCallback
@@ -132,9 +189,9 @@ private class BiometricUserAuthPrompt(
             .build()
 
         if (cryptoObject != null) {
-            biometricPrompt.authenticate(biometricPromptInfo, cryptoObject!!)
+            androidBiometricPrompt.authenticate(biometricPromptInfo, cryptoObject!!)
         } else {
-            biometricPrompt.authenticate(biometricPromptInfo)
+            androidBiometricPrompt.authenticate(biometricPromptInfo)
         }
     }
 
@@ -149,9 +206,9 @@ private class BiometricUserAuthPrompt(
             .build()
 
         if (cryptoObject != null) {
-            biometricPrompt.authenticate(lskfPromptInfo, cryptoObject!!)
+            androidBiometricPrompt.authenticate(lskfPromptInfo, cryptoObject!!)
         } else {
-            biometricPrompt.authenticate(lskfPromptInfo)
+            androidBiometricPrompt.authenticate(lskfPromptInfo)
         }
     }
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPrompt.kt
@@ -1,4 +1,4 @@
-package com.android.identity_credential.wallet.ui.destination.consentprompt
+package com.android.identity_credential.wallet.ui.prompt.consent
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptData.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptData.kt
@@ -1,4 +1,4 @@
-package com.android.identity_credential.wallet.ui.destination.consentprompt
+package com.android.identity_credential.wallet.ui.prompt.consent
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptDialog.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptDialog.kt
@@ -1,0 +1,106 @@
+package com.android.identity_credential.wallet.ui.prompt.consent
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.FragmentManager
+import com.android.identity.documenttype.DocumentTypeRepository
+import com.android.identity.issuance.DocumentExtensions.documentConfiguration
+import com.android.identity_credential.wallet.presentation.PresentationRequestData
+import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Show the ConsentPrompt via the Dialog wrapper class and return a [Boolean] indicating that the
+ * user confirmed or cancelled the credential request.
+ */
+suspend fun showConsentPrompt(
+    presentationRequestData: PresentationRequestData,
+    documentTypeRepository: DocumentTypeRepository,
+    fragmentManager: FragmentManager
+): Boolean =
+    suspendCancellableCoroutine { continuation ->
+        // new instance of the ConsentPrompt bottom sheet dialog fragment but not shown yet
+        val consentPromptDialog = ConsentPromptDialog(
+            consentPromptData = ConsentPromptData(
+                credentialId = presentationRequestData.document.name,
+                documentName = presentationRequestData.document.documentConfiguration.displayName,
+                credentialData = presentationRequestData.document.documentConfiguration.mdocConfiguration!!.staticData,
+                documentRequest = presentationRequestData.documentRequest,
+                docType = presentationRequestData.docType,
+                verifier = presentationRequestData.trustPoint,
+            ),
+            documentTypeRepository = documentTypeRepository,
+            consentPromptListener = object :
+                ConsentPromptDialog.ConsentPromptResponseListener {
+                override fun onConfirm() {
+                    continuation.resume(true)
+                }
+
+                override fun onCancel() {
+                    continuation.resume(false)
+                }
+            }
+        )
+        consentPromptDialog.show(fragmentManager, "consent_prompt")
+    }
+
+
+/**
+ * Wrapper (Dialog) class for rendering Consent prompt via composition since composable functions
+ * cannot be defined as "suspend".
+ *
+ * Extends BottomSheetDialogFragment and shows up as an overlay above the current UI.
+ *
+ * Expects a [ConsentPromptResponseListener] instance to be provided to notify when the user taps on
+ * Confirm or Cancel.
+ *
+ * @param consentPromptData data that is extracted (via TransferHelper) during a presentation engagement
+ * @param documentTypeRepository repository used to get the human-readable credential names
+ * @param consentPromptListener the listener that notifies when user taps on "Confirm" or "Cancel"
+ */
+class ConsentPromptDialog(
+    private val consentPromptData: ConsentPromptData,
+    private val documentTypeRepository: DocumentTypeRepository,
+    private val consentPromptListener: ConsentPromptResponseListener
+) : BottomSheetDialogFragment() {
+
+    /**
+     * Listener notifying when user taps on Confirm or Cancel.
+     */
+    interface ConsentPromptResponseListener {
+        fun onConfirm()
+        fun onCancel()
+    }
+
+    /**
+     * Define the ConsentPrompt composition and issue callbacks based on user's actions.
+     */
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View =
+        ComposeView(requireContext()).apply {
+            setContent {
+                IdentityCredentialTheme {
+                    ConsentPrompt(
+                        consentData = consentPromptData,
+                        documentTypeRepository = documentTypeRepository,
+                        onConfirm = { // user accepted to send requested credential data
+                            consentPromptListener.onConfirm()
+                            dismiss()
+                        },
+                        onCancel = { // user declined submitting data to requesting party
+                            consentPromptListener.onCancel()
+                            dismiss()
+                        }
+                    )
+                }
+            }
+        }
+}


### PR DESCRIPTION
- New package wallet.ui.prompt.**consent** houses `ConsentPrompt`, `ConsentPromptData`, `ConsentPromptDialog`
- New wrapper class `ConsentPromptDialog` (extends `BottomSheetDialogFragment`) is responsible for rendering the Consent Prompt as a new Fragment and issues callbacks to its listener `ConsentPromptResponseListener` when user Confirms/Cancels the prompt.
- Global function `showConsentPrompt(..)` uses the wrapper class to show the Consent Prompt and returns a boolean whenever `onConfirm` (true) or `onCancel` (false) callbacks are triggered from the Consent Prompt listener.


### This PR is dependent on PR #626 (commit https://github.com/openwallet-foundation-labs/identity-credential/pull/627/commits/044e4da06b1d7fbd0d4449254e01e908993d916f) to land first.