### PR TITLE
PresentationActivity: Make sure multiple NFC taps work.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -342,6 +342,7 @@ class PresentationActivity : FragmentActivity() {
                 DeviceResponseGenerator(Constants.DEVICE_RESPONSE_STATUS_GENERAL_ERROR)
             sendResponseToDevice(deviceResponseGenerator.generate())
         }
+        state.value = State.NOT_CONNECTED
         deviceRetrievalHelper?.disconnect()
         deviceRetrievalHelper = null
         transport = null


### PR DESCRIPTION
After running PresentationActivity we forgot to reset the global state so subsequent NFC taps didn't work. Manually tested two mdoc presentations in the same wallet app instance, both using NFC engagement.

Test: Manually tested.
