### PR TITLE
Add a way for the wallet server to send notifications to the wallet app.

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,13 +136,6 @@ interfaces. Server configuration file, resources and database can be found in
 Use the following command to run the server locally for development:
 `./gradlew server:tomcatRun`.
 
-Server URL is currently hardcoded in the wallet app as `http://localhost:8080/wallet-server` (see
-WalletApplication.kt). This is expected to be moved to settings in the future. For now either
-change it explicitly (but remember to configure various possible firewalls) or run the server
-locally at the development computer and tunnel in to the device using the following command:
-`adb reverse tcp:8080 tcp:8080`. When everything works you should see "El Dorado" issuance authority
-when trying to add new document to the wallet.
-
 ## Sample Applications
 
 The `samples/` directory contain a number of sample applications, intended primarily

--- a/identity-flow/src/main/java/com/android/identity/flow/environment/Notifications.kt
+++ b/identity-flow/src/main/java/com/android/identity/flow/environment/Notifications.kt
@@ -1,8 +1,23 @@
 package com.android.identity.flow.environment
 
+import kotlinx.coroutines.flow.SharedFlow
+
 /**
  * Simple interface to convey notifications to registered clients.
  */
 interface Notifications {
-    suspend fun emitNotification(clientId: String, issuingAuthorityIdentifier: String, documentIdentifier: String)
+    /**
+     * Sends a notification to a target.
+     *
+     * Implementations of this method must also emit the notification on [eventFlow].
+     *
+     * @param targetId the target of the notification.
+     * @param payload the payload of the notification.
+     */
+    suspend fun emit(targetId: String, payload: ByteArray)
+
+    /**
+     * A [SharedFlow] which can be used to listen in on emitted notifications.
+     */
+    val eventFlow: SharedFlow<Pair<String, ByteArray>>
 }

--- a/identity-flow/src/main/java/com/android/identity/flow/handler/FlowHandlerRemote.kt
+++ b/identity-flow/src/main/java/com/android/identity/flow/handler/FlowHandlerRemote.kt
@@ -35,12 +35,47 @@ class FlowHandlerRemote(private val client: HttpClient) : FlowHandler {
     }
 
     /**
-     * Should be thrown by [HttpClient] methods when connecting to the
-     * server failed.
+     * Base class for all exceptions thrown by [HttpClient]
      */
-    class ConnectionException(message: String) : RuntimeException(message)
+    open class HttpClientException: Error {
+        constructor(message: String) : super(message)
+        constructor(message: String, cause: Throwable) : super(message, cause)
+    }
 
-    class RemoteException(message: String) : RuntimeException(message)
+    /**
+     * Base class for exceptions related to connection problems in [HttpClient].
+     */
+    open class ConnectionException: HttpClientException {
+        constructor(message: String) : super(message)
+        constructor(message: String, cause: Throwable) : super(message, cause)
+    }
+
+    /**
+     * Should be thrown by [HttpClient] methods when the method fails because the connection
+     * to the remote server was refused.
+     */
+    class ConnectionRefusedException: ConnectionException {
+        constructor(message: String) : super(message)
+        constructor(message: String, cause: Throwable) : super(message, cause)
+    }
+
+    /**
+     * Should be thrown by [HttpClient] methods when a connection was established to the remote
+     * server but the connection was terminated before the server responded.
+     */
+    class TimeoutException: ConnectionException {
+        constructor(message: String) : super(message)
+        constructor(message: String, cause: Throwable) : super(message, cause)
+    }
+
+    /**
+     * Should be thrown by [HttpClient] if the the remote server encountered an error during
+     * the processing of the request.
+     */
+    class RemoteException: HttpClientException {
+        constructor(message: String) : super(message)
+        constructor(message: String, cause: Throwable) : super(message, cause)
+    }
 
     data class HttpResponse(val status: Int, val statusText: String, val body: ByteString)
 

