### PR TITLE
Use PassphraseEntryField for German eID PIN entry.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/EvidenceRequest.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/EvidenceRequest.kt
@@ -54,6 +54,7 @@ import com.android.identity.issuance.remote.WalletServerProvider
 import com.android.identity.mrtd.MrtdNfc
 import com.android.identity.mrtd.MrtdNfcDataReader
 import com.android.identity.mrtd.MrtdNfcReader
+import com.android.identity.securearea.PassphraseConstraints
 import com.android.identity_credential.wallet.NfcTunnelScanner
 import com.android.identity_credential.wallet.PermissionTracker
 import com.android.identity_credential.wallet.ProvisioningViewModel
@@ -760,28 +761,29 @@ fun AusweisView(
             }
         }
         composable(AusweisModel.Route.PIN_ENTRY.route) {
-            val pin = remember { mutableStateOf("") }
             Column {
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center
                 ) {
-                    TextField(value = pin.value, onValueChange = {pin.value = it},
-                        label = { Text(stringResource(R.string.eid_enter_pin)) })
+                    Text(
+                        text = stringResource(R.string.eid_enter_pin),
+                        textAlign = TextAlign.Center,
+                        modifier = Modifier.padding(8.dp),
+                        style = MaterialTheme.typography.titleLarge
+                    )
                 }
                 Row(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center
                 ) {
-                    Button(
-                        enabled = status.value is AusweisModel.WaitingForPin &&
-                                pin.value.matches(Regex("^\\d{6}\$")),  // 6-digit
-                        onClick = {
-                            model.providePin(pin.value)
-                            pin.value = ""
+                    PassphraseEntryField(
+                        constraints = PassphraseConstraints.PIN_SIX_DIGITS,
+                        checkWeakPassphrase = false
+                    ) { passphrase, meetsRequirements, _ ->
+                        if (meetsRequirements) {
+                            model.providePin(passphrase)
                         }
-                    ) {
-                        Text(stringResource(R.string.eid_enter_pin_continue))
                     }
                 }
             }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphraseEntryField.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphraseEntryField.kt
@@ -117,7 +117,7 @@ fun PassphraseEntryField(
                 }
 
                 inputText = it
-                calcHintAndMeetsRequirements(inputText, constraints).let {
+                calcHintAndMeetsRequirements(inputText, constraints, checkWeakPassphrase).let {
                     hint = it.first
                     meetsRequirements = it.second
                 }
@@ -192,7 +192,7 @@ fun PassphraseEntryField(
     LaunchedEffect(Unit) {
         focusRequester.requestFocus()
 
-        calcHintAndMeetsRequirements(inputText, constraints).let {
+        calcHintAndMeetsRequirements(inputText, constraints, checkWeakPassphrase).let {
             hint = it.first
             meetsRequirements = it.second
         }
@@ -202,6 +202,7 @@ fun PassphraseEntryField(
 private fun calcHintAndMeetsRequirements(
     passphrase: String,
     constraints: PassphraseConstraints,
+    checkWeakPassphrase: Boolean
 ): Pair<String, Boolean> {
     // For a fixed-length passphrase, never give any hints until user has typed it in.
     val isFixedLength = (constraints.minLength == constraints.maxLength)
@@ -221,7 +222,7 @@ private fun calcHintAndMeetsRequirements(
         )
     }
 
-    if (isWeakPassphrase(passphrase)) {
+    if (checkWeakPassphrase && isWeakPassphrase(passphrase)) {
         return Pair(
             if (constraints.requireNumerical)
                 "PIN is weak, please choose another"

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -246,7 +246,6 @@
     <string name="eid_access_right_allow">Allow</string>
     <string name="eid_nfc_scanning">Scanning eID using NFC</string>
     <string name="eid_enter_pin">Enter your PIN</string>
-    <string name="eid_enter_pin_continue">Continue</string>
     <string name="eid_network_error">Error establishing network connection</string>
     <string name="eid_generic_error">Error scanning or processing the card</string>
     <string name="eid_try_again">Try again</string>


### PR DESCRIPTION
Also fixed a minor bug in PassphraseEntryField. 

Fixes #655.

Manually tested.