### PR TITLE
AndroidStorageEngine: Change to store data in a single file.

### DIFF
--- a/appholder/src/androidTest/java/com/android/mdl/app/selfsigned/SelfSignedScreenStateTest.kt
+++ b/appholder/src/androidTest/java/com/android/mdl/app/selfsigned/SelfSignedScreenStateTest.kt
@@ -14,6 +14,7 @@ import com.android.identity.wallet.selfsigned.AddSelfSignedScreenState
 import com.android.identity.wallet.selfsigned.AddSelfSignedViewModel
 import com.android.identity.wallet.util.PreferencesHelper
 import com.android.identity.wallet.util.ProvisioningUtil
+import kotlinx.io.files.Path
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test
@@ -29,8 +30,8 @@ class SelfSignedScreenStateTest {
     fun setUp() {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         repository = ProvisioningUtil.getInstance(context).secureAreaRepository
-        val storageDir = PreferencesHelper.getKeystoreBackedStorageLocation(context)
-        val storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
+        val storageFile = Path(PreferencesHelper.getKeystoreBackedStorageLocation(context).path)
+        val storageEngine = AndroidStorageEngine.Builder(context, storageFile).build()
         val androidKeystoreSecureArea = AndroidKeystoreSecureArea(context, storageEngine)
         val softwareSecureArea = SoftwareSecureArea(storageEngine)
         repository.addImplementation(androidKeystoreSecureArea)

--- a/appholder/src/main/java/com/android/identity/wallet/HolderApp.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/HolderApp.kt
@@ -80,8 +80,8 @@ class HolderApp: Application() {
             context: Context,
             secureAreaRepository: SecureAreaRepository
         ): DocumentStore {
-            val storageDir = PreferencesHelper.getKeystoreBackedStorageLocation(context)
-            val storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
+            val storageFile = Path(PreferencesHelper.getKeystoreBackedStorageLocation(context).path)
+            val storageEngine = AndroidStorageEngine.Builder(context, storageFile).build()
 
             val androidKeystoreSecureArea = AndroidKeystoreSecureArea(context, storageEngine)
             val softwareSecureArea = SoftwareSecureArea(storageEngine)

--- a/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
+++ b/appholder/src/main/java/com/android/identity/wallet/util/PreferencesHelper.kt
@@ -30,7 +30,7 @@ object PreferencesHelper {
         // As per the docs, the document data contains reference to Keystore aliases so ensure
         // this is stored in a location where it's not automatically backed up and restored by
         // Android Backup as per https://developer.android.com/guide/topics/data/autobackup
-        val storageDir = File(context.noBackupFilesDir, "identity")
+        val storageDir = File(context.noBackupFilesDir, "identity.bin")
         if (!storageDir.exists()) {
             storageDir.mkdir()
         }

--- a/identity-android-legacy/build.gradle.kts
+++ b/identity-android-legacy/build.gradle.kts
@@ -40,6 +40,7 @@ dependencies {
     implementation(libs.bouncy.castle.bcpkix)
     implementation(libs.volley)
     implementation(libs.kotlinx.datetime)
+    implementation(libs.kotlinx.io.core)
     implementation(libs.kotlinx.io.bytestring)
     implementation(libs.cbor)
 

--- a/identity-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.java
+++ b/identity-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.java
@@ -47,6 +47,7 @@ import java.util.Set;
 
 import co.nstant.in.cbor.CborBuilder;
 import co.nstant.in.cbor.model.UnicodeString;
+import kotlinx.io.files.Path;
 
 @SuppressWarnings("deprecation")
 public class MigrateFromKeystoreICStoreTest {
@@ -62,8 +63,8 @@ public class MigrateFromKeystoreICStoreTest {
     @Test
     public void testMigrateToCredentialStore() throws Exception {
         Context context = androidx.test.InstrumentationRegistry.getTargetContext();
-        File storageDir = new File(context.getDataDir(), "ic-testing");
-        StorageEngine storageEngine = new AndroidStorageEngine.Builder(context, storageDir).build();
+        Path storageFile = new Path(new File(context.getDataDir(), "testdata.bin"));
+        StorageEngine storageEngine = new AndroidStorageEngine.Builder(context, storageFile).build();
         AndroidKeystoreSecureArea aksSecureArea = new AndroidKeystoreSecureArea(context, storageEngine);
         IdentityCredentialStore icStore = Utility.getIdentityCredentialStore(context);
 

--- a/identity-android/build.gradle.kts
+++ b/identity-android/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation(libs.bouncy.castle.bcpkix)
     implementation(libs.volley)
     implementation(libs.kotlinx.datetime)
+    implementation(libs.kotlinx.io.core)
     implementation(libs.kotlinx.io.bytestring)
 
     testImplementation(libs.junit)

--- a/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
@@ -20,7 +20,6 @@ import com.android.identity.android.TestUtil
 import com.android.identity.android.securearea.AndroidKeystoreCreateKeySettings
 import com.android.identity.android.securearea.AndroidKeystoreKeyAttestation
 import com.android.identity.android.securearea.AndroidKeystoreSecureArea
-import com.android.identity.android.securearea.UserAuthenticationType
 import com.android.identity.android.storage.AndroidStorageEngine
 import com.android.identity.credential.CredentialFactory
 import com.android.identity.credential.SecureAreaBoundCredential
@@ -31,10 +30,11 @@ import com.android.identity.securearea.SecureArea
 import com.android.identity.securearea.SecureAreaRepository
 import com.android.identity.storage.StorageEngine
 import com.android.identity.util.AndroidAttestationExtensionParser
+import kotlinx.io.files.Path
+import kotlinx.io.files.SystemFileSystem
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
-import java.io.File
 
 // See DocumentStoreTest in non-Android tests for main tests for DocumentStore. These
 // tests are just for the Android-specific bits including attestation.
@@ -51,9 +51,11 @@ class AndroidKeystoreSecureAreaDocumentStoreTest {
 
     @Before
     fun setup() {
+
         val context = InstrumentationRegistry.getTargetContext()
-        val storageDir = File(context.dataDir, "ic-testing")
-        storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
+        val storageFile = Path(context.dataDir.path, "testdata.bin")
+        SystemFileSystem.delete(storageFile, false)
+        storageEngine = AndroidStorageEngine.Builder(context, storageFile).build()
         secureAreaRepository = SecureAreaRepository()
         secureArea = AndroidKeystoreSecureArea(context, storageEngine)
         secureAreaRepository.addImplementation(secureArea)

--- a/samples/age-verifier-mdl/build.gradle.kts
+++ b/samples/age-verifier-mdl/build.gradle.kts
@@ -52,6 +52,7 @@ dependencies {
     implementation(project(":identity-android"))
 
     implementation(libs.kotlinx.datetime)
+    implementation(libs.kotlinx.io.core)
 
     implementation(compose.runtime)
     implementation(compose.foundation)

--- a/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
+++ b/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
@@ -22,6 +22,7 @@ import com.android.identity.mdoc.connectionmethod.ConnectionMethodWifiAware
 import com.android.identity.storage.StorageEngine
 import com.android.identity.util.Logger
 import com.android.identity.util.UUID
+import kotlinx.io.files.Path
 import java.io.File
 import java.util.OptionalLong
 
@@ -201,8 +202,8 @@ class TransferHelper private constructor(
 
     init {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        val storageDir = File(context.noBackupFilesDir, "identity")
-        storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
+        val storageFile = Path(context.noBackupFilesDir.path, "identity.bin")
+        storageEngine = AndroidStorageEngine.Builder(context, storageFile).build()
         androidKeystoreSecureArea = AndroidKeystoreSecureArea(context, storageEngine);
         state.value = State.IDLE
 

--- a/samples/preconsent-mdl/build.gradle.kts
+++ b/samples/preconsent-mdl/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(project(":identity-android"))
 
     implementation(libs.kotlinx.datetime)
+    implementation(libs.kotlinx.io.core)
 
     implementation(compose.runtime)
     implementation(compose.foundation)

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
@@ -40,6 +40,7 @@ import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import java.io.File
 import kotlinx.datetime.Clock
+import kotlinx.io.files.Path
 
 class TransferHelper private constructor(private val context: Context) {
 
@@ -99,9 +100,9 @@ class TransferHelper private constructor(private val context: Context) {
     }
 
     init {
-        val storageDir = File(context.noBackupFilesDir, "identity")
+        val storagePath = Path(context.noBackupFilesDir.path, "identity.bin")
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
-        storageEngine = AndroidStorageEngine.Builder(context, storageDir).build()
+        storageEngine = AndroidStorageEngine.Builder(context, storagePath).build()
         secureAreaRepository = SecureAreaRepository();
         androidKeystoreSecureArea = AndroidKeystoreSecureArea(context, storageEngine);
         secureAreaRepository.addImplementation(androidKeystoreSecureArea);

--- a/samples/secure-area-test-app/build.gradle.kts
+++ b/samples/secure-area-test-app/build.gradle.kts
@@ -51,6 +51,7 @@ kotlin {
             implementation(project(":identity"))
             implementation(project(":identity-mdoc"))
             implementation(libs.kotlinx.datetime)
+            implementation(libs.kotlinx.io.core)
         }
     }
 }

--- a/samples/secure-area-test-app/src/androidMain/kotlin/com/android/identity/secure_area_test_app/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/secure-area-test-app/src/androidMain/kotlin/com/android/identity/secure_area_test_app/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -67,7 +67,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
-import java.io.File
+import kotlinx.io.files.Path
 import kotlin.time.Duration.Companion.days
 
 private val TAG = "AndroidKeystoreSecureAreaScreen"
@@ -75,7 +75,7 @@ private val TAG = "AndroidKeystoreSecureAreaScreen"
 private val androidKeystoreStorage: AndroidStorageEngine by lazy { 
     AndroidStorageEngine.Builder(
         MainActivity.appContext,
-        File(MainActivity.appContext.dataDir, "ic-testing")
+        Path(MainActivity.appContext.dataDir.path, "testdata.bin")
     ).build()
 }
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -50,6 +50,7 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
+import kotlinx.io.files.Path
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.io.File
 import java.security.Security
@@ -124,9 +125,9 @@ class WalletApplication : Application() {
         documentTypeRepository.addDocumentType(DrivingLicense.getDocumentType())
         documentTypeRepository.addDocumentType(EUPersonalID.getDocumentType())
 
-        // secure storage properties
-        val storageDir = File(applicationContext.noBackupFilesDir, "identity")
-        val storageEngine = AndroidStorageEngine.Builder(applicationContext, storageDir).build()
+        // init storage
+        val storageFile = Path(applicationContext.noBackupFilesDir.path, "identity.bin")
+        val storageEngine = AndroidStorageEngine.Builder(applicationContext, storageFile).build()
 
         // init AndroidKeyStoreSecureArea
         androidKeystoreSecureArea = AndroidKeystoreSecureArea(applicationContext, storageEngine)


### PR DESCRIPTION
This is similar to the change made in GenericStorageEngine recently and makes it simpler to write unit tests to check that new code is backwards compatible with existing on-disk data. We want to do this so we can guarantee backwards compat to our downstream users.

This is a breaking change, the `wallet` module will lose all provisioned documents.

Test: ./gradlew check
Test: ./gradlew checkConnected
Test: Manually tested wallet app and secure-area-test-app.
