### PR TITLE
Add support for mdoc profile of OpenID4VP in wallet

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -56,6 +56,7 @@
     ktor = "2.3.10"
     hsqldb = "2.7.2"
     mysql = "8.0.16"
+    nimbus-sdk = "11.8"
 
 [libraries]
     androidx-core-ktx = { module = "androidx.core:core-ktx", version.ref = "core-ktx" }
@@ -144,9 +145,14 @@
 
     kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin-test"}
 
+    nimbus-oauth2-oidc-sdk = { module = "com.nimbusds:oauth2-oidc-sdk", version.ref = "nimbus-sdk" }
+
     ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
     ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+    ktor-client-content-negotiation = { module = "io.ktor:ktor-client-content-negotiation", version.ref = "ktor" }
+    ktor-serialization-kotlinx-json = { module = "io.ktor:ktor-serialization-kotlinx-json", version.ref = "ktor" }
     javax-servlet-api = { module = "javax.servlet:javax.servlet-api", version.ref = "javax-servlet-api" }
+    ktor-client-mock = { module = "io.ktor:ktor-client-mock", version.ref = "ktor" }
 
 [bundles]
     androidx-core = ["androidx-core-ktx", "androidx-appcompat", "androidx-material", "androidx-contraint-layout", "androidx-fragment-ktx", "androidx-legacy-v4", "androidx-preference-ktx", "androidx-work"]

--- a/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/EUPersonalID.kt
+++ b/identity-doctypes/src/main/java/com/android/identity/documenttype/knowntypes/EUPersonalID.kt
@@ -27,8 +27,8 @@ import com.android.identity.documenttype.DocumentType
  * Source: https://github.com/eu-digital-identity-wallet/eudi-doc-architecture-and-reference-framework/blob/main/docs/annexes/annex-06-pid-rulebook.md
  */
 object EUPersonalID {
-    const val EUPID_DOCTYPE = "eu.europa.ec.eudi.pid.1"
-    const val EUPID_NAMESPACE = "eu.europa.ec.eudi.pid.1"
+    const val EUPID_DOCTYPE = "eu.europa.ec.eudiw.pid.1"
+    const val EUPID_NAMESPACE = "eu.europa.ec.eudiw.pid.1"
 
     /**
      * Build the EU Personal ID Document Type.

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
     alias(libs.plugins.ksp)
+    alias(libs.plugins.kotlinx.serialization.plugin)
 }
 
 kotlin {
@@ -106,7 +107,11 @@ dependencies {
     implementation libs.ktor.client.android
     implementation libs.kotlinx.io.bytestring
     implementation libs.kotlinx.serialization
+    implementation libs.ktor.client.content.negotiation
+    implementation libs.ktor.serialization.kotlinx.json
     debugImplementation libs.compose.icons
+
+    implementation libs.nimbus.oauth2.oidc.sdk
 
     implementation libs.net.sf.scuba.scuba.sc.android
     implementation libs.org.jmrtd.jmrtd
@@ -119,5 +124,6 @@ dependencies {
     debugImplementation libs.compose.test.manifest
 
     testImplementation libs.bundles.unit.testing
+    testImplementation libs.ktor.client.mock
     testRuntimeOnly libs.junit.jupiter.engine
 }

--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -57,6 +57,19 @@
         </activity>
 
         <activity
+            android:name=".presentation.OpenID4VPPresentationActivity"
+            android:exported="true"
+            android:label="@string/app_name_presentation"
+            android:theme="@style/Theme.IdentityCredential">
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="eudi-openid4vp" android:host="*" />
+            </intent-filter>
+        </activity>
+
+        <activity
             android:label="@string/app_name"
             android:name=".credman.CredmanPresentationActivity"
             android:enabled="true"

--- a/wallet/src/main/java/com/android/identity_credential/wallet/presentation/OpenID4VPPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/presentation/OpenID4VPPresentationActivity.kt
@@ -1,0 +1,819 @@
+package com.android.identity_credential.wallet.presentation
+
+import android.content.Intent
+import android.net.Uri
+import android.os.Bundle
+import android.widget.Toast
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.lifecycleScope
+import com.android.identity.android.securearea.AndroidKeystoreKeyInfo
+import com.android.identity.android.securearea.AndroidKeystoreKeyUnlockData
+import com.android.identity.android.securearea.UserAuthenticationType
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborArray
+import com.android.identity.cbor.Simple
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+import com.android.identity.document.Document
+import com.android.identity.document.DocumentRequest
+import com.android.identity.document.NameSpacedData
+import com.android.identity.issuance.CredentialFormat
+import com.android.identity.issuance.DocumentExtensions.documentConfiguration
+import com.android.identity.issuance.DocumentExtensions.issuingAuthorityIdentifier
+import com.android.identity.mdoc.credential.MdocCredential
+import com.android.identity.mdoc.mso.MobileSecurityObjectParser
+import com.android.identity.mdoc.mso.StaticAuthDataParser
+import com.android.identity.mdoc.response.DeviceResponseGenerator
+import com.android.identity.mdoc.response.DocumentGenerator
+import com.android.identity.mdoc.util.MdocUtil
+import com.android.identity.securearea.KeyLockedException
+import com.android.identity.securearea.KeyUnlockData
+import com.android.identity.trustmanagement.TrustPoint
+import com.android.identity.util.Constants
+import com.android.identity.util.Logger
+import com.android.identity_credential.wallet.R
+import com.android.identity_credential.wallet.WalletApplication
+import com.android.identity_credential.wallet.ui.ScreenWithAppBar
+import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
+import com.android.identity_credential.wallet.ui.prompt.consent.ConsentPromptEntryField
+import com.android.identity_credential.wallet.ui.prompt.consent.ConsentPromptEntryFieldData
+import com.android.identity_credential.wallet.ui.theme.IdentityCredentialTheme
+// TODO: replace the nimbusds library usage with non-java-based alternative
+import com.nimbusds.jose.EncryptionMethod
+import com.nimbusds.jose.JOSEObjectType
+import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.JWEHeader
+import com.nimbusds.jose.crypto.ECDHEncrypter
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier
+import com.nimbusds.jose.proc.JWSKeySelector
+import com.nimbusds.jose.proc.SecurityContext
+import com.nimbusds.jose.shaded.gson.Gson
+import com.nimbusds.jose.util.Base64URL
+import com.nimbusds.jose.util.X509CertUtils
+import com.nimbusds.jwt.EncryptedJWT
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.SignedJWT
+import com.nimbusds.jwt.proc.BadJWTException
+import com.nimbusds.jwt.proc.DefaultJWTProcessor
+import com.nimbusds.jwt.proc.JWTClaimsSetVerifier
+import io.ktor.client.HttpClient
+import io.ktor.client.call.NoTransformationFoundException
+import io.ktor.client.call.body
+import io.ktor.client.plugins.contentnegotiation.*
+import io.ktor.client.request.accept
+import io.ktor.client.request.get
+import io.ktor.client.request.post
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.Parameters
+import io.ktor.http.Url
+import io.ktor.http.content.OutgoingContent
+import io.ktor.http.formUrlEncode
+import io.ktor.serialization.kotlinx.json.*
+import io.ktor.util.InternalAPI
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.Required
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.contentOrNull
+import kotlinx.serialization.json.encodeToJsonElement
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import java.security.cert.X509Certificate
+import java.util.UUID
+import kotlin.coroutines.resume
+import kotlin.io.encoding.Base64
+import kotlin.io.encoding.ExperimentalEncodingApi
+import kotlin.random.Random
+
+@Serializable
+internal data class PresentationSubmission(
+    @Required val id: String,
+    @Required
+    @SerialName("definition_id")
+    val definitionId: String,
+    @Required
+    @SerialName("descriptor_map")
+    val descriptorMaps: List<DescriptorMap>,
+)
+
+@Serializable
+internal data class DescriptorMap(
+    @Required val id: String,
+    @Required val format: String,
+    @Required val path: String,
+)
+
+internal data class AuthorizationRequest (
+    var presentationDefinition: JsonObject,
+    var clientId: String,
+    var nonce: String,
+    var responseUri: String,
+    var state: String?,
+    var clientMetadata: JsonObject,
+    var certificateChain: List<X509Certificate>?
+)
+
+internal data class ResponseComponents (
+    var documentRequest: DocumentRequest,
+    var sessionTranscript: ByteArray,
+    var jweHeader: JWEHeader,
+    var responseUrl: Url,
+    var state: String?,
+    var presentationSubmission: PresentationSubmission,
+    val keySet: JWKSet
+)
+
+class OpenID4VPPresentationActivity : FragmentActivity() {
+    companion object {
+        private const val TAG = "OnlinePresentmentActivity"
+    }
+
+    private enum class State { PROCESSING, RESPONSE_SENT }
+
+    private var state = MutableLiveData<State>()
+    private var document: Document? = null
+    private var responseComponents: ResponseComponents? = null
+    private var consentData: ConsentPromptEntryFieldData? = null
+
+    // creating new HttpClients is not cheap, better to reuse/not create when possible
+    private var httpClient = lazy { HttpClient {
+        install(ContentNegotiation) { json() }
+        expectSuccess = true
+    } }
+
+    private val walletApp: WalletApplication by lazy {
+        application as WalletApplication
+    }
+
+    private val showErrorAndDismiss: (Throwable) -> Unit = { throwable ->
+        Toast.makeText(applicationContext, throwable.message, Toast.LENGTH_SHORT).show()
+        onDestroy()
+    }
+
+    private fun onAuthenticationKeyLocked(credential: MdocCredential) {
+        val keyInfo = credential.secureArea.getKeyInfo(credential.alias)
+        var userAuthenticationTypes = emptySet<UserAuthenticationType>()
+        if (keyInfo is AndroidKeystoreKeyInfo) {
+            userAuthenticationTypes = keyInfo.userAuthenticationTypes
+        }
+
+        val unlockData = AndroidKeystoreKeyUnlockData(credential.alias)
+        val cryptoObject = unlockData.getCryptoObjectForSigning(Algorithm.ES256)
+
+        showBiometricPrompt(
+            activity = this,
+            title = applicationContext.resources.getString(R.string.presentation_biometric_prompt_title),
+            subtitle = applicationContext.resources.getString(R.string.presentation_biometric_prompt_subtitle),
+            cryptoObject = cryptoObject,
+            userAuthenticationTypes = userAuthenticationTypes,
+            requireConfirmation = false,
+            onCanceled = { finish() },
+            onSuccess = {
+                // create and send response on IO thread
+                lifecycleScope.launch {
+                    createAndSendResponse(unlockData, credential)
+                } },
+            onError = {exception ->
+                Logger.e(TAG, exception.toString())
+                finish() },
+        )
+    }
+
+    override fun onDestroy() {
+        Logger.i(TAG, "onDestroy")
+        if (httpClient.isInitialized()) {
+            httpClient.value.close()
+        }
+        super.onDestroy()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        val supportedUriSchemes = listOf("mdoc-openid4vp", "eudi-openid4vp")
+        var authorizationRequest = ""
+        if (supportedUriSchemes.contains(intent.scheme)) {
+            authorizationRequest = Uri.parse(intent.toUri(0)).toString()
+            state.value = State.PROCESSING
+        } else {
+            Logger.e(TAG, "URI scheme not recognized")
+            showErrorAndDismiss(IllegalArgumentException("URI scheme not recognized"))
+        }
+
+        setContent {
+            IdentityCredentialTheme {
+
+                val stateDisplay = remember { mutableStateOf("Idle") }
+                val consentPromptData = remember { mutableStateOf<ConsentPromptEntryFieldData?>(null) }
+
+                state.observe(this as LifecycleOwner) { state ->
+                    when (state) {
+                        State.PROCESSING -> {
+                            Logger.i(TAG, "State: Processing")
+                            stateDisplay.value = "Processing"
+                            processRequest(authorizationRequest, consentPromptData)
+                        }
+
+                        State.RESPONSE_SENT -> {
+                            Logger.i(TAG, "State: Response Sent")
+                            stateDisplay.value = "Response Sent"
+                        }
+
+                        else -> {}
+                    }
+                }
+
+                ScreenWithAppBar(title = "Presenting", navigationIcon = { }) {
+                    Column(
+                        modifier = Modifier
+                            .padding(16.dp),
+                        verticalArrangement = Arrangement.spacedBy(16.dp),
+                        horizontalAlignment = Alignment.CenterHorizontally
+                    ) {
+                        Text(
+                            text = "Sending mDL to reader.",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        Text(
+                            text = "TODO: finalize UI",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        HorizontalDivider()
+                        Text(
+                            text = "State: ${stateDisplay.value}",
+                            style = MaterialTheme.typography.bodyMedium,
+                            color = MaterialTheme.colorScheme.onSurface
+                        )
+                        HorizontalDivider()
+                        Button(onClick = { finish() }) {
+                            Text("Close")
+                        }
+                    }
+
+                    // when consent data is available, show consent prompt
+                    consentData = consentPromptData.value
+                    if (consentData != null) {
+                        ConsentPromptEntryField(
+                            consentData = consentData!!,
+                            documentTypeRepository = walletApp.documentTypeRepository,
+                            onConfirm = {
+                                // create and send response on IO thread
+                                lifecycleScope.launch {
+                                    createAndSendResponse()
+                                }
+                            },
+                            onCancel = {
+                                finish()
+                            }
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    @OptIn(ExperimentalEncodingApi::class)
+    private fun processRequest(
+        authRequest: String,
+        consentPromptData: MutableState<ConsentPromptEntryFieldData?>
+    )  {
+        val uri = Uri.parse(authRequest)
+
+        lifecycleScope.launch {
+            val authorizationRequest = getAuthorizationRequest(uri, httpClient, showErrorAndDismiss)
+            val presentationSubmission = createPresentationSubmission(authorizationRequest)
+            val inputDescriptors = authorizationRequest.presentationDefinition["input_descriptors"]!!.jsonArray
+
+            // for now, we only respond to the first credential being requested
+            // NOTE: openid4vp spec gives a non-normative example of multiple input descriptors
+            // as "alternatives credentials" https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.1-6
+            // but identity.foundation says all input descriptors MUST be satisfied https://identity.foundation/presentation-exchange/spec/v2.0.0/#input-descriptor
+            val inputDescriptorObj = inputDescriptors[0].jsonObject
+            val docType = inputDescriptorObj["id"]!!.toString().run { substring(1, this.length - 1) }
+            val verifierName = inputDescriptorObj["name"].toString().run { substring(1, this.length - 1) }
+            val format = inputDescriptorObj["format"]!!.jsonObject
+            val documentRequest = formatAsDocumentRequest(inputDescriptorObj)
+
+            val credentialFormat: CredentialFormat
+            if (format.contains("mso_mdoc")) {
+                credentialFormat = CredentialFormat.MDOC_MSO
+            } else {
+                throw IllegalArgumentException("We only support the mdoc profile.")
+            }
+            document = firstMatchingDocument(credentialFormat, docType)
+                ?: run { throw IllegalStateException("No matching credentials in wallet") }
+
+            // begin collecting and creating data needed for the response
+            val secureRandom = Random.Default
+            val bytes = ByteArray(16)
+            secureRandom.nextBytes(bytes)
+            val mdocGeneratedNonce = Base64.UrlSafe.encode(bytes)
+            val sessionTranscript = createSessionTranscript(
+                clientId = authorizationRequest.clientId,
+                responseUri = authorizationRequest.responseUri,
+                authorizationRequestNonce = authorizationRequest.nonce,
+                mdocGeneratedNonce = mdocGeneratedNonce
+            )
+
+            if (authorizationRequest.clientMetadata["authorization_signed_response_alg"] != null) {
+                TODO("Support signing the authorization response")
+            }
+            val responseEncryptionAlg = JWEAlgorithm.parse(authorizationRequest.clientMetadata
+                ["authorization_encrypted_response_alg"]!!.toString().run { substring(1, this.length - 1) })
+            val responseEncryptionMethod = EncryptionMethod.parse(authorizationRequest.clientMetadata
+                ["authorization_encrypted_response_enc"]!!.toString().run { substring(1, this.length - 1) })
+            val apv = Base64URL.encode(authorizationRequest.nonce)
+            val apu = Base64URL.encode(mdocGeneratedNonce)
+            val jweHeader = JWEHeader.Builder(responseEncryptionAlg, responseEncryptionMethod)
+                .apply {
+                    apv?.let(::agreementPartyVInfo)
+                    apu?.let(::agreementPartyUInfo)
+                }
+                .build()
+
+            responseComponents = ResponseComponents(
+                documentRequest = documentRequest,
+                sessionTranscript = sessionTranscript,
+                jweHeader = jweHeader,
+                responseUrl = Url(authorizationRequest.responseUri),
+                state = authorizationRequest.state,
+                presentationSubmission = presentationSubmission,
+                keySet = getKeySet(authorizationRequest.clientMetadata)
+            )
+
+            consentPromptData.value = ConsentPromptEntryFieldData(
+                documentRequest = documentRequest,
+                docType = docType,
+                documentName = document!!.documentConfiguration.displayName,
+                credentialData = document!!.documentConfiguration.mdocConfiguration!!.staticData,
+                credentialId = document!!.name,
+                verifier = if (authorizationRequest.certificateChain != null) TrustPoint(
+                    authorizationRequest.certificateChain!![0], verifierName) else null
+            )
+        }
+    }
+
+    private fun firstMatchingDocument(
+        credentialFormat: CredentialFormat,
+        docType: String
+    ): Document? {
+        val settingsModel = walletApp.settingsModel
+        val documentStore = walletApp.documentStore
+
+        // prefer the credential which is on-screen if possible
+        val credentialIdFromPager: String? = settingsModel.focusedCardId.value
+        if (credentialIdFromPager != null
+            && canDocumentSatisfyRequest(credentialIdFromPager, credentialFormat, docType)
+        ) {
+            return documentStore.lookupDocument(credentialIdFromPager)!!
+        }
+
+        val docId = documentStore.listDocuments().firstOrNull { credentialId ->
+            canDocumentSatisfyRequest(credentialId, credentialFormat, docType)
+        }
+        return docId?.let { documentStore.lookupDocument(it) }
+    }
+
+    private fun canDocumentSatisfyRequest(
+        credentialId: String,
+        credentialFormat: CredentialFormat,
+        docType: String
+    ): Boolean {
+        val credential = walletApp.documentStore.lookupDocument(credentialId)!!
+        val issuingAuthorityIdentifier = credential.issuingAuthorityIdentifier
+//        if (!credentialFormats.contains(credentialFormat)) {
+//            return false
+//        }
+
+        return credential.documentConfiguration.mdocConfiguration?.docType == docType
+    }
+
+    private suspend fun getKeySet(clientMetadata: JsonObject): JWKSet {
+        if (clientMetadata["jwks"] != null) {
+            TODO("Add support for parsing keySet directly")
+        }
+
+        val jwksUri = clientMetadata["jwks_uri"].toString().run { substring(1, this.length - 1) }
+        val unparsed = httpClient.value.get(Url(jwksUri)).body<String>()
+        return JWKSet.parse(unparsed)
+    }
+
+    /**
+     * [OutgoingContent] for `application/x-www-form-urlencoded` formatted requests that use US-ASCII encoding.
+     */
+    internal class FormData(
+        val formData: Parameters,
+    ) : OutgoingContent.ByteArrayContent() {
+        private val content = formData.formUrlEncode().toByteArray(Charsets.US_ASCII)
+
+        override val contentLength: Long = content.size.toLong()
+        override val contentType: ContentType = ContentType.Application.FormUrlEncoded
+
+        override fun bytes(): ByteArray = content
+    }
+
+    @OptIn(InternalAPI::class, ExperimentalEncodingApi::class)
+    private suspend fun createAndSendResponse(
+        keyUnlockData: KeyUnlockData? = null,
+        credential: MdocCredential? = null,
+    ) {
+        val now = Clock.System.now()
+        val credentialToUse: MdocCredential = credential
+            ?: (document!!.findCredential(WalletApplication.CREDENTIAL_DOMAIN_MDOC, now)
+                ?: run {
+                    showErrorAndDismiss(IllegalArgumentException("No valid credentials, please request more"))
+                    return
+                }) as MdocCredential
+
+        val staticAuthData = StaticAuthDataParser(credentialToUse.issuerProvidedData).parse()
+        val issuerAuthCoseSign1 = Cbor.decode(staticAuthData.issuerAuth).asCoseSign1
+        val encodedMsoBytes = Cbor.decode(issuerAuthCoseSign1.payload!!)
+        val encodedMso = Cbor.encode(encodedMsoBytes.asTaggedEncodedCbor)
+        val mso = MobileSecurityObjectParser(encodedMso).parse()
+
+        val credentialConfiguration = document!!.documentConfiguration
+        val mergedIssuerNamespaces = MdocUtil.mergeIssuerNamesSpaces(
+            responseComponents!!.documentRequest,
+            credentialConfiguration.mdocConfiguration!!.staticData,
+            staticAuthData
+        )
+
+        val deviceResponseGenerator = DeviceResponseGenerator(Constants.DEVICE_RESPONSE_STATUS_OK)
+
+        // in sep coroutine so that an unexpected error will still allow this function to
+        // finish and send potentially empty response
+        val result = withContext(Dispatchers.IO) { //<- Offload from UI thread
+            addDocumentToResponse(
+                deviceResponseGenerator = deviceResponseGenerator,
+                docType = mso.docType,
+                issuerAuth = staticAuthData.issuerAuth,
+                mergedIssuerNamespaces = mergedIssuerNamespaces,
+                credential = credentialToUse,
+                keyUnlockData = keyUnlockData
+            )
+        }
+
+        if (result != null) {
+            onAuthenticationKeyLocked(result)
+            return
+        }
+
+        // build response
+        val deviceResponseCbor = deviceResponseGenerator.generate()
+        val vpToken = Base64.UrlSafe.encode(deviceResponseCbor)
+        val claimSet = JWTClaimsSet.parse(Json.encodeToString(buildJsonObject {
+            // put("id_token", idToken) // depends on response type, only supporting vp_token for now
+            put("state", responseComponents!!.state)
+            put("vp_token", vpToken)
+            put("presentation_submission", Json.encodeToJsonElement(responseComponents!!.presentationSubmission))
+        }))
+
+
+        // encrypt
+        val jweEncrypter: ECDHEncrypter? = responseComponents!!.keySet.keys.mapNotNull { key ->
+            runCatching { ECDHEncrypter(key as ECKey) }.getOrNull()?.let { encrypter -> key to encrypter }}
+            .toMap().firstNotNullOfOrNull { it.value }
+        val encrypted = EncryptedJWT(responseComponents!!.jweHeader, claimSet).apply { encrypt(jweEncrypter) }
+
+        // send response
+        val requestState: String? = responseComponents!!.state
+        val response = httpClient.value.post(responseComponents!!.responseUrl.toString()) {
+            body = FormData(Parameters.build {
+                append("response", encrypted.serialize())
+                requestState?.let {
+                    append("state", it)
+                }
+            })
+        }
+
+        // receive redirectUri and launch with browser
+        when (response.status) {
+            HttpStatusCode.OK -> {
+                val responseBody = response.body<JsonObject?>()
+                val redirectUri =
+                    try {
+                        responseBody
+                            ?.get("redirect_uri")
+                            ?.takeIf { it is JsonPrimitive }
+                            ?.jsonPrimitive?.contentOrNull
+                            ?.let { Uri.parse(it) }
+                    } catch (t: NoTransformationFoundException) {
+                        null
+                    }
+                startActivity(Intent(Intent.ACTION_VIEW, Uri.parse(redirectUri.toString())))
+            }
+
+            else -> Logger.d(TAG, "Response from verifier not ok")
+        }
+
+        // ensure we update UI-bound state value on Main thread
+        lifecycleScope.launch {
+            state.value = State.RESPONSE_SENT
+        }
+
+        // terminate PresentationActivity since "presentation is complete" (once response is sent)
+        finish()
+    }
+
+    private suspend fun addDocumentToResponse(
+        deviceResponseGenerator: DeviceResponseGenerator,
+        docType: String,
+        issuerAuth: ByteArray,
+        mergedIssuerNamespaces: Map<String, MutableList<ByteArray>>,
+        credential: MdocCredential,
+        keyUnlockData: KeyUnlockData?
+    ) = suspendCancellableCoroutine { continuation ->
+        var result: MdocCredential?
+
+        try {
+            deviceResponseGenerator.addDocument(
+                DocumentGenerator(
+                    docType,
+                    issuerAuth, responseComponents!!.sessionTranscript
+                )
+                    .setIssuerNamespaces(mergedIssuerNamespaces)
+                    .setDeviceNamespacesSignature(
+                        NameSpacedData.Builder().build(),
+                        credential.secureArea,
+                        credential.alias,
+                        keyUnlockData,
+                        Algorithm.ES256
+                    )
+                    .generate()
+            )
+            credential.increaseUsageCount()
+            if (credential.usageCount > 1) {
+                Toast.makeText(
+                    applicationContext,
+                    applicationContext.resources.getString(R.string.presentation_credential_usage_warning),
+                    Toast.LENGTH_SHORT
+                ).show()
+            }
+            result = null
+        } catch (e: KeyLockedException) {
+            result = credential
+        }
+
+        continuation.resume(result)
+    }
+}
+
+// returns <namespace, dataElem>
+internal fun parsePathItem(item: String): Pair<String, String> {
+    // format: "$['namespace']['dataElem']"
+    val spacer = item.indexOf("']['")
+    val namespace = item.substring(4, spacer)
+    val dataElem = item.substring(spacer + 4, item.length - 3)
+    return Pair(namespace, dataElem)
+}
+
+// defined in ISO 18013-7 Annex B
+private fun createSessionTranscript(
+    clientId: String,
+    responseUri: String,
+    authorizationRequestNonce: String,
+    mdocGeneratedNonce: String
+): ByteArray {
+    val clientIdToHash = Cbor.encode(CborArray.builder()
+        .add(clientId)
+        .add(mdocGeneratedNonce)
+        .end()
+        .build())
+    val clientIdHash = Crypto.digest(Algorithm.SHA256, clientIdToHash)
+
+    val responseUriToHash = Cbor.encode(CborArray.builder()
+        .add(responseUri)
+        .add(mdocGeneratedNonce)
+        .end()
+        .build())
+    val responseUriHash = Crypto.digest(Algorithm.SHA256, responseUriToHash)
+
+    val oid4vpHandover = CborArray.builder()
+        .add(clientIdHash)
+        .add(responseUriHash)
+        .add(authorizationRequestNonce)
+        .end()
+        .build()
+
+    return Cbor.encode(
+        CborArray.builder()
+            .add(Simple.NULL)
+            .add(Simple.NULL)
+            .add(oid4vpHandover)
+            .end()
+            .build()
+    )
+}
+
+private suspend fun getAuthorizationRequest(requestUri: Uri, httpClient: Lazy<HttpClient>, onError: (Exception) -> Unit): AuthorizationRequest {
+    // simplified same-device flow:
+    val presentationDefinition = requestUri.getQueryParameter("presentation_definition")?.let { Json.parseToJsonElement(it).jsonObject }
+    if (presentationDefinition != null) {
+        return AuthorizationRequest(
+            presentationDefinition = presentationDefinition,
+            clientId = requestUri.getQueryParameter("client_id")!!,
+            nonce = requestUri.getQueryParameter("nonce")!!,
+            responseUri = requestUri.getQueryParameter("response_uri")!!,
+            state = requestUri.getQueryParameter("state"),
+            clientMetadata = requestUri.getQueryParameter("client_metadata")!!
+                .run { Json.parseToJsonElement(this).jsonObject },
+            certificateChain = null
+        )
+    }
+
+    val clientId = requestUri.getQueryParameter("client_id")!!
+    val requestValue = requestUri.getQueryParameter("request")
+    if (requestValue != null) {
+        return getAuthRequestFromJwt(SignedJWT.parse(requestValue), clientId)
+    }
+
+    // more complex same-device flow as outline in Annex B -> request_uri is
+    // needed to retrieve Request Object from provided url
+    val requestUriValue = requestUri.getQueryParameter("request_uri")
+    if (requestUriValue == null) {
+        onError(IllegalArgumentException("Unexpected Error"))
+    }
+
+    val httpResponse = httpClient.value.get(urlString = requestUriValue!!) {
+        accept(ContentType.parse("application/oauth-authz-req+jwt"))
+        accept(ContentType.parse("application/jwt"))
+    }.body<String>()
+
+    return getAuthRequestFromJwt(SignedJWT.parse(httpResponse), clientId)
+}
+
+internal fun getAuthRequestFromJwt(signedJWT: SignedJWT, clientId: String): AuthorizationRequest {
+    if (signedJWT.jwtClaimsSet.getStringClaim("client_id") != clientId) {
+        throw IllegalArgumentException("Client ID doesn't match")
+    }
+    val x5c = signedJWT.header?.x509CertChain ?: throw IllegalArgumentException("Error retrieving cert chain")
+    val pubCertChain = x5c.mapNotNull { runCatching { X509CertUtils.parse(it.decode()) }.getOrNull() }
+    if (pubCertChain.isEmpty()) {
+        throw IllegalArgumentException("Invalid x5c")
+    }
+
+    // verify JWT signature
+    try {
+        val jwtProcessor = DefaultJWTProcessor<SecurityContext>().apply {
+            // see also: DefaultJOSEObjectTypeVerifier.JWT
+            jwsTypeVerifier =
+                DefaultJOSEObjectTypeVerifier(
+                    JOSEObjectType("oauth-authz-req+jwt"),
+                    JOSEObjectType.JWT,
+                    JOSEObjectType(""),
+                    null,
+                )
+            jwsKeySelector = JWSKeySelector<SecurityContext> { _, _ -> listOf(pubCertChain[0].publicKey) }
+            jwtClaimsSetVerifier = TimeChecks()
+        }
+        jwtProcessor.process(signedJWT, null)
+    } catch (e: Exception) {
+        throw RuntimeException(e)
+    }
+
+    // build auth request
+    val jsonStr = Gson().toJson(signedJWT.jwtClaimsSet.getJSONObjectClaim("presentation_definition"))
+    val presentationDefinition = Json.parseToJsonElement(jsonStr).jsonObject
+
+    if (signedJWT.jwtClaimsSet.getStringClaim("response_mode") != "direct_post.jwt") { // required as part of mdoc profile; NOTE that sd-jwt profile requires direct_post
+        throw IllegalArgumentException("Response modes other than direct_post.jwt are unsupported.")
+    }
+    if (signedJWT.jwtClaimsSet.getStringClaim("response_type") != "vp_token") { // not supporting id_token atm
+        throw IllegalArgumentException("Response types other than vp_token are unsupported.")
+    }
+
+    return AuthorizationRequest(
+        presentationDefinition = presentationDefinition,
+        clientId = signedJWT.jwtClaimsSet.getStringClaim("client_id"),
+        nonce = signedJWT.jwtClaimsSet.getStringClaim("nonce"),
+        responseUri = signedJWT.jwtClaimsSet.getStringClaim("response_uri"),
+        state = signedJWT.jwtClaimsSet.getStringClaim("state"),
+        clientMetadata = Json.parseToJsonElement(Gson().toJson(signedJWT.jwtClaimsSet.getJSONObjectClaim("client_metadata"))).jsonObject,
+        certificateChain = pubCertChain
+    )
+}
+
+private class TimeChecks : JWTClaimsSetVerifier<SecurityContext> {
+    @Throws(BadJWTException::class)
+    override fun verify(claimsSet: JWTClaimsSet, context: SecurityContext?) {
+        val now = Clock.System.now()
+
+        val expiration = claimsSet.expirationTime
+        var exp: Instant? = null
+        if (expiration != null) {
+            exp = Instant.fromEpochMilliseconds(expiration.time)
+            if (exp >= now) {
+                throw BadJWTException("Expired JWT")
+            }
+        }
+
+        val issuance = claimsSet.issueTime
+        var iat: Instant? = null
+        if (issuance != null) {
+            iat = Instant.fromEpochMilliseconds(issuance.time)
+            if (now <= iat) {
+                throw BadJWTException("JWT issued in the future")
+            }
+
+            if (exp != null) {
+                if (exp <= iat) {
+                    throw BadJWTException("JWT issued after expiration")
+                }
+            }
+        }
+
+        val notBefore = claimsSet.notBeforeTime
+        if (notBefore != null) {
+            val nbf = Instant.fromEpochMilliseconds(notBefore.time)
+            if (nbf >= now) {
+                throw BadJWTException("JWT not yet active")
+            }
+
+            if (exp != null) {
+                if (nbf >= exp) {
+                    throw BadJWTException("JWT active after expiration")
+                }
+            }
+
+            if (iat != null) {
+                if (nbf <= iat) {
+                    throw BadJWTException("JWT active before issuance")
+                }
+            }
+        }
+    }
+}
+
+internal fun createPresentationSubmission(authRequest: AuthorizationRequest): PresentationSubmission {
+    val descriptorMaps = ArrayList<DescriptorMap>()
+    val inputDescriptors = authRequest.presentationDefinition["input_descriptors"]!!.jsonArray
+
+    for (inputDescriptor: JsonElement in inputDescriptors) {
+        val inputDescriptorObj = inputDescriptor.jsonObject
+        val docType = inputDescriptorObj["id"]!!.toString().run { substring(1, this.length - 1) }
+        descriptorMaps.add(DescriptorMap(
+            id = docType,
+            format = "mso_mdoc",
+            path = "$"
+        ))
+    }
+
+    return PresentationSubmission(
+        id = UUID.randomUUID().toString(),
+        definitionId = authRequest.presentationDefinition["id"]!!.toString().run { substring(1, this.length - 1) },
+        descriptorMaps = descriptorMaps
+    )
+}
+
+internal fun formatAsDocumentRequest(inputDescriptor: JsonObject): DocumentRequest {
+    val requestedDataElements = ArrayList<DocumentRequest.DataElement>()
+    val constraints = inputDescriptor["constraints"]!!.jsonObject
+    val fields = constraints["fields"]!!.jsonArray
+
+    for (field: JsonElement in fields) {
+        val fieldObj = field.jsonObject
+        val path = fieldObj["path"]!!.jsonArray[0].toString()
+        val intentToRetain = fieldObj["intent_to_retain"].toString()
+        val parsed = parsePathItem(path)
+        requestedDataElements.add(DocumentRequest.DataElement(
+            nameSpaceName = parsed.first,
+            dataElementName = parsed.second,
+            intentToRetain = intentToRetain == "true"
+        ))
+    }
+    return DocumentRequest(requestedDataElements)
+}

