### PR TITLE
Bluetooth LE: work around bugs in BLE stack.

### DIFF
--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
@@ -487,7 +487,12 @@ internal class GattClient(
         }
         val chunk = writingQueue.poll() ?: return
         if (chunk.size == 0) {
-            Logger.d(TAG, "Chunk is length 0, shutting down GattClient")
+            Logger.d(TAG, "Chunk is length 0, shutting down GattClient in 1000ms")
+            // TODO: On some devices we lose messages already sent if we don't have a delay like
+            //  this. Need to properly investigate if this is a problem in our stack or the
+            //  underlying BLE subsystem.
+            Thread.sleep(1000)
+            Logger.d(TAG, "Shutting down GattClient now")
             try {
                 gatt!!.disconnect()
                 gatt!!.close()

--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/GattServer.kt
@@ -432,7 +432,12 @@ internal class GattServer(
         }
         val chunk = writingQueue.poll() ?: return
         if (chunk.size == 0) {
-            Logger.d(TAG, "Chunk is length 0, shutting down GattServer")
+            Logger.d(TAG, "Chunk is length 0, shutting down GattServer in 1000ms")
+            // TODO: On some devices we lose messages already sent if we don't have a delay like
+            //  this. Need to properly investigate if this is a problem in our stack or the
+            //  underlying BLE subsystem.
+            Thread.sleep(1000)
+            Logger.d(TAG, "Shutting down GattServer now")
             try {
                 if (currentConnection != null) {
                     gattServer!!.cancelConnection(currentConnection)


### PR DESCRIPTION
On some combination of devices, messages being sent to the GATT layer are list if we call disconnect() right after sending them. Specifically this results in the mDL reader not receiving the entire DeviceResponse before receiving a notification that the other device disconnected.

Work around this bug by inserting a 1 second sleep before calling disconnect().

Test: Manually tested with two devices.
