### PR TITLE
CredmanPresentationActivity updates to use showPresentmentFlow

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -226,7 +226,7 @@ class PresentationActivity : FragmentActivity() {
                             // send the response with all the Document CBOR bytes that succeeded Presentation Flows
                             sendResponseToDevice(deviceResponseGenerator.generate())
                         } catch (exception: Exception) {
-                            Logger.e(TAG, "Unable to start Presentment Flow: $exception")
+                            Logger.e(TAG, "Unable to start Presentment Flow", exception)
                         }
                     }
                 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
@@ -20,6 +20,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.util.Base64
 import androidx.fragment.app.FragmentActivity
+import androidx.lifecycle.lifecycleScope
 import com.android.identity.android.mdoc.util.CredmanUtil
 import com.android.identity.android.securearea.AndroidKeystoreKeyUnlockData
 import com.android.identity.android.securearea.UserAuthenticationType
@@ -31,6 +32,7 @@ import com.android.identity.document.NameSpacedData
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
+import com.android.identity.crypto.EcPublicKey
 import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
 import com.android.identity.issuance.DocumentExtensions.documentConfiguration
 import com.android.identity.mdoc.mso.MobileSecurityObjectParser
@@ -44,16 +46,24 @@ import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.WalletApplication
+import com.android.identity_credential.wallet.presentation.showPresentmentFlow
 import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
 import org.json.JSONObject
 
 import com.google.android.gms.identitycredentials.GetCredentialResponse
 import com.google.android.gms.identitycredentials.IntentHelper
+import kotlinx.coroutines.launch
 import java.util.StringTokenizer
 import kotlinx.datetime.Clock
 
 
