### PR TITLE
Add automatically generated version string to apps.

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
     - name: Check out code
       uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
     - name: Set up JDK 17
       uses: actions/setup-java@v4
       with:

--- a/appholder/build.gradle.kts
+++ b/appholder/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
     alias(libs.plugins.kapt)
 }
 
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
 kotlin {
     jvmToolchain(17)
 }
@@ -20,8 +23,8 @@ android {
         applicationId = "com.android.identity.wallet"
         minSdk = 29
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = projectVersionCode
+        versionName = projectVersionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/appverifier/build.gradle.kts
+++ b/appverifier/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
     alias(libs.plugins.kapt)
 }
 
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
 kotlin {
     jvmToolchain(17)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,25 @@
+import org.apache.commons.io.output.ByteArrayOutputStream
+
+// For `versionCode` we just use the number of commits.
+val projectVersionCode: Int by extra {
+    val stdout = ByteArrayOutputStream()
+    rootProject.exec {
+        commandLine("git", "rev-list", "HEAD", "--count")
+        standardOutput = stdout
+    }
+    stdout.toString().trim().toInt()
+}
+
+// For versionName, we use the output of: git describe --tags --dirty
+val projectVersionName: String by extra {
+    val stdout = ByteArrayOutputStream()
+    rootProject.exec {
+        commandLine("git", "describe", "--tags", "--dirty")
+        standardOutput = stdout
+    }
+    stdout.toString().trim()
+}
+
 plugins {
     // this is necessary to avoid the plugins to be loaded multiple times
     // in each subproject's classloader
@@ -11,4 +33,5 @@ plugins {
     alias(libs.plugins.navigation.safe.args) apply false
     alias(libs.plugins.parcelable) apply false
     alias(libs.plugins.kapt) apply false
+    alias(libs.plugins.buildconfig) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -55,6 +55,7 @@ androidx-preference = "1.2.1"
 exif = "1.3.7"
 ausweis-sdk = "2.1.1"
 jetbrains-navigation = "2.7.0-alpha07"
+buildconfig = "5.3.5"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -137,3 +138,4 @@ gretty = { id = "org.gretty", version.ref = "gretty"}
 navigation-safe-args = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation-plugin" }
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 parcelable = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
+buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }

--- a/identityctl/build.gradle.kts
+++ b/identityctl/build.gradle.kts
@@ -1,6 +1,15 @@
 plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
+    alias(libs.plugins.buildconfig)
+}
+
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
+buildConfig {
+    packageName("com.android.identity.identityctl")
+    buildConfigField("VERSION", projectVersionName)
 }
 
 kotlin {

--- a/identityctl/src/main/java/com/android/identity/identityctl/IdentityCtl.kt
+++ b/identityctl/src/main/java/com/android/identity/identityctl/IdentityCtl.kt
@@ -472,7 +472,13 @@ Generate an IACA certificate and corresponding private key:
         [--subject_and_issuer 'CN=Utopia TEST Reader CA,C=UT']
         [--validity_in_years 3]
         [--curve P384]
+
+    identityctl version
 """)
+    }
+
+    fun version(args: Array<String>) {
+        println(BuildConfig.VERSION)
     }
 
     @JvmStatic
@@ -488,6 +494,7 @@ Generate an IACA certificate and corresponding private key:
                 "generateDs" -> generateDs(args)
                 "generateReaderRoot" -> generateReaderRoot(args)
                 "help" -> usage(args)
+                "version" -> version(args)
                 else -> {
                     println("Unknown command '$command'")
                     usage(args)

--- a/samples/age-verifier-mdl/build.gradle.kts
+++ b/samples/age-verifier-mdl/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     id("kotlin-android")
 }
 
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
 kotlin {
     jvmToolchain(17)
 }
@@ -17,8 +20,8 @@ android {
         applicationId = "com.android.identity.age_verifier_mdl"
         minSdk = 28
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = projectVersionCode
+        versionName = projectVersionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/samples/preconsent-mdl/build.gradle.kts
+++ b/samples/preconsent-mdl/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     id("kotlin-android")
 }
 
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
 kotlin {
     jvmToolchain(17)
 }
@@ -17,8 +20,8 @@ android {
         applicationId = "com.android.identity.preconsent_mdl"
         minSdk = 28
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = projectVersionCode
+        versionName = projectVersionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/samples/secure-area-test-app/build.gradle.kts
+++ b/samples/secure-area-test-app/build.gradle.kts
@@ -8,6 +8,9 @@ plugins {
     alias(libs.plugins.compose.compiler)
 }
 
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
 kotlin {
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
@@ -68,8 +71,8 @@ android {
         applicationId = "com.android.identity.secure_area_test_app"
         minSdk = libs.versions.android.minSdk.get().toInt()
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = projectVersionCode
+        versionName = projectVersionName
     }
     packaging {
         resources {

--- a/samples/simple-verifier/build.gradle.kts
+++ b/samples/simple-verifier/build.gradle.kts
@@ -5,6 +5,9 @@ plugins {
     id("kotlin-android")
 }
 
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
 kotlin {
     jvmToolchain(17)
 }
@@ -17,8 +20,8 @@ android {
         applicationId = "com.android.identity.simple_verifier"
         minSdk = 29
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = projectVersionCode
+        versionName = projectVersionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/wallet/build.gradle.kts
+++ b/wallet/build.gradle.kts
@@ -2,7 +2,16 @@ plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.jetbrainsCompose)
+    alias(libs.plugins.buildconfig)
     id("kotlin-android")
+}
+
+val projectVersionCode: Int by rootProject.extra
+val projectVersionName: String by rootProject.extra
+
+buildConfig {
+    packageName("com.android.identity_credential.wallet")
+    buildConfigField("VERSION", projectVersionName)
 }
 
 kotlin {
@@ -17,8 +26,8 @@ android {
         applicationId = "com.android.identity_credential.wallet"
         minSdk = 27
         targetSdk = libs.versions.android.targetSdk.get().toInt()
-        versionCode = 1
-        versionName = "1.0"
+        versionCode = projectVersionCode
+        versionName = projectVersionName
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/wallet/src/main/assets/webview/about.md
+++ b/wallet/src/main/assets/webview/about.md
@@ -1,3 +1,5 @@
+Wallet version TODO
+
 This application supports provisioning and presentation of real-world
 identity using the ISO/IEC 18013-5:2021 mdoc credential format.
 


### PR DESCRIPTION
Use the output of `git describe --tags --dirty` as the version number which for releases is equal to the tag name (e.g. `20240702`) and for snapshots will be the latest tag, the number of commits since, the commit-id, and possibly if the tree has been modified. For example `20231002-179-gd592df9c-dirty`.

Also start using a Gradle plugin for generating `BuildConfig` so we can convey the version numbers in code. Do this for `identityctl` tool and make room in the `about.md` page in the Wallet app to do this. Peter will implement conveying the version number to Markdown/HTML in a future commit.

Test: ./gradlew check
Test: ./gradlew connectedCheck