--- a/identity-issuance/build.gradle
+++ b/identity-issuance/build.gradle
@@ -25,6 +25,7 @@ dependencies {
     implementation libs.kotlinx.datetime
     implementation libs.kotlinx.serialization
     implementation libs.kotlinx.io.bytestring
+    implementation libs.kotlinx.coroutines.core
     implementation libs.net.sf.scuba.scuba.sc.android
     implementation libs.org.jmrtd.jmrtd
     ksp project(':processor')

--- a/identity-issuance/src/main/java/com/android/identity/issuance/AuthenticationFlow.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/AuthenticationFlow.kt
@@ -13,5 +13,5 @@ interface AuthenticationFlow : FlowBaseInterface {
     suspend fun requestChallenge(clientId: String): ClientChallenge
 
     @FlowMethod
-    suspend fun authenticate(auth: ClientAuthentication)
+    suspend fun authenticate(auth: ClientAuthentication): WalletServerCapabilities
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/ClientAuthentication.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/ClientAuthentication.kt
@@ -4,8 +4,30 @@ import com.android.identity.cbor.annotation.CborSerializable
 import com.android.identity.crypto.CertificateChain
 import kotlinx.io.bytestring.ByteString
 
+/**
+ * An data structure sent from the Wallet Application to the Wallet Server used to prove
+ * that it is the legitimate instance for clientId.
+ */
 @CborSerializable
 data class ClientAuthentication(
+    /**
+     * An ECDSA signature made by WalletAppliactionKey.
+     *
+     * TODO: describe what we're actually signing here.
+     */
     val signature: ByteString,
-    val certificateChain: CertificateChain?
+
+    /**
+     * The attestation for WalletAppliactionKey.
+     *
+     * This is only set if this is the first time the client is authenticating.
+     */
+    val certificateChain: CertificateChain?,
+
+    /**
+     * The capabilities of the Wallet Application.
+     *
+     * This is sent every time the wallet app authenticates to the wallet server.
+     */
+    val walletApplicationCapabilities: WalletApplicationCapabilities
 )

--- a/identity-issuance/src/main/java/com/android/identity/issuance/WalletApplicationCapabilities.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/WalletApplicationCapabilities.kt
@@ -1,0 +1,20 @@
+package com.android.identity.issuance
+
+import com.android.identity.cbor.annotation.CborSerializable
+import kotlinx.datetime.Instant
+
+/**
+ * Information about the capabilities of the wallet application, for the wallet server.
+ *
+ * @property generatedAt The point in time this data was generated.
+ * @property androidKeystoreAttestKeyAvailable Whether Android Keystore supports attest keys.
+ * @property androidKeystoreStrongBoxAvailable Whether StrongBox is available on the device.
+ */
+@CborSerializable
+data class WalletApplicationCapabilities(
+    val generatedAt: Instant,
+    val androidKeystoreAttestKeyAvailable: Boolean,
+    val androidKeystoreStrongBoxAvailable: Boolean,
+) {
+    companion object
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/WalletNotificationPayload.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/WalletNotificationPayload.kt
@@ -1,0 +1,17 @@
+package com.android.identity.issuance
+
+import com.android.identity.cbor.annotation.CborSerializable
+
+/**
+ * A data structure for capturing notification data.
+ *
+ * @property issuingAuthorityId the issuer.
+ * @property documentId the document.
+ */
+@CborSerializable
+data class WalletNotificationPayload(
+    val issuingAuthorityId: String,
+    val documentId: String
+) {
+    companion object
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/WalletServer.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/WalletServer.kt
@@ -1,11 +1,8 @@
 package com.android.identity.issuance
 
 import com.android.identity.flow.FlowBaseInterface
-import com.android.identity.flow.annotation.FlowGetter
 import com.android.identity.flow.annotation.FlowInterface
 import com.android.identity.flow.annotation.FlowMethod
-import kotlinx.io.bytestring.ByteString
-import org.intellij.lang.annotations.Identifier
 
 @FlowInterface
 interface WalletServer: FlowBaseInterface {
@@ -26,4 +23,18 @@ interface WalletServer: FlowBaseInterface {
 
     @FlowMethod
     suspend fun getIssuingAuthority(identifier: String): IssuingAuthority
+
+    /**
+     * Waits until a notification is available for the client.
+     *
+     * A wallet should only use this if [WalletServerCapabilities.waitForNotificationSupported] is
+     * set to `true`.
+     *
+     * This may error out if a notification wasn't available within a certain server-defined
+     * timeframe.
+     *
+     * @return a [ByteArray] with the notification payload.
+     */
+    @FlowMethod
+    suspend fun waitForNotification(): ByteArray
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/WalletServerCapabilities.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/WalletServerCapabilities.kt
@@ -1,0 +1,25 @@
+package com.android.identity.issuance
+
+import com.android.identity.cbor.annotation.CborSerializable
+import kotlinx.datetime.Instant
+
+/**
+ * Information about the capabilities of the wallet server, for the wallet application.
+ *
+ * If [waitForNotificationSupported] is `false` it means that the wallet application
+ * should use push notifications instead of long polling on [WalletServer.waitForNotification].
+ * This is normally only set to `true` for development instances of the server because
+ * of the fact that things like [WalletServer.waitForNotification] doesn't work efficiently
+ * at scale or when the application is not running.
+ *
+ * @property generatedAt The point in time this data was generated.
+ * @property waitForNotificationSupported Whether the [WalletServer.waitForNotification] method is
+ * supported by the server.
+ */
+@CborSerializable
+data class WalletServerCapabilities(
+    val generatedAt: Instant,
+    val waitForNotificationSupported: Boolean,
+) {
+    companion object
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/IssuingAuthorityState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/IssuingAuthorityState.kt
@@ -39,11 +39,13 @@ import com.android.identity.issuance.IssuingAuthority
 import com.android.identity.issuance.IssuingAuthorityConfiguration
 import com.android.identity.issuance.MdocDocumentConfiguration
 import com.android.identity.issuance.RegistrationResponse
+import com.android.identity.issuance.WalletNotificationPayload
 import com.android.identity.issuance.evidence.EvidenceResponse
 import com.android.identity.issuance.evidence.EvidenceResponseIcaoNfcTunnelResult
 import com.android.identity.issuance.evidence.EvidenceResponseIcaoPassiveAuthentication
 import com.android.identity.issuance.evidence.EvidenceResponseQuestionMultipleChoice
 import com.android.identity.issuance.proofing.defaultCredentialConfiguration
+import com.android.identity.issuance.toCbor
 import com.android.identity.mdoc.mso.MobileSecurityObjectGenerator
 import com.android.identity.mdoc.mso.StaticAuthDataGenerator
 import com.android.identity.mdoc.util.MdocUtil
@@ -604,7 +606,7 @@ class IssuingAuthorityState(
         storage.delete("IssuerDocument", clientId, documentId)
         if (emitNotification) {
             val notifications = env.getInterface(Notifications::class)!!
-            notifications.emitNotification(clientId, authorityId, documentId)
+            notifications.emit(clientId, WalletNotificationPayload(authorityId, documentId).toCbor())
         }
     }
 
@@ -622,7 +624,7 @@ class IssuingAuthorityState(
         storage.update("IssuerDocument", clientId, documentId, ByteString(bytes))
         if (emitNotification) {
             val notifications = env.getInterface(Notifications::class)!!
-            notifications.emitNotification(clientId, authorityId, documentId)
+            notifications.emit(clientId, WalletNotificationPayload(authorityId, documentId).toCbor())
         }
     }
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/WalletServerState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/WalletServerState.kt
@@ -1,5 +1,6 @@
 package com.android.identity.issuance.hardcoded
 
+import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.annotation.CborSerializable
 import com.android.identity.flow.annotation.FlowJoin
 import com.android.identity.flow.annotation.FlowMethod
@@ -7,10 +8,15 @@ import com.android.identity.flow.annotation.FlowState
 import com.android.identity.flow.environment.Configuration
 import com.android.identity.flow.environment.Resources
 import com.android.identity.flow.environment.FlowEnvironment
+import com.android.identity.flow.environment.Notifications
 import com.android.identity.flow.handler.FlowHandlerLocal
 import com.android.identity.issuance.DocumentConfiguration
 import com.android.identity.issuance.IssuingAuthorityConfiguration
 import com.android.identity.issuance.WalletServer
+import com.android.identity.util.Logger
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.withTimeoutOrNull
 import kotlinx.io.bytestring.buildByteString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonArray
@@ -26,6 +32,8 @@ class WalletServerState(
     var clientId: String = ""
 ) {
     companion object {
+        private const val TAG = "WalletServerState"
+
         private fun devConfig(env: FlowEnvironment): IssuingAuthorityConfiguration {
             val resources = env.getInterface(Resources::class)!!
             val logo = resources.getRawResource("default/logo.png")!!
@@ -54,6 +62,7 @@ class WalletServerState(
             RegistrationState.register(flowHandlerBuilder)
             RequestCredentialsState.register(flowHandlerBuilder)
         }
+
     }
 
     @FlowMethod
@@ -88,4 +97,31 @@ class WalletServerState(
         check(clientId.isNotEmpty())
         return IssuingAuthorityState(clientId, identifier)
     }
+
+    @FlowMethod
+    suspend fun waitForNotification(env: FlowEnvironment): ByteArray {
+        val notifications = env.getInterface(Notifications::class)!!
+
+        // The maximum amount of time we want a client to hang around and we throw an
+        // error when this is reached. This is to conserve resources on the server
+        // side. The wallet app will handle this gracefully by just reconnecting.
+        //
+        // This should be shorter than the Wallet's client timeout, see REQUEST_TIMEOUT_SECONDS
+        // in WalletHttpClient
+        //
+        val timeoutForClientSeconds = 3*60
+
+        val notificationPayload = withTimeoutOrNull(timeoutForClientSeconds.toLong()*1000) {
+            notifications.eventFlow.first { it.first == clientId  }.second
+        }
+        if (notificationPayload == null) {
+            throw NotificationTimeoutError(
+                "Timed out waiting for notification (timeout: ${timeoutForClientSeconds} seconds)"
+            )
+        }
+        Logger.i(TAG, "Notification for $clientId: ${Cbor.toDiagnostics(notificationPayload)}")
+        return notificationPayload
+    }
+
+    class NotificationTimeoutError(message: String): Error(message)
 }

--- a/server/environment/settings.json
+++ b/server/environment/settings.json
@@ -4,7 +4,8 @@
     "user": "dbuser",
     "password": "dbpass"
   },
-  "developerMode": false,
+  "developerMode": true,
+  "waitForNotificationSupported": true,
   "android": {
     "requireGmsAttestation": false,
     "requireVerifiedBootGreen": false,

--- a/server/src/main/java/com/android/identity/wallet/server/FlowServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/FlowServlet.kt
@@ -3,6 +3,7 @@ package com.android.identity.wallet.server
 import com.android.identity.flow.environment.Storage
 import com.android.identity.flow.handler.FlowHandlerLocal
 import com.android.identity.issuance.hardcoded.WalletServerState
+import com.android.identity.util.Logger
 import kotlinx.coroutines.runBlocking
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
@@ -15,18 +16,17 @@ import kotlin.random.Random
 
 // To run this servlet for development, use this command:
 //
-// ./gradlew wallet-server:tomcatRun
+// ./gradlew server:tomcatRun
 //
-// This should start the server on http://localhost:8080/wallet-server. To get the Android
-// app to connect it, use this command to tunnel 8080 port local connections on the Android
-// device to your development machine:
-//
-// adb reverse tcp:8080 tcp:8080
+// To get the Wallet App to use it, go into Settings and make it point to the machine
+// you are running the server on.
 //
 class FlowServlet : HttpServlet() {
 
     companion object {
-        private val serverEnvironment = ServerEnvironment("environment")
+        private const val TAG = "FlowServlet"
+
+        internal val serverEnvironment = ServerEnvironment("environment")
 
         private val flowHandler = createHandler()
 
@@ -56,29 +56,49 @@ class FlowServlet : HttpServlet() {
         }
     }
 
+
+    private fun getRemoteHost(req: HttpServletRequest): String {
+        var remoteHost = req.remoteHost
+        val forwardedFor = req.getHeader("X-Forwarded-For")
+        if (forwardedFor != null) {
+            remoteHost = forwardedFor
+        }
+        return remoteHost
+    }
+
     override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
-        println("POST ${req.servletPath}")
+        val threadId = Thread.currentThread().id
+        val remoteHost = getRemoteHost(req)
+        val prefix = "tid=$threadId host=$remoteHost"
         val parts = req.servletPath.split("/")
         if (parts.size < 3) {
+            Logger.i(TAG, "$prefix: malformed request")
             throw Exception("Illegal request!")
         }
         val requestLength = req.contentLength
-        println("Content-length: $requestLength")
+        Logger.i(TAG, "$prefix: POST ${req.servletPath} ($requestLength bytes)")
         val requestData = req.inputStream.readNBytes(requestLength)
         try {
             val bytes = runBlocking {
                 flowHandler.handlePost(parts[parts.lastIndex-1],
                     parts.last(), ByteString(requestData))
             }
+            Logger.i(TAG, "$prefix: POST response status 200 (${bytes.size} bytes)")
             resp.contentType = "application/cbor"
             resp.outputStream.write(bytes.toByteArray())
-        } catch (ex: FlowHandlerLocal.NotFoundException) {
-            resp.sendError(404, ex.message)
-        } catch (ex: FlowHandlerLocal.StateTamperedException) {
+        } catch (e: FlowHandlerLocal.NotFoundException) {
+            Logger.i(TAG, "$prefix: POST response status 404")
+            resp.sendError(404, e.message)
+        } catch (e: FlowHandlerLocal.StateTamperedException) {
+            Logger.i(TAG, "$prefix: POST response status 405")
             resp.sendError(405, "State tampered")
-        } catch (ex: Exception) {
-            ex.printStackTrace()
-            resp.sendError(500, ex.message)
+        } catch (e: Throwable) {
+            Logger.i(TAG, "$prefix: POST response status 500: ${e::class.simpleName}: ${e.message}")
+            // NotificationTimeoutError happens frequently, don't need a stack trace for this...
+            if (e !is WalletServerState.NotificationTimeoutError) {
+                e.printStackTrace()
+            }
+            resp.sendError(500, e.message)
         }
     }
 

--- a/server/src/main/java/com/android/identity/wallet/server/ServerEnvironment.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/ServerEnvironment.kt
@@ -16,7 +16,7 @@ class ServerEnvironment(private val directory: String) : FlowEnvironment {
         configuration.getProperty("database.connection") ?: defaultDatabase(),
         configuration.getProperty("database.user") ?: "",
         configuration.getProperty("database.password") ?: "")
-    private val notifications = ServerNotifications()
+    private val notifications = ServerNotifications(storage)
 
     override fun <T : Any> getInterface(clazz: KClass<T>): T? {
         return clazz.cast(when(clazz) {

--- a/server/src/main/java/com/android/identity/wallet/server/ServerNotifications.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/ServerNotifications.kt
@@ -1,20 +1,31 @@
 package com.android.identity.wallet.server
 
+import com.android.identity.document.Document
+import com.android.identity.document.DocumentStore
 import com.android.identity.flow.environment.Notifications
+import com.android.identity.flow.environment.Storage
 import com.android.identity.util.Logger
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.asSharedFlow
 
-class ServerNotifications : Notifications {
+class ServerNotifications(
+    private val storage: Storage,
+) : Notifications {
     companion object {
         private const val TAG = "ServerNotifications"
     }
-    override suspend fun emitNotification(
-        clientId: String,
-        issuingAuthorityIdentifier: String,
-        documentIdentifier: String
+
+    private val _eventFlow = MutableSharedFlow<Pair<String, ByteArray>>()
+
+    override val eventFlow
+        get() = _eventFlow.asSharedFlow()
+
+    override suspend fun emit(
+        targetId: String,
+        payload: ByteArray
     ) {
-        Logger.w(TAG, "emitNotification not yet implemented - " +
-                "clientId:$clientId " +
-                "issuingAuthorityIdentifier:$issuingAuthorityIdentifier " +
-                "documentIdentifier:$documentIdentifier")
+        _eventFlow.emit(Pair(targetId, payload))
+        // TODO: emit notification via Firebase
     }
 }

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -7,6 +7,7 @@
         <display-name>FlowServlet</display-name>
         <servlet-name>FlowServlet</servlet-name>
         <servlet-class>com.android.identity.wallet.server.FlowServlet</servlet-class>
+        <load-on-startup>0</load-on-startup>
     </servlet>
 
     <servlet-mapping>

--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -70,7 +70,7 @@
 
         <provider
             android:name=".LogFileProvider"
-            android:authorities="com.android.identity_credential.wallet"
+            android:authorities="${applicationId}"
             android:exported="false"
             android:grantUriPermissions="true">
             <meta-data

--- a/wallet/src/main/java/com/android/identity/issuance/DocumentExtensions.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/DocumentExtensions.kt
@@ -71,12 +71,10 @@ object DocumentExtensions {
      * condition in [Document.state] is set to [DocumentCondition.NO_SUCH_DOCUMENT].
      *
      * @param walletServerProvider the wallet server provider.
-     * @return true if the refresh succeeded, false if the document is unknown.
      */
-    suspend fun Document.refreshState(walletServerProvider: WalletServerProvider): Boolean {
+    suspend fun Document.refreshState(walletServerProvider: WalletServerProvider) {
         val walletServer = walletServerProvider.getWalletServer()
         val issuer = walletServer.getIssuingAuthority(issuingAuthorityIdentifier)
         this.state = issuer.getState(documentIdentifier)
-        return true
     }
 }

--- a/wallet/src/main/java/com/android/identity/issuance/remote/WalletHttpClient.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/WalletHttpClient.kt
@@ -3,25 +3,49 @@ package com.android.identity.issuance.remote
 import com.android.identity.flow.handler.FlowHandlerRemote
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.timeout
 import io.ktor.client.request.get
 import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.client.statement.readBytes
 import kotlinx.io.bytestring.ByteString
+import java.net.ConnectException
 
 class WalletHttpClient(val baseUrl: String): FlowHandlerRemote.HttpClient {
-    val client = HttpClient(CIO)
+    companion object {
+        // The request timeout.
+        //
+        // TODO: make it possible to set the requestTimeout for each RPC call so
+        //   this timeout can be specified in WalletServerProvider.kt where we do the
+        //   waitUntilNotificationAvailable() call.
+        //
+        private const val REQUEST_TIMEOUT_SECONDS = 5*60
+    }
+
+    val client = HttpClient(CIO) {
+        install(HttpTimeout)
+    }
 
     override suspend fun get(url: String): FlowHandlerRemote.HttpResponse {
         try {
-            val response = client.get("$baseUrl/$url")
+            val response = client.get("$baseUrl/$url") {
+                timeout {
+                    requestTimeoutMillis = REQUEST_TIMEOUT_SECONDS.toLong()*1000
+                }
+            }
             return FlowHandlerRemote.HttpResponse(
                 response.status.value,
                 response.status.description,
                 ByteString(response.readBytes())
             )
-        } catch (ex: Exception) {
-            throw FlowHandlerRemote.ConnectionException(ex.message ?: "")
+        } catch (e: HttpRequestTimeoutException) {
+            throw FlowHandlerRemote.TimeoutException("Timed out", e)
+        } catch (e: ConnectException) {
+            throw FlowHandlerRemote.ConnectionRefusedException("Connection refused", e)
+        } catch (e: Throwable) {
+            throw FlowHandlerRemote.ConnectionException("Error", e)
         }
     }
 
@@ -31,6 +55,9 @@ class WalletHttpClient(val baseUrl: String): FlowHandlerRemote.HttpClient {
     ): FlowHandlerRemote.HttpResponse {
         try {
             val response = client.post("$baseUrl/$url") {
+                timeout {
+                    requestTimeoutMillis = REQUEST_TIMEOUT_SECONDS.toLong()*1000
+                }
                 setBody(data.toByteArray())
             }
             return FlowHandlerRemote.HttpResponse(
@@ -38,8 +65,12 @@ class WalletHttpClient(val baseUrl: String): FlowHandlerRemote.HttpClient {
                 response.status.description,
                 ByteString(response.readBytes())
             )
-        } catch (ex: Exception) {
-            throw FlowHandlerRemote.ConnectionException(ex.message ?: "")
+        } catch (e: HttpRequestTimeoutException) {
+            throw FlowHandlerRemote.TimeoutException("Timed out", e)
+        } catch (e: ConnectException) {
+            throw FlowHandlerRemote.ConnectionRefusedException("Connection refused", e)
+        } catch (e: Throwable) {
+            throw FlowHandlerRemote.ConnectionException("Error", e)
         }
     }
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
@@ -128,7 +128,7 @@ fun DocumentInfoScreen(
                                     remoteDeletionCheckedState.value,
                                     notifyApplicationCheckedState.value
                                 )
-                            } catch (e: Exception) {
+                            } catch (e: Throwable) {
                                 showErrorMessage = "Unexpected exception: $e"
                             }
 
@@ -196,7 +196,7 @@ fun DocumentInfoScreen(
                                 documentModel.refreshCard(documentInfo)
                             } catch (e: ScreenLockRequiredException) {
                                 showErrorMessage = context.getString(R.string.document_info_screen_refresh_error_missing_screenlock)
-                            } catch (e: Exception) {
+                            } catch (e: Throwable) {
                                 showErrorMessage = "Unexpected exception while refreshing: $e"
                             }
                         }


### PR DESCRIPTION
These notifiactions only work when the appliaction is running but on the other hand, no secrets/configuration is needed on neither the client nor server side. Support for real push notifications using Firebase Messaging will be added in a future commit.

Also add WalletServerCapabilities and WalletApplicationCapabilities objects which are exchanged at authentication time, that is, the first time a fresh wallet app instance connects to the wallet server.

Also clarify the document sync code in DocumentModel a little bit and fix a bug there so we get notifiactions on remote document deletion.

Also enhance logging in the FlowServlet code.

Test: Manually tested.
Test: All unit tests pass.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR