### PR TITLE
Fix network configuration problem when whitelabeling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,10 +85,13 @@ for applications and samples.
 The `wallet` application is intended to be easily customizable by downstream
 consumers and has built-in support for this via
 [Android product flavors](https://developer.android.com/build/build-variants#product-flavors).
-Downstreams are expected to change
+Downstreams are expected to change files under `wallet/src/customized` to
+suit their configuration, including
 
-- strings/icons in `wallet/customized`
-- configuration in `wallet/src/customized/java/com/android/identity_credential/wallet/WalletApplicationConfiguration.kt`
+- strings/icons (in particular the application name) and text in `about.md`
+- configuration in `WalletApplicationConfiguration.kt` in particular change
+  the wallet server address from `ws.example.com` to point to your own wallet server
+- the `ws.example.com` domain in `network_security_config.xml`
 - the `com.example.wallet.customized` applicationId in `wallet/build.gradle`
 
 ### Command-line tool

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -144,7 +144,7 @@
 
     kotlin-test = { group = "org.jetbrains.kotlin", name = "kotlin-test", version.ref = "kotlin-test"}
 
-    ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
+    ktor-client-android = { module = "io.ktor:ktor-client-android", version.ref = "ktor" }
     ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
     javax-servlet-api = { module = "javax.servlet:javax.servlet-api", version.ref = "javax-servlet-api" }
 

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     implementation libs.accompanist.permissions
     implementation libs.androidx.work
     implementation libs.ktor.client.core
-    implementation libs.ktor.client.cio
+    implementation libs.ktor.client.android
     implementation libs.kotlinx.io.bytestring
     implementation libs.kotlinx.serialization
     debugImplementation libs.compose.icons

--- a/wallet/src/customized/java/com/android/identity_credential/wallet/WalletApplicationConfiguration.kt
+++ b/wallet/src/customized/java/com/android/identity_credential/wallet/WalletApplicationConfiguration.kt
@@ -22,5 +22,5 @@ object WalletApplicationConfiguration {
     /**
      * The default Wallet Server URL.
      */
-    const val WALLET_SERVER_DEFAULT_URL = "dev:"
+    const val WALLET_SERVER_DEFAULT_URL = "https://ws.example.com/server"
 }

--- a/wallet/src/customized/res/xml/network_security_config.xml
+++ b/wallet/src/customized/res/xml/network_security_config.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="false"/>
+    <domain-config>
+        <domain includeSubdomains="true">ws.example.com</domain>
+        <trust-anchors>
+            <certificates src="system"/>
+        </trust-anchors>
+    </domain-config>
+</network-security-config>

--- a/wallet/src/main/java/com/android/identity/issuance/remote/WalletHttpClient.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/WalletHttpClient.kt
@@ -2,7 +2,7 @@ package com.android.identity.issuance.remote
 
 import com.android.identity.flow.handler.FlowHandlerRemote
 import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.timeout
@@ -24,7 +24,7 @@ class WalletHttpClient(val baseUrl: String): FlowHandlerRemote.HttpClient {
         private const val REQUEST_TIMEOUT_SECONDS = 5*60
     }
 
-    val client = HttpClient(CIO) {
+    val client = HttpClient(Android) {
         install(HttpTimeout)
     }
 

--- a/wallet/src/main/java/com/android/identity/issuance/remote/WalletServerProvider.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/WalletServerProvider.kt
@@ -25,15 +25,7 @@ import com.android.identity.securearea.KeyInfo
 import com.android.identity.securearea.SecureArea
 import com.android.identity.storage.StorageEngine
 import com.android.identity.util.Logger
-import com.android.identity.util.toHex
 import com.android.identity_credential.wallet.SettingsModel
-import io.ktor.client.HttpClient
-import io.ktor.client.engine.cio.CIO
-import io.ktor.client.plugins.websocket.WebSockets
-import io.ktor.client.plugins.websocket.webSocket
-import io.ktor.client.plugins.websocket.webSocketSession
-import io.ktor.websocket.Frame
-import io.ktor.websocket.send
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job

--- a/wallet/src/main/res/xml/network_security_config.xml
+++ b/wallet/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <network-security-config>
-    <domain-config cleartextTrafficPermitted="true">
-        <domain includeSubdomains="false">localhost</domain>
-        <domain includeSubdomains="false">127.0.0.1</domain>
-    </domain-config>
+    <!-- NOTE: for the upstream version, we allow HTTP traffic anywhere since a developer
+         may run a wallet-server locally. This is locked down in the customized flavor -->
+    <base-config cleartextTrafficPermitted="true"/>
 </network-security-config>


### PR DESCRIPTION
The CIO engine for ktor seems to have some problems, for example it doesn't respect network_security_config.xml and it has issues when using https URLs. Fix this by changing to the Android engine which has none of these problems.

For the default flavor, allow any cleartext traffic and leave a note explaining why this is allowed (so developers can easily point to local wallet servers). For the 'customized' flavor don't allow cleartext traffic and only allow traffic to ws.example.com. Make a note in README.md that downstreams need to customize this.

Test: Manually tested `customized` flavor pointing to a wallet server.
