### PR TITLE
Display version info in about screen.

### DIFF
--- a/wallet/build.gradle.kts
+++ b/wallet/build.gradle.kts
@@ -12,6 +12,7 @@ val projectVersionName: String by rootProject.extra
 buildConfig {
     packageName("com.android.identity_credential.wallet")
     buildConfigField("VERSION", projectVersionName)
+    useKotlinOutput { internalVisibility = false }
 }
 
 kotlin {

--- a/wallet/src/main/assets/webview/about.md
+++ b/wallet/src/main/assets/webview/about.md
@@ -1,4 +1,4 @@
-Wallet version TODO
+Wallet version __placeholder__{appinfo=version}
 
 This application supports provisioning and presentation of real-world
 identity using the ISO/IEC 18013-5:2021 mdoc credential format.

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/HtmlSnippet.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/HtmlSnippet.kt
@@ -36,6 +36,9 @@ private val htmlRenderer = object : WebViewContentRenderer() {
         function render(markupText, css) {
           let doc = (new DOMParser()).parseFromString(
               "<div>" + markupText + "</div>", "text/xml");
+          for (let q of doc.querySelectorAll("[appinfo]")) {
+            q.textContent = window.Callback?.appinfo(q.getAttribute("appinfo"))
+          }
           let destination = document.getElementById('content');
           destination.innerHTML = '';
           injectContent(doc.firstChild, destination);
@@ -142,6 +145,8 @@ private val htmlRenderer = object : WebViewContentRenderer() {
  * Styling can be applied using style attributes. Only certain elements and
  * attributes are allowed (in particular, no scripting), so this should be
  * generally safe to use with arbitrary content.
+ *
+ * Use `appinfo` attribute to inject application data, e.g. `<span appinfo='version'/>`.
  */
 @Composable
 fun HtmlSnippetText(

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/Markdown.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/Markdown.kt
@@ -37,8 +37,11 @@ private val markdownRenderer = object : WebViewContentRenderer() {
         }
         function render(markdownText, css) {
           var md = markdownit().use(markdownItAttrs,
-             {allowedAttributes: ['id', 'class', 'width', 'height', 'style']}).use(markdownItAnchor);
+             {allowedAttributes: ['id', 'class', 'width', 'height', 'style', 'appinfo']}).use(markdownItAnchor);
           document.getElementById('content').innerHTML = md.render(markdownText);
+          for (let q of document.querySelectorAll("[appinfo]")) {
+            q.textContent = window.Callback?.appinfo(q.getAttribute("appinfo"))
+          }
           document.getElementById('style').textContent = css;
           reportHeight();
           for (let image of document.images) {
@@ -52,7 +55,11 @@ private val markdownRenderer = object : WebViewContentRenderer() {
         """.trimIndent()
 }
 
-/** Displays markdown-formatted content. */
+/**
+ * Displays markdown-formatted content.
+ *
+ * Use `appinfo` attribute to inject application data, e.g. `_dummytext_[appinfo=version]`.
+ */
 @Composable
 fun MarkdownText(
     content: String,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/WebViewContentRenderer.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/WebViewContentRenderer.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.graphics.colorspace.ColorSpaces
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import com.android.identity_credential.wallet.BuildConfig
 import kotlinx.io.bytestring.ByteString
 import java.io.ByteArrayInputStream
 import java.io.FileNotFoundException
@@ -93,6 +94,16 @@ abstract class WebViewContentRenderer {
                             } else {
                                 contentHeight.intValue = height.roundToInt()
                            }
+                        }
+                    }
+
+                    @JavascriptInterface
+                    fun appinfo(query: String): String {
+                        // Returns text that will be injected into an HTML element that has
+                        // appinfo attribute with the given query.
+                        return when (query) {
+                            "version" -> return BuildConfig.VERSION
+                            else -> ""
                         }
                     }
                 }


### PR DESCRIPTION
Added appinfo attribute to inject app-specific content into HTML/Markdown that we render in-app and hooked that to about screen.

Tested manually for both markdown and HTML.