### PR TITLE
Added Passphrase Prompt

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -56,6 +56,7 @@ import com.android.identity_credential.wallet.presentation.TransferHelper
 import com.android.identity_credential.wallet.ui.ScreenWithAppBar
 import com.android.identity_credential.wallet.ui.destination.consentprompt.ConsentPrompt
 import com.android.identity_credential.wallet.ui.destination.consentprompt.ConsentPromptData
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
 import kotlinx.coroutines.launch
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
@@ -44,7 +44,7 @@ import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.WalletApplication
-import com.android.identity_credential.wallet.showBiometricPrompt
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import org.json.JSONObject
 
 import com.google.android.gms.identitycredentials.GetCredentialResponse

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentDetailsScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentDetailsScreen.kt
@@ -41,7 +41,7 @@ import com.android.identity_credential.wallet.DocumentInfo
 import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.navigation.WalletDestination
-import com.android.identity_credential.wallet.showBiometricPrompt
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import com.android.identity_credential.wallet.ui.KeyValuePairText
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
 import kotlinx.coroutines.launch

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/biometric/BiometricPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/biometric/BiometricPrompt.kt
@@ -1,4 +1,4 @@
-package com.android.identity_credential.wallet
+package com.android.identity_credential.wallet.ui.prompt.biometric
 
 import android.os.Handler
 import android.os.Looper
@@ -8,11 +8,15 @@ import androidx.biometric.BiometricPrompt.PromptInfo
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.FragmentActivity
 import com.android.identity.android.securearea.UserAuthenticationType
+import com.android.identity_credential.wallet.R
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+import kotlin.coroutines.resumeWithException
 
 /**
- * Prompts user for authentication, and calls the provided functions when authentication is
- * complete. Biometric authentication will be offered first if both [UserAuthenticationType.LSKF]
- * and [UserAuthenticationType.BIOMETRIC] are allowed.
+ * Async function to show Biometric Prompt and return the result as a [Boolean] of whether
+ * authentication was successful, or raises/throws an Exception, such as IllegalStateException,
+ * if an error prevented the Biometric Prompt from showing
  *
  * @param activity the activity hosting the authentication prompt
  * @param title the title for the authentication prompt
@@ -21,10 +25,41 @@ import com.android.identity.android.securearea.UserAuthenticationType
  * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
  *                                least one element
  * @param requireConfirmation option to require explicit user confirmation after a passive biometric
- * @param onSuccess the function which will be called when the user successfully authenticates
- * @param onCanceled the function which will be called when the user cancels
- * @param onError the function which will be called when there is an unexpected error in the user
- *                authentication process - a throwable will be passed into this function
+ * @return a [Boolean] indicating whether biometric authentication was successful
+ * @throws Exception if there were errors showing the prompt
+ */
+suspend fun showBiometricPrompt(
+    activity: FragmentActivity,
+    title: String,
+    subtitle: String,
+    cryptoObject: BiometricPrompt.CryptoObject?,
+    userAuthenticationTypes: Set<UserAuthenticationType>,
+    requireConfirmation: Boolean,
+): Boolean = suspendCancellableCoroutine { continuation ->
+    // wrap around the function that uses callbacks to notify of the prompt's result and
+    // return true, false or raise an Exception
+    showBiometricPrompt(
+        activity = activity,
+        title = title,
+        subtitle = subtitle,
+        cryptoObject = cryptoObject,
+        userAuthenticationTypes = userAuthenticationTypes,
+        requireConfirmation = requireConfirmation,
+        onSuccess = {
+            continuation.resume(true)
+        },
+        onCanceled = {
+            continuation.resume(false)
+        },
+        onError = {
+            continuation.resumeWithException(it)
+        }
+    )
+}
+
+/**
+ * Show biometric prompt and issue callbacks to [onSuccess], [onCanceled] and [onError] to notify
+ * of the prompt's result.
  */
 fun showBiometricPrompt(
     activity: FragmentActivity,
@@ -45,7 +80,7 @@ fun showBiometricPrompt(
         )
     }
 
-    BiometricUserAuthPrompt(
+    BiometricPrompt(
         activity = activity,
         title = title,
         subtitle = subtitle,
@@ -58,7 +93,26 @@ fun showBiometricPrompt(
     ).authenticate()
 }
 
-private class BiometricUserAuthPrompt(
+
+/**
+ * Prompts user for authentication, and calls the provided functions when authentication is
+ * complete. Biometric authentication will be offered first if both [UserAuthenticationType.LSKF]
+ * and [UserAuthenticationType.BIOMETRIC] are allowed.
+ *
+ * @param activity the activity hosting the authentication prompt
+ * @param title the title for the authentication prompt
+ * @param subtitle the subtitle for the authentication prompt
+ * @param cryptoObject a crypto object to be associated with this authentication
+ * @param userAuthenticationTypes the set of allowed user authentication types, must contain at
+ *                                least one element
+ * @param requireConfirmation option to require explicit user confirmation after a passive biometric
+ * @param onSuccess the function which will be called when the user successfully authenticates
+ * @param onCanceled the function which will be called when the user cancels
+ * @param onError the function which will be called when there is an unexpected error in the user
+ *                authentication process - a throwable will be passed into this function
+ */
+
+private class BiometricPrompt(
     private val activity: FragmentActivity,
     private val title: String,
     private val subtitle: String,
@@ -81,9 +135,12 @@ private class BiometricUserAuthPrompt(
             errorString: CharSequence
         ) {
             super.onAuthenticationError(errorCode, errorString)
-            if (setOf(BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+            if (setOf(
+                    BiometricPrompt.ERROR_NEGATIVE_BUTTON,
                     BiometricPrompt.ERROR_NO_BIOMETRICS,
-                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS).contains(errorCode) && lskfOnNegativeBtn) {
+                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS
+                ).contains(errorCode) && lskfOnNegativeBtn
+            ) {
                 // if no delay is injected, then biometric prompt's auth callbacks would not be called
                 Handler(Looper.getMainLooper()).postDelayed({
                     authenticateLskf()
@@ -103,7 +160,7 @@ private class BiometricUserAuthPrompt(
         }
     }
 
-    private var biometricPrompt = BiometricPrompt(
+    private var androidBiometricPrompt = BiometricPrompt(
         activity,
         ContextCompat.getMainExecutor(activity),
         biometricAuthCallback
@@ -132,9 +189,9 @@ private class BiometricUserAuthPrompt(
             .build()
 
         if (cryptoObject != null) {
-            biometricPrompt.authenticate(biometricPromptInfo, cryptoObject!!)
+            androidBiometricPrompt.authenticate(biometricPromptInfo, cryptoObject!!)
         } else {
-            biometricPrompt.authenticate(biometricPromptInfo)
+            androidBiometricPrompt.authenticate(biometricPromptInfo)
         }
     }
 
@@ -149,9 +206,9 @@ private class BiometricUserAuthPrompt(
             .build()
 
         if (cryptoObject != null) {
-            biometricPrompt.authenticate(lskfPromptInfo, cryptoObject!!)
+            androidBiometricPrompt.authenticate(lskfPromptInfo, cryptoObject!!)
         } else {
-            biometricPrompt.authenticate(lskfPromptInfo)
+            androidBiometricPrompt.authenticate(lskfPromptInfo)
         }
     }
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPrompt.kt
@@ -1,4 +1,4 @@
-package com.android.identity_credential.wallet.ui.destination.consentprompt
+package com.android.identity_credential.wallet.ui.prompt.consent
 
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptData.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptData.kt
@@ -1,4 +1,4 @@
-package com.android.identity_credential.wallet.ui.destination.consentprompt
+package com.android.identity_credential.wallet.ui.prompt.consent
 
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptDialog.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptDialog.kt
@@ -1,0 +1,106 @@
+package com.android.identity_credential.wallet.ui.prompt.consent
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.FragmentManager
+import com.android.identity.documenttype.DocumentTypeRepository
+import com.android.identity.issuance.DocumentExtensions.documentConfiguration
+import com.android.identity_credential.wallet.presentation.PresentationRequestData
+import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+/**
+ * Show the ConsentPrompt via the Dialog wrapper class and return a [Boolean] indicating that the
+ * user confirmed or cancelled the credential request.
+ */
+suspend fun showConsentPrompt(
+    presentationRequestData: PresentationRequestData,
+    documentTypeRepository: DocumentTypeRepository,
+    fragmentManager: FragmentManager
+): Boolean =
+    suspendCancellableCoroutine { continuation ->
+        // new instance of the ConsentPrompt bottom sheet dialog fragment but not shown yet
+        val consentPromptDialog = ConsentPromptDialog(
+            consentPromptData = ConsentPromptData(
+                credentialId = presentationRequestData.document.name,
+                documentName = presentationRequestData.document.documentConfiguration.displayName,
+                credentialData = presentationRequestData.document.documentConfiguration.mdocConfiguration!!.staticData,
+                documentRequest = presentationRequestData.documentRequest,
+                docType = presentationRequestData.docType,
+                verifier = presentationRequestData.trustPoint,
+            ),
+            documentTypeRepository = documentTypeRepository,
+            consentPromptListener = object :
+                ConsentPromptDialog.ConsentPromptResponseListener {
+                override fun onConfirm() {
+                    continuation.resume(true)
+                }
+
+                override fun onCancel() {
+                    continuation.resume(false)
+                }
+            }
+        )
+        consentPromptDialog.show(fragmentManager, "consent_prompt")
+    }
+
+
+/**
+ * Wrapper (Dialog) class for rendering Consent prompt via composition since composable functions
+ * cannot be defined as "suspend".
+ *
+ * Extends BottomSheetDialogFragment and shows up as an overlay above the current UI.
+ *
+ * Expects a [ConsentPromptResponseListener] instance to be provided to notify when the user taps on
+ * Confirm or Cancel.
+ *
+ * @param consentPromptData data that is extracted (via TransferHelper) during a presentation engagement
+ * @param documentTypeRepository repository used to get the human-readable credential names
+ * @param consentPromptListener the listener that notifies when user taps on "Confirm" or "Cancel"
+ */
+class ConsentPromptDialog(
+    private val consentPromptData: ConsentPromptData,
+    private val documentTypeRepository: DocumentTypeRepository,
+    private val consentPromptListener: ConsentPromptResponseListener
+) : BottomSheetDialogFragment() {
+
+    /**
+     * Listener notifying when user taps on Confirm or Cancel.
+     */
+    interface ConsentPromptResponseListener {
+        fun onConfirm()
+        fun onCancel()
+    }
+
+    /**
+     * Define the ConsentPrompt composition and issue callbacks based on user's actions.
+     */
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View =
+        ComposeView(requireContext()).apply {
+            setContent {
+                IdentityCredentialTheme {
+                    ConsentPrompt(
+                        consentData = consentPromptData,
+                        documentTypeRepository = documentTypeRepository,
+                        onConfirm = { // user accepted to send requested credential data
+                            consentPromptListener.onConfirm()
+                            dismiss()
+                        },
+                        onCancel = { // user declined submitting data to requesting party
+                            consentPromptListener.onCancel()
+                            dismiss()
+                        }
+                    )
+                }
+            }
+        }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphraseEntryField.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphraseEntryField.kt
@@ -1,0 +1,256 @@
+package com.android.identity_credential.wallet.ui.prompt.passphrase
+
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.text.KeyboardActions
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.android.identity.securearea.PassphraseConstraints
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+
+/**
+ * A composable for entering a passphrase or PIN.
+ *
+ * @param constraints the constraints for the passphrase.
+ * @param checkWeakPassphrase if true, checks and disallows for weak passphrase/PINs and also
+ *   shows a hint if this is the case.
+ * @param onChanged called when the user is entering text or pressing the "Done" IME action
+ */
+@Composable
+fun PassphraseEntryField(
+    constraints: PassphraseConstraints,
+    checkWeakPassphrase: Boolean,
+    onChanged: (passphrase: String, meetsRequirements: Boolean, donePressed: Boolean) -> Unit,
+) {
+    var inputText by remember { mutableStateOf("") }
+    var meetsRequirements by remember { mutableStateOf(false) }
+    var hint by remember { mutableStateOf("") }
+    var obfuscateAll by remember { mutableStateOf(false) }
+    val focusRequester = FocusRequester()
+    val scope = rememberCoroutineScope()
+
+    // Put boxes around the entered chars for fixed length and six or fewer characters
+    var decorationBox: @Composable (@Composable () -> Unit) -> Unit =
+        @Composable { innerTextField -> innerTextField() }
+    val isFixedLength = (constraints.minLength == constraints.maxLength)
+    if (isFixedLength && constraints.minLength <= 6) {
+        decorationBox = {
+            Row(
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                // Obfuscate all but the last characters ... note `visualTransformation` isn't used.
+                repeat(constraints.maxLength) { digitIndex ->
+                    val digit =
+                        if (digitIndex == inputText.length - 1) {
+                            if (obfuscateAll) {
+                                "\u2022"  // U+2022 Bullet
+                            } else {
+                                inputText[digitIndex].toString()
+                            }
+                        } else if (digitIndex < inputText.length) {
+                            "\u2022"  // U+2022 Bullet
+                        } else {
+                            ""
+                        }
+                    Text(
+                        text = digit,
+                        modifier = Modifier
+                            .width(48.dp)
+                            .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
+                            .padding(2.dp),
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.headlineLarge,
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                }
+            }
+        }
+    }
+
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        horizontalArrangement = Arrangement.Center,
+    ) {
+        BasicTextField(
+            value = inputText,
+            modifier = Modifier
+                .padding(8.dp)
+                .focusRequester(focusRequester),
+            onValueChange = {
+                if (it.length > constraints.maxLength) {
+                    return@BasicTextField
+                }
+                if (constraints.requireNumerical) {
+                    if (!(it.all { it.isDigit() })) {
+                        return@BasicTextField
+                    }
+                }
+
+                inputText = it
+                calcHintAndMeetsRequirements(inputText, constraints).let {
+                    hint = it.first
+                    meetsRequirements = it.second
+                }
+
+                obfuscateAll = false
+                scope.launch {
+                    delay(750)
+                    obfuscateAll = true
+                    val value = inputText
+                    inputText = ""
+                    inputText = value
+                }
+
+                onChanged(inputText, meetsRequirements, false)
+            },
+            singleLine = true,
+            textStyle = MaterialTheme.typography.headlineMedium,
+            decorationBox = decorationBox,
+            keyboardOptions = KeyboardOptions(
+                keyboardType = if (constraints.requireNumerical) KeyboardType.NumberPassword else KeyboardType.Password,
+                imeAction = ImeAction.Done,
+            ),
+            keyboardActions = KeyboardActions(
+                onDone = {
+                    onChanged(inputText, meetsRequirements, true)
+                }
+            ),
+            visualTransformation = { text ->
+                val mask = '\u2022'
+                val result = if (text.isNotEmpty()) {
+                    if (obfuscateAll) {
+                        mask.toString().repeat(text.text.length)
+                    } else {
+                        mask.toString().repeat(text.text.length - 1) + text.last()
+                    }
+                } else {
+                    ""
+                }
+                TransformedText(
+                    AnnotatedString(result),
+                    OffsetMapping.Identity
+                )
+            }
+        )
+    }
+
+    if (!isFixedLength) {
+        Divider(
+            color = Color.Blue,
+            thickness = 2.dp,
+            modifier = Modifier.padding(start = 32.dp, end = 32.dp)
+        )
+    }
+
+    if (checkWeakPassphrase) {
+        Row(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(8.dp),
+            horizontalArrangement = Arrangement.Center,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Text(
+                text = hint,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.secondary
+            )
+        }
+    }
+
+    // Bring up keyboard when entering screen
+    LaunchedEffect(Unit) {
+        focusRequester.requestFocus()
+
+        calcHintAndMeetsRequirements(inputText, constraints).let {
+            hint = it.first
+            meetsRequirements = it.second
+        }
+    }
+}
+
+private fun calcHintAndMeetsRequirements(
+    passphrase: String,
+    constraints: PassphraseConstraints,
+): Pair<String, Boolean> {
+    // For a fixed-length passphrase, never give any hints until user has typed it in.
+    val isFixedLength = (constraints.minLength == constraints.maxLength)
+    if (isFixedLength) {
+        if (passphrase.length < constraints.minLength) {
+            return Pair("", false)
+        }
+    }
+
+    if (passphrase.length < constraints.minLength) {
+        return Pair(
+            if (constraints.requireNumerical)
+                "PIN must be at least ${constraints.minLength} digits"
+            else
+                "Passphrase must be at least ${constraints.minLength} characters",
+            false
+        )
+    }
+
+    if (isWeakPassphrase(passphrase)) {
+        return Pair(
+            if (constraints.requireNumerical)
+                "PIN is weak, please choose another"
+            else
+                "Passphrase is weak, please choose another",
+            false
+        )
+    }
+
+    return Pair("", true)
+}
+
+private fun isWeakPassphrase(passphrase: String): Boolean {
+    if (passphrase.isEmpty()) {
+        return false
+    }
+
+    // Check all characters being the same
+    if (passphrase.all { it.equals(passphrase.first()) }) {
+        return true
+    }
+
+    // Check consecutive characters (e.g. 1234 or abcd)
+    var nextChar = passphrase.first().inc()
+    for (n in IntRange(1, passphrase.length - 1)) {
+        if (passphrase[n] != nextChar) {
+            return false
+        }
+        nextChar = nextChar.inc()
+    }
+    return true
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphrasePromptDialog.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphrasePromptDialog.kt
@@ -1,0 +1,79 @@
+package com.android.identity_credential.wallet.ui.prompt.passphrase
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.compose.ui.platform.ComposeView
+import androidx.fragment.app.FragmentManager
+import com.android.identity.securearea.PassphraseConstraints
+import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+
+/**
+ * Show the "Passphrase Prompt" by rendering a [PassphraseEntryField] and returning the typed string
+ * as the result of the prompt.
+ */
+suspend fun showPassphrasePrompt(
+    constraints: PassphraseConstraints,
+    checkWeakPassphrase: Boolean,
+    fragmentManager: FragmentManager
+): String  =
+    suspendCancellableCoroutine { continuation ->
+        val passphrasePromptDialog = PassphrasePromptDialog(
+            constraints = constraints,
+            checkWeakPassphrase = checkWeakPassphrase,
+            passphrasePromptListener = object :
+                PassphrasePromptDialog.PassphrasePromptResponseListener {
+                override fun onPassphraseChanged(passphrase: String) {
+                    continuation.resume(passphrase)
+                }
+            }
+        )
+        passphrasePromptDialog.show(fragmentManager, "passphrase_prompt")
+    }
+
+
+/**
+ * Wrapper (Dialog) class for rendering the Passphrase prompt via composition since composable
+ * functions cannot be defined as "suspend".
+ *
+ * Extends BottomSheetDialogFragment and shows up as an overlay above the current UI.
+ *
+ * Expects a [PassphrasePromptResponseListener] instance to be provided to notify when the user
+ * finishes submitting a passphrase.
+ */
+class PassphrasePromptDialog(
+    private val constraints: PassphraseConstraints,
+    private val checkWeakPassphrase: Boolean,
+    private val passphrasePromptListener: PassphrasePromptResponseListener,
+) : BottomSheetDialogFragment() {
+
+    interface PassphrasePromptResponseListener {
+        fun onPassphraseChanged(passphrase: String)
+    }
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View =
+        ComposeView(requireContext()).apply {
+            setContent {
+                IdentityCredentialTheme {
+                    PassphraseEntryField(
+                        constraints = constraints,
+                        checkWeakPassphrase = checkWeakPassphrase,
+                        onChanged = { passphrase, _, donePressed ->
+                            if (donePressed) {
+                                passphrasePromptListener.onPassphraseChanged(passphrase)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+}


### PR DESCRIPTION
- new package wallet.ui.prompt.**passphrase** contains `PassphraseEntryField` and `PassphrasePromptDialog`
- Created wrapper class `PassphrasePromptDialog` to render a `PassphraseEntryField` and issue a callback when a passphrase is entered.
- global function `showPassphrasePrompt(..)` uses the wrapper function shows the prompt and returns the typed passphrase String when the dialog's listener triggers the callback.


### This PR is dependent on PR #627 (commit https://github.com/openwallet-foundation-labs/identity-credential/commit/9399fa17642916e6a5b65a3088c1c2141dddad63) to land first.