-// using FragmentActivity in order to support androidx.biometric.BiometricPrompt
+/**
+ * Activity that is called from Credential Manager to authenticate the user.
+ * Depending on the protocol that is specified on this Activity's Intent,
+ * a Presentment Flow is initiated and a response JSON is called back as the payload on the Intent.
+ *
+ * Using FragmentActivity in order to support androidx.biometric.BiometricPrompt.
+ */
 class CredmanPresentationActivity : FragmentActivity() {
     companion object {
         private const val TAG = "CredmanPresentationActivity"
@@ -64,87 +74,10 @@ class CredmanPresentationActivity : FragmentActivity() {
         application as WalletApplication
     }
 
-    private fun addDeviceNamespaces(
-        documentGenerator: DocumentGenerator,
-        credential: MdocCredential,
-        unlockData: KeyUnlockData?
-    ) {
-        documentGenerator.setDeviceNamespacesSignature(
-            NameSpacedData.Builder().build(),
-            credential.secureArea,
-            credential.alias,
-            unlockData,
-            Algorithm.ES256)
-    }
-
-    private fun createMDocDeviceResponse(
-        credentialId: Int,
-        dataElements: List<DocumentRequest.DataElement>,
-        encodedSessionTranscript: ByteArray,
-        onComplete: (deviceResponse: ByteArray, credential: Credential) -> Unit
-    ) {
-        val documentRequest = DocumentRequest(dataElements)
-
-        val credentialStore = walletApp.documentStore
-        val credentialName = credentialStore.listDocuments().get(credentialId.toInt())
-        val document = credentialStore.lookupDocument(credentialName)
-        val credConf = document!!.documentConfiguration
-
-        val credential = document.findCredential(
-            WalletApplication.CREDENTIAL_DOMAIN_MDOC,
-            Clock.System.now()
-        ) as MdocCredential?
-        if (credential == null) {
-            throw IllegalStateException("No credential")
-        }
-        val staticAuthData = StaticAuthDataParser(credential.issuerProvidedData).parse()
-        val mergedIssuerNamespaces = MdocUtil.mergeIssuerNamesSpaces(
-            documentRequest, credConf.mdocConfiguration!!.staticData, staticAuthData
-        )
-
-        val issuerAuthCoseSign1 = Cbor.decode(staticAuthData.issuerAuth).asCoseSign1
-        val encodedMsoBytes = Cbor.decode(issuerAuthCoseSign1.payload!!)
-        val encodedMso = Cbor.encode(encodedMsoBytes.asTaggedEncodedCbor)
-        val mso = MobileSecurityObjectParser(encodedMso).parse()
-
-        val deviceResponseGenerator = DeviceResponseGenerator(Constants.DEVICE_RESPONSE_STATUS_OK)
-        var documentGenerator = DocumentGenerator(
-            mso.docType,
-            staticAuthData.issuerAuth,
-            encodedSessionTranscript
-        )
-        documentGenerator.setIssuerNamespaces(mergedIssuerNamespaces)
-
-        try {
-            addDeviceNamespaces(documentGenerator, credential, null)
-            deviceResponseGenerator.addDocument(documentGenerator.generate())
-            onComplete(deviceResponseGenerator.generate(), credential)
-        } catch (e: KeyLockedException) {
-            val keyUnlockData = AndroidKeystoreKeyUnlockData(credential.alias)
-            showBiometricPrompt(
-                this,
-                title = applicationContext.resources.getString(R.string.presentation_biometric_prompt_title),
-                subtitle = applicationContext.resources.getString(R.string.presentation_biometric_prompt_subtitle),
-                keyUnlockData.getCryptoObjectForSigning(Algorithm.ES256),
-                setOf(UserAuthenticationType.BIOMETRIC, UserAuthenticationType.LSKF),
-                false,
-                onSuccess = {
-                    addDeviceNamespaces(documentGenerator, credential, keyUnlockData)
-                    deviceResponseGenerator.addDocument(documentGenerator.generate())
-                    onComplete(deviceResponseGenerator.generate(), credential)
-                },
-                onCanceled = {},
-                onError = {
-                    Logger.i(TAG, "Biometric auth failed", e)
-                }
-            )
-        }
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         try {
-
 
             val cmrequest = IntentHelper.extractGetCredentialRequest(intent)
             val credentialId = intent.getLongExtra(IntentHelper.EXTRA_CREDENTIAL_ID, -1).toInt()
@@ -216,44 +149,43 @@ class CredmanPresentationActivity : FragmentActivity() {
                         Crypto.digest(Algorithm.SHA256, readerPublicKey.asUncompressedPointEncoding)
                     )
                 }
-                // Create ISO DeviceResponse
-                createMDocDeviceResponse(
-                    credentialId,
-                    dataElements,
-                    encodedSessionTranscript,
-                    onComplete = { deviceResponse, credential ->
-                        credential.increaseUsageCount()
-                        // The Preview protocol HPKE encrypts the response.
-                        val (cipherText, encapsulatedPublicKey) = Crypto.hpkeEncrypt(
-                            Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
-                            readerPublicKey,
-                            deviceResponse,
-                            encodedSessionTranscript
-                        )
-                        val encodedCredentialDocument =
-                            CredmanUtil.generateCredentialDocument(cipherText, encapsulatedPublicKey)
+                lifecycleScope.launch {
+                    val deviceResponse = showPresentmentFlowAndGetDeviceResponse(
+                        credentialId,
+                        dataElements,
+                        encodedSessionTranscript
+                    )
 
-                        // Create the preview response
-                        val responseJson = JSONObject()
-                        responseJson.put(
-                            "token",
-                            Base64.encodeToString(
-                                encodedCredentialDocument,
-                                Base64.NO_WRAP or Base64.URL_SAFE
-                            )
-                        )
-                        val response = responseJson.toString(2)
+                    val (cipherText, encapsulatedPublicKey) = Crypto.hpkeEncrypt(
+                        Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
+                        readerPublicKey,
+                        deviceResponse,
+                        encodedSessionTranscript
+                    )
+                    val encodedCredentialDocument =
+                        CredmanUtil.generateCredentialDocument(cipherText, encapsulatedPublicKey)
 
-                        // Send result back to credman
-                        val resultData = Intent()
-                        IntentHelper.setGetCredentialResponse(
-                            resultData,
-                            createGetCredentialResponse(response)
+                    // Create the preview response
+                    val responseJson = JSONObject()
+                    responseJson.put(
+                        "token",
+                        Base64.encodeToString(
+                            encodedCredentialDocument,
+                            Base64.NO_WRAP or Base64.URL_SAFE
                         )
-                        setResult(RESULT_OK, resultData)
-                        finish()
-                    }
-                )
+                    )
+                    val response = responseJson.toString(2)
+
+                    // Send result back to credman
+                    val resultData = Intent()
+                    IntentHelper.setGetCredentialResponse(
+                        resultData,
+                        createGetCredentialResponse(response)
+                    )
+                    setResult(RESULT_OK, resultData)
+                    finish()
+                }
+
             } else if (protocol == "openid4vp") {
                 val openid4vpRequest = JSONObject(request)
                 val clientID = openid4vpRequest.getString("client_id")
@@ -306,34 +238,33 @@ class CredmanPresentationActivity : FragmentActivity() {
                         Crypto.digest(Algorithm.SHA256, clientID.toByteArray())
                     )
                 }
-                // Create ISO DeviceResponse
-                createMDocDeviceResponse(
-                    credentialId,
-                    dataElements,
-                    encodedSessionTranscript,
-                    onComplete = { deviceResponse, credential ->
-                        credential.increaseUsageCount()
-                        // Create the openid4vp response
-                        val responseJson = JSONObject()
-                        responseJson.put(
-                            "vp_token",
-                            Base64.encodeToString(
-                                deviceResponse,
-                                Base64.NO_WRAP or Base64.URL_SAFE
-                            )
+                lifecycleScope.launch {
+                    val deviceResponse = showPresentmentFlowAndGetDeviceResponse(
+                        credentialId,
+                        dataElements,
+                        encodedSessionTranscript
+                    )
+                    // Create the openid4vp response
+                    val responseJson = JSONObject()
+                    responseJson.put(
+                        "vp_token",
+                        Base64.encodeToString(
+                            deviceResponse,
+                            Base64.NO_WRAP or Base64.URL_SAFE
                         )
-                        val response = responseJson.toString(2)
+                    )
+                    val response = responseJson.toString(2)
 
-                        // Send result back to credman
-                        val resultData = Intent()
-                        IntentHelper.setGetCredentialResponse(
-                            resultData,
-                            createGetCredentialResponse(response)
-                        )
-                        setResult(RESULT_OK, resultData)
-                        finish()
-                    }
-                )
+                    // Send result back to credman
+                    val resultData = Intent()
+                    IntentHelper.setGetCredentialResponse(
+                        resultData,
+                        createGetCredentialResponse(response)
+                    )
+                    setResult(RESULT_OK, resultData)
+                    finish()
+
+                }
             } else {
                 // Unknown protocol
                 throw IllegalArgumentException("Unknown protocol")
@@ -346,6 +277,52 @@ class CredmanPresentationActivity : FragmentActivity() {
             setResult(RESULT_OK, resultData)
             finish()
         }
+    }
+
+    /**
+     * Show the Presentment Flow and handle producing the DeviceResponse CBOR bytes.
+     *
+     * @param credentialId the int index of [Document] in [DocumentStore]
+     * @param dataElements the list of requested data points of a credential
+     * @param encodedSessionTranscript CBOR bytes
+     * @return the DeviceResponse CBOR bytes containing the [Document] for the given [credentialId]
+     */
+    private suspend fun showPresentmentFlowAndGetDeviceResponse(
+        credentialId: Int,
+        dataElements: List<DocumentRequest.DataElement>,
+        encodedSessionTranscript: ByteArray,
+    ): ByteArray {
+        val mdocCredential = getMdocCredentialForCredentialId(credentialId)
+        val documentCborBytes = showPresentmentFlow(
+            activity = this@CredmanPresentationActivity,
+            walletApp = walletApp,
+            documentRequest = DocumentRequest(dataElements),
+            mdocCredential = mdocCredential,
+            // TODO: Need to extend TrustManager with a verify() variants which takes a domain or appId
+            trustPoint = null,
+            encodedSessionTranscript = encodedSessionTranscript,
+        )
+        // Create ISO DeviceResponse
+        DeviceResponseGenerator(Constants.DEVICE_RESPONSE_STATUS_OK).run {
+            addDocument(documentCborBytes)
+            return generate()
+        }
+    }
+
+    /**
+     * Return the MdocCredential that has the given Int credentialId.
+     *
+     * @param credentialId the index of the credential in the document store.
+     * @return the [MdocCredential] object.
+     */
+    private fun getMdocCredentialForCredentialId(credentialId: Int): MdocCredential {
+        val documentName = walletApp.documentStore.listDocuments().get(credentialId)
+        val document = walletApp.documentStore.lookupDocument(documentName)
+
+        return document!!.findCredential(
+            WalletApplication.CREDENTIAL_DOMAIN_MDOC,
+            Clock.System.now()
+        ) as MdocCredential
     }
 
     private fun createGetCredentialResponse(response: String): GetCredentialResponse {


### PR DESCRIPTION
**Squashed commits from PR https://github.com/openwallet-foundation-labs/identity-credential/pull/667**
Due to `main` pulled into the branch replaying main's commits on the branch first then adding the branch's commit on top -- once pushed the commit history is unrecoverable at this point which is why PR #667 is closed. This PR provides all the commits already squashed rather than squashing the commits at the time of merging the PR. 


- Removal of unused functions in CredmanPresentationActivity whose functionality is provided from the Presentment Flow.
- Helper function in CredmanPresentationActivity to handle showing the Presentment Flow
- Removal of param to optionally hide the Consent Prompt from a Presentment Flow
- Reverting to allowing each protocol handle their own response after a device response is generated from Presentment Flow
- Left kdoc for private function showPresentmentFlowAndGetDeviceResponse since its helpful insight
- Addressing line/space nits

test: ./gradlew test  - all unit tests pass