--- a/wallet/src/test/java/com/android/identity_credential/wallet/OpenID4VPTest.kt
+++ b/wallet/src/test/java/com/android/identity_credential/wallet/OpenID4VPTest.kt
@@ -1,0 +1,138 @@
+package com.android.identity_credential.wallet
+
+import com.android.identity.document.DocumentRequest
+import com.android.identity_credential.wallet.presentation.DescriptorMap
+import com.android.identity_credential.wallet.presentation.createPresentationSubmission
+import com.android.identity_credential.wallet.presentation.formatAsDocumentRequest
+import com.android.identity_credential.wallet.presentation.getAuthRequestFromJwt
+import com.android.identity_credential.wallet.presentation.parsePathItem
+import com.nimbusds.jwt.SignedJWT
+import kotlinx.serialization.json.Json.Default.parseToJsonElement
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import org.junit.Assert
+import org.junit.Test
+
+class OpenID4VPTest {
+
+    // real-life example from https://verifier.eudiw.dev/home
+    private val eudiAgeOver18RequestObject = "eyJ4NWMiOlsiTUlJREtqQ0NBckNnQXdJQkFnSVVmeTl1NlNMdGdOdWY5UFhZYmgvUURxdVh6NTB3Q2dZSUtvWkl6ajBFQXdJd1hERWVNQndHQTFVRUF3d1ZVRWxFSUVsemMzVmxjaUJEUVNBdElGVlVJREF4TVMwd0t3WURWUVFLRENSRlZVUkpJRmRoYkd4bGRDQlNaV1psY21WdVkyVWdTVzF3YkdWdFpXNTBZWFJwYjI0eEN6QUpCZ05WQkFZVEFsVlVNQjRYRFRJME1ESXlOakF5TXpZek0xb1hEVEkyTURJeU5UQXlNell6TWxvd2FURWRNQnNHQTFVRUF3d1VSVlZFU1NCU1pXMXZkR1VnVm1WeWFXWnBaWEl4RERBS0JnTlZCQVVUQXpBd01URXRNQ3NHQTFVRUNnd2tSVlZFU1NCWFlXeHNaWFFnVW1WbVpYSmxibU5sSUVsdGNHeGxiV1Z1ZEdGMGFXOXVNUXN3Q1FZRFZRUUdFd0pWVkRCWk1CTUdCeXFHU000OUFnRUdDQ3FHU000OUF3RUhBMElBQk1iV0JBQzFHaitHRE8veUNTYmdiRndwaXZQWVdMekV2SUxOdGRDdjdUeDFFc3hQQ3hCcDNEWkI0RklyNEJsbVZZdEdhVWJvVklpaFJCaVFEbzNNcFdpamdnRkJNSUlCUFRBTUJnTlZIUk1CQWY4RUFqQUFNQjhHQTFVZEl3UVlNQmFBRkxOc3VKRVhITmVrR21ZeGgwTGhpOEJBekpVYk1DVUdBMVVkRVFRZU1CeUNHblpsY21sbWFXVnlMV0poWTJ0bGJtUXVaWFZrYVhjdVpHVjJNQklHQTFVZEpRUUxNQWtHQnlpQmpGMEZBUVl3UXdZRFZSMGZCRHd3T2pBNG9EYWdOSVl5YUhSMGNITTZMeTl3Y21Wd2NtOWtMbkJyYVM1bGRXUnBkeTVrWlhZdlkzSnNMM0JwWkY5RFFWOVZWRjh3TVM1amNtd3dIUVlEVlIwT0JCWUVGRmdtQWd1QlN2U25tNjhaem81SVN0SXYyZk0yTUE0R0ExVWREd0VCL3dRRUF3SUhnREJkQmdOVkhSSUVWakJVaGxKb2RIUndjem92TDJkcGRHaDFZaTVqYjIwdlpYVXRaR2xuYVhSaGJDMXBaR1Z1ZEdsMGVTMTNZV3hzWlhRdllYSmphR2wwWldOMGRYSmxMV0Z1WkMxeVpXWmxjbVZ1WTJVdFpuSmhiV1YzYjNKck1Bb0dDQ3FHU000OUJBTUNBMmdBTUdVQ01RREdmZ0xLbmJLaGlPVkYzeFNVMGFlanUvbmVHUVVWdU5ic1F3MExlRER3SVcrckxhdGViUmdvOWhNWERjM3dybFVDTUFJWnlKN2xSUlZleU1yM3dqcWtCRjJsOVliMHdPUXBzblpCQVZVQVB5STV4aFdYMlNBYXpvbTJKanNOL2FLQWtRPT0iLCJNSUlESFRDQ0FxT2dBd0lCQWdJVVZxamd0SnFmNGhVWUprcWRZemkrMHh3aHdGWXdDZ1lJS29aSXpqMEVBd013WERFZU1Cd0dBMVVFQXd3VlVFbEVJRWx6YzNWbGNpQkRRU0F0SUZWVUlEQXhNUzB3S3dZRFZRUUtEQ1JGVlVSSklGZGhiR3hsZENCU1pXWmxjbVZ1WTJVZ1NXMXdiR1Z0Wlc1MFlYUnBiMjR4Q3pBSkJnTlZCQVlUQWxWVU1CNFhEVEl6TURrd01URTRNelF4TjFvWERUTXlNVEV5TnpFNE16UXhObG93WERFZU1Cd0dBMVVFQXd3VlVFbEVJRWx6YzNWbGNpQkRRU0F0SUZWVUlEQXhNUzB3S3dZRFZRUUtEQ1JGVlVSSklGZGhiR3hsZENCU1pXWmxjbVZ1WTJVZ1NXMXdiR1Z0Wlc1MFlYUnBiMjR4Q3pBSkJnTlZCQVlUQWxWVU1IWXdFQVlIS29aSXpqMENBUVlGSzRFRUFDSURZZ0FFRmc1U2hmc3hwNVIvVUZJRUtTM0wyN2R3bkZobmpTZ1VoMmJ0S09RRW5mYjNkb3llcU1BdkJ0VU1sQ2xoc0YzdWVmS2luQ3cwOE5CMzFyd0MrZHRqNlgvTEUzbjJDOWpST0lVTjhQcm5sTFM1UXM0UnM0WlU1T0lnenRvYU84RzlvNElCSkRDQ0FTQXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBREFmQmdOVkhTTUVHREFXZ0JTemJMaVJGeHpYcEJwbU1ZZEM0WXZBUU15Vkd6QVdCZ05WSFNVQkFmOEVEREFLQmdncmdRSUNBQUFCQnpCREJnTlZIUjhFUERBNk1EaWdOcUEwaGpKb2RIUndjem92TDNCeVpYQnliMlF1Y0d0cExtVjFaR2wzTG1SbGRpOWpjbXd2Y0dsa1gwTkJYMVZVWHpBeExtTnliREFkQmdOVkhRNEVGZ1FVczJ5NGtSY2MxNlFhWmpHSFF1R0x3RURNbFJzd0RnWURWUjBQQVFIL0JBUURBZ0VHTUYwR0ExVWRFZ1JXTUZTR1VtaDBkSEJ6T2k4dloybDBhSFZpTG1OdmJTOWxkUzFrYVdkcGRHRnNMV2xrWlc1MGFYUjVMWGRoYkd4bGRDOWhjbU5vYVhSbFkzUjFjbVV0WVc1a0xYSmxabVZ5Wlc1alpTMW1jbUZ0WlhkdmNtc3dDZ1lJS29aSXpqMEVBd01EYUFBd1pRSXdhWFVBM2orK3hsL3RkRDc2dFhFV0Npa2ZNMUNhUno0dnpCQzdOUzB3Q2RJdEtpejZIWmVWOEVQdE5DbnNmS3BOQWpFQXFyZGVLRG5yNUt3ZjhCQTd0QVRlaHhObE9WNEhuYzEwWE8xWFVMdGlnQ3diNDlScGtxbFMySHVsK0RwcU9iVXMiXSwidHlwIjoib2F1dGgtYXV0aHotcmVxK2p3dCIsImFsZyI6IkVTMjU2In0.eyJyZXNwb25zZV91cmkiOiJodHRwczovL3ZlcmlmaWVyLWJhY2tlbmQuZXVkaXcuZGV2L3dhbGxldC9kaXJlY3RfcG9zdCIsImNsaWVudF9pZF9zY2hlbWUiOiJ4NTA5X3Nhbl9kbnMiLCJyZXNwb25zZV90eXBlIjoidnBfdG9rZW4iLCJub25jZSI6IjliNGYwNGEzLTgzMjgtNGE4Ny1iMGYxLTIzNTBmNjJkNDczNiIsImNsaWVudF9pZCI6InZlcmlmaWVyLWJhY2tlbmQuZXVkaXcuZGV2IiwicmVzcG9uc2VfbW9kZSI6ImRpcmVjdF9wb3N0Lmp3dCIsImF1ZCI6Imh0dHBzOi8vc2VsZi1pc3N1ZWQubWUvdjIiLCJzY29wZSI6IiIsInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiMzJmNTQxNjMtNzE2Ni00OGYxLTkzZDgtZmYyMTdiZGIwNjUzIiwiaW5wdXRfZGVzY3JpcHRvcnMiOlt7ImlkIjoiZXUuZXVyb3BhLmVjLmV1ZGl3LnBpZC4xIiwibmFtZSI6IkVVREkgUElEIiwicHVycG9zZSI6IldlIG5lZWQgdG8gdmVyaWZ5IHlvdXIgaWRlbnRpdHkiLCJmb3JtYXQiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiIsIkVkRFNBIiwiRVNCMjU2IiwiRVNCMzIwIiwiRVNCMzg0IiwiRVNCNTEyIl19fSwiY29uc3RyYWludHMiOnsiZmllbGRzIjpbeyJwYXRoIjpbIiRbJ2V1LmV1cm9wYS5lYy5ldWRpdy5waWQuMSddWydhZ2Vfb3Zlcl8xOCddIl0sImludGVudF90b19yZXRhaW4iOmZhbHNlfV19fV19LCJzdGF0ZSI6IjQ0elo3Rm1yTTRuU3VvNWNKb1FYMkd4MXBLaW9Bd1ZiTl9nT2FTT1IxTi1HR2kySmZDa3k2NDFSMVVzU0pUNmJLMkFMTzR6VVE3U09WeWMwbWR5NWt3IiwiaWF0IjoxNzE2MjIxMDExLCJjbGllbnRfbWV0YWRhdGEiOnsiYXV0aG9yaXphdGlvbl9lbmNyeXB0ZWRfcmVzcG9uc2VfYWxnIjoiRUNESC1FUyIsImF1dGhvcml6YXRpb25fZW5jcnlwdGVkX3Jlc3BvbnNlX2VuYyI6IkExMjhDQkMtSFMyNTYiLCJpZF90b2tlbl9lbmNyeXB0ZWRfcmVzcG9uc2VfYWxnIjoiUlNBLU9BRVAtMjU2IiwiaWRfdG9rZW5fZW5jcnlwdGVkX3Jlc3BvbnNlX2VuYyI6IkExMjhDQkMtSFMyNTYiLCJqd2tzX3VyaSI6Imh0dHBzOi8vdmVyaWZpZXItYmFja2VuZC5ldWRpdy5kZXYvd2FsbGV0L2phcm0vNDR6WjdGbXJNNG5TdW81Y0pvUVgyR3gxcEtpb0F3VmJOX2dPYVNPUjFOLUdHaTJKZkNreTY0MVIxVXNTSlQ2YksyQUxPNHpVUTdTT1Z5YzBtZHk1a3cvandrcy5qc29uIiwic3ViamVjdF9zeW50YXhfdHlwZXNfc3VwcG9ydGVkIjpbInVybjppZXRmOnBhcmFtczpvYXV0aDpqd2stdGh1bWJwcmludCJdLCJpZF90b2tlbl9zaWduZWRfcmVzcG9uc2VfYWxnIjoiUlMyNTYifX0.xLzRWy-mPHPC3oaczv71R1eaz_7kumUVC1CIx3wpt2v6HjZa6vQIhyISGGNgdqANBvAs-xiSXzFYp-zcVOQCDQ"
+    // the request object in ISO 18013-7 Annex B
+    private val annexBRequestObject = "eyJ4NWMiOlsiTUlJQ1B6Q0NBZVdnQXdJQkFnSVVEbUJYeDcrMTlLaHdqbHREYkJXNEJFMENSUkV3Q2dZSUtvWkl6ajBFQXdJd2FURUxNQWtHIEExVUVCaE1DVlZReER6QU5CZ05WQkFnTUJsVjBiM0JwWVRFTk1Bc0dBMVVFQnd3RVEybDBlVEVTTUJBR0ExVUVDZ3dKUVVOTlIgU0JEYjNKd01SQXdEZ1lEVlFRTERBZEpWQ0JFWlhCME1SUXdFZ1lEVlFRRERBdGxlR0Z0Y0d4bExtTnZiVEFlRncweU16RXdNRCBNeE5EUTVNemhhRncweU5EQTVNak14TkRRNU16aGFNR2t4Q3pBSkJnTlZCQVlUQWxWVU1ROHdEUVlEVlFRSURBWlZkRzl3YVdFIHhEVEFMQmdOVkJBY01CRU5wZEhreEVqQVFCZ05WQkFvTUNVRkRUVVVnUTI5eWNERVFNQTRHQTFVRUN3d0hTVlFnUkdWd2RERVUgTUJJR0ExVUVBd3dMWlhoaGJYQnNaUzVqYjIwd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFSZkxoK2NXWHE1ZiBXUmY5Q3dvOFZSa3A5QUFPT0xhUDNVQ2kzWVkxVkRISEV4N2xBbjlNQ1hvL3ZuaXFMODhWRkVpMVB0VDlPRGFJTlZJWFpGRmpPIHJZbzJzd2FUQWRCZ05WSFE0RUZnUVV4djZIdFJRazlxN0FTUUNVcU9xRXVuNVM4UVF3SHdZRFZSMGpCQmd3Rm9BVXh2Nkh0UlEgazlxN0FTUUNVcU9xRXVuNVM4UVF3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFXQmdOVkhSRUVEekFOZ2d0bGVHRnRjR3hsTG1OdiBiVEFLQmdncWhrak9QUVFEQWdOSUFEQkZBaUJ0NS9tYWl4SnlhV05LRzhXOWRBZVBodmhoNU9IanN3SmFFamN5WWlxb29nSWhBIE53VEdUZGcxMlJFelFNZlFTWFRTVnROcDFqakpNUHNpcHFSN2tJSzFKZFQiXSwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOiJodHRwczovL3NlbGYtaXNzdWVkLm1lL3YyIiwicmVzcG9uc2VfdHlwZSI6InZwX3Rva2VuIiwicHJlc2VudGF0aW9uX2RlZmluaXRpb24iOnsiaWQiOiJtREwtc2FtcGxlLXJlcSIsImlucHV0X2Rlc2NyaXB0b3JzIjpbeyJpZCI6Im9yZy5pc28uMTgwMTMuNS4xLm1ETCAiLCJmb3JtYXQiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiIsIkVkRFNBIiwiRVNCMjU2IiwiRVNCMzIwIiwiRVNCMzg0IiwiRVNCNTEyIl19fSwiY29uc3RyYWludHMiOnsiZmllbGRzIjpbeyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2JpcnRoX2RhdGUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2RvY3VtZW50X251bWJlciddIl0sImludGVudF90b19yZXRhaW4iOmZhbHNlfSx7InBhdGgiOlsiJFsnb3JnLmlzby4xODAxMy41LjEnXVsnZHJpdmluZ19wcml2aWxlZ2VzJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWydleHBpcnlfZGF0ZSddIl0sImludGVudF90b19yZXRhaW4iOmZhbHNlfSx7InBhdGgiOlsiJFsnb3JnLmlzby4xODAxMy41LjEnXVsnZmFtaWx5X25hbWUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2dpdmVuX25hbWUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2lzc3VlX2RhdGUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2lzc3VpbmdfYXV0aG9yaXR5J10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWydpc3N1aW5nX2NvdW50cnknXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ3BvcnRyYWl0J10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWyd1bl9kaXN0aW5ndWlzaGluZ19zaWduJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9XSwibGltaXRfZGlzY2xvc3VyZSI6InJlcXVpcmVkIn19XX0sImNsaWVudF9tZXRhZGF0YSI6eyJqd2tzIjp7ImtleXMiOlt7Imt0eSI6IkVDIiwidXNlIjoiZW5jIiwiY3J2IjoiUC0yNTYiLCJ4IjoieFZMdFphUFBLLXh2cnVoMWZFQ2xOVlRSNlJDWkJzUWFpMi1Ecm55S2t4ZyIsInkiOiItNS1RdEZxSnFHd09qRUwzVXQ4OW5yRTBNZWFVcDVSb3prc0tIcEJpeXcwIiwiYWxnIjoiRUNESC1FUyIsImtpZCI6IlA4cDB2aXJSbGg2ZkFraDUtWVNlSHQ0RUl2LWhGR25lWWsxNGQ4REY1MXcifV19LCJhdXRob3JpemF0aW9uX2VuY3J5cHRlZF9yZXNwb25zZV9hbGciOiJFQ0RILUVTIiwiYXV0aG9yaXphdGlvbl9lbmNyeXB0ZWRfcmVzcG9uc2VfZW5jIjoiQTI1NkdDTSIsInZwX2Zvcm1hdHMiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiIsIkVkRFNBIiwiRVNCMjU2IiwiRVNCMzIwIiwiRVNCMzg0IiwiRVNCNTEyIl19fX0sInN0YXRlIjoiMzRhc2ZkMzRfMzQkMzQiLCJub25jZSI6IlNhZmRhZXKnJDQ1XzMzNDIiLCJjbGllbnRfaWQiOiJleGFtcGxlLmNvbSAiLCJjbGllbnRfaWRfc2NoZW1lIjoieDUwOV9zYW5fZG5zIiwicmVzcG9uc2VfbW9kZSI6ImRpcmVjdF9wb3N0Lmp3dCIsInJlc3BvbnNlX3VyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vMTIzNDUvcmVzcG9uc2UifQ.DIEllOaSydngto5RYP-W5eWifqcqylKuRXYoZwtSo8ekWPkTE1_IfabbpkYCS9Y42HuAbuKiVQCN2OKAyabEwA"
+
+    @Test
+    fun testParsePath() {
+        Assert.assertEquals(Pair("namespace", "dataElem"), parsePathItem("\"\$['namespace']['dataElem']\""))
+    }
+
+    @Test
+    fun eudiwJwtToPresentationSubmission() {
+        val authRequest = getAuthRequestFromJwt(SignedJWT.parse(eudiAgeOver18RequestObject), "verifier-backend.eudiw.dev")
+        Assert.assertEquals(parseToJsonElement(
+                "{\"input_descriptors\":" +
+                    "[{\"id\":\"eu.europa.ec.eudiw.pid.1\"," +
+                    "\"name\":\"EUDI PID\"," +
+                    "\"purpose\":\"We need to verify your identity\"," +
+                    "\"format\":{\"mso_mdoc\":{\"alg\":[\"ES256\",\"ES384\",\"ES512\",\"EdDSA\",\"ESB256\",\"ESB320\",\"ESB384\",\"ESB512\"]}}," +
+                    "\"constraints\":{\"fields\":[{\"path\":[\"\$['eu.europa.ec.eudiw.pid.1']['age_over_18']\"],\"intent_to_retain\":false}]}}]," +
+                "\"id\":\"32f54163-7166-48f1-93d8-ff217bdb0653\"}"),
+            authRequest.presentationDefinition
+        )
+        Assert.assertEquals("verifier-backend.eudiw.dev", authRequest.clientId)
+        Assert.assertEquals("9b4f04a3-8328-4a87-b0f1-2350f62d4736", authRequest.nonce)
+        Assert.assertEquals("https://verifier-backend.eudiw.dev/wallet/direct_post",
+            authRequest.responseUri)
+        Assert.assertEquals("44zZ7FmrM4nSuo5cJoQX2Gx1pKioAwVbN_gOaSOR1N-GGi2JfCky641R1UsSJT6bK2ALO4zUQ7SOVyc0mdy5kw",
+            authRequest.state)
+        Assert.assertEquals(parseToJsonElement(
+                "{\"authorization_encrypted_response_alg\":\"ECDH-ES\"," +
+                "\"authorization_encrypted_response_enc\":\"A128CBC-HS256\"," +
+                "\"id_token_encrypted_response_alg\":\"RSA-OAEP-256\"," +
+                "\"id_token_encrypted_response_enc\":\"A128CBC-HS256\"," +
+                "\"jwks_uri\":\"https://verifier-backend.eudiw.dev/wallet/jarm/44zZ7FmrM4nSuo5cJoQX2Gx1pKioAwVbN_gOaSOR1N-GGi2JfCky641R1UsSJT6bK2ALO4zUQ7SOVyc0mdy5kw/jwks.json\"," +
+                "\"subject_syntax_types_supported\":[\"urn:ietf:params:oauth:jwk-thumbprint\"]," +
+                "\"id_token_signed_response_alg\":\"RS256\"}"),
+            authRequest.clientMetadata!!)
+
+        val presentationSubmission = createPresentationSubmission(authRequest)
+        Assert.assertEquals("32f54163-7166-48f1-93d8-ff217bdb0653",
+            presentationSubmission.definitionId)
+        val descriptorMaps = presentationSubmission.descriptorMaps
+        for (descriptorMap: DescriptorMap in descriptorMaps) {
+            Assert.assertEquals("eu.europa.ec.eudiw.pid.1", descriptorMap.id)
+            Assert.assertEquals("mso_mdoc", descriptorMap.format)
+            Assert.assertEquals("$", descriptorMap.path)
+        }
+
+        val docRequest = formatAsDocumentRequest(authRequest.presentationDefinition["input_descriptors"]!!.jsonArray[0].jsonObject)
+        val expectedRequestedElems = listOf(
+            DocumentRequest.DataElement("eu.europa.ec.eudiw.pid.1", "age_over_18", false))
+        Assert.assertEquals(expectedRequestedElems, docRequest.requestedDataElements)
+    }
+
+    @Test
+    fun annexBJwtToPresentationSubmission() {
+        val authRequest = getAuthRequestFromJwt(SignedJWT.parse(annexBRequestObject), "example.com ")
+        Assert.assertEquals(parseToJsonElement(
+            "{\"input_descriptors\":" +
+                    "[{\"id\":\"org.iso.18013.5.1.mDL \"," +
+                    "\"format\":{\"mso_mdoc\":{\"alg\":[\"ES256\",\"ES384\",\"ES512\",\"EdDSA\",\"ESB256\",\"ESB320\",\"ESB384\",\"ESB512\"]}}," +
+                    "\"constraints\":{\"fields\":" +
+                        "[{\"path\":[\"\$['org.iso.18013.5.1']['birth_date']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['document_number']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['driving_privileges']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['expiry_date']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['family_name']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['given_name']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['issue_date']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['issuing_authority']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['issuing_country']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['portrait']\"],\"intent_to_retain\":false}," +
+                        "{\"path\":[\"\$['org.iso.18013.5.1']['un_distinguishing_sign']\"],\"intent_to_retain\":false}]," +
+                    "\"limit_disclosure\":\"required\"}}]," +
+                    "\"id\":\"mDL-sample-req\"}\n"),
+            authRequest.presentationDefinition
+        )
+        Assert.assertEquals("example.com ", authRequest.clientId)
+        Assert.assertEquals("Safdaer�\$45_3342", authRequest.nonce)
+        Assert.assertEquals("https://example.com/12345/response",
+            authRequest.responseUri)
+        Assert.assertEquals("34asfd34_34\$34", authRequest.state)
+        Assert.assertEquals(parseToJsonElement(
+            "{\"authorization_encrypted_response_alg\":\"ECDH-ES\"," +
+                    "\"authorization_encrypted_response_enc\":\"A256GCM\"," +
+                    "\"jwks\":{\"keys\":[{" +
+                        "\"kty\":\"EC\"," +
+                        "\"use\":\"enc\"," +
+                        "\"crv\":\"P-256\"," +
+                        "\"x\":\"xVLtZaPPK-xvruh1fEClNVTR6RCZBsQai2-DrnyKkxg\"," +
+                        "\"y\":\"-5-QtFqJqGwOjEL3Ut89nrE0MeaUp5RozksKHpBiyw0\"," +
+                        "\"alg\":\"ECDH-ES\"," +
+                        "\"kid\":\"P8p0virRlh6fAkh5-YSeHt4EIv-hFGneYk14d8DF51w\"}]}," +
+                    "\"vp_formats\":{\"mso_mdoc\":{\"alg\":[\"ES256\",\"ES384\",\"ES512\",\"EdDSA\",\"ESB256\",\"ESB320\",\"ESB384\",\"ESB512\"]}}}\n"),
+            authRequest.clientMetadata!!)
+
+        val presentationSubmission = createPresentationSubmission(authRequest)
+        val descriptorMaps = presentationSubmission.descriptorMaps
+        for (descriptorMap: DescriptorMap in descriptorMaps) {
+            Assert.assertEquals("org.iso.18013.5.1.mDL ", descriptorMap.id)
+            Assert.assertEquals("mso_mdoc", descriptorMap.format)
+            Assert.assertEquals("$", descriptorMap.path)
+        }
+
+        val docRequest = formatAsDocumentRequest(authRequest.presentationDefinition["input_descriptors"]!!.jsonArray[0].jsonObject)
+        val expectedRequestedElems = listOf(
+            DocumentRequest.DataElement("org.iso.18013.5.1", "birth_date", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "document_number", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "driving_privileges", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "expiry_date", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "family_name", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "given_name", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "issue_date", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "issuing_authority", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "issuing_country", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "portrait", false),
+            DocumentRequest.DataElement("org.iso.18013.5.1", "un_distinguishing_sign", false))
+        Assert.assertEquals(expectedRequestedElems, docRequest.requestedDataElements)
+    }
+}


### PR DESCRIPTION
Created a new OpenID4VPPresentationActivity in wallet which will handle any uri invocations with supported schema, parse the incoming request, ask user for confirmation, and send the appropriate response. Also added unit tests to confirm functionality of a subset of parsing methods.

Test methods: Unit tests + manually against EUDIW verifier at https://verifier.eudiw.dev/home