### PR TITLE
Add Selfie verification, including MLKit-based facial pose recognition

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ androidx-espresso-core = "3.5.1"
 androidx-material = "1.12.0"
 androidx-test-junit = "1.1.5"
 compose-plugin = "1.6.10"
+faceDetection = "16.1.6"
 junit = "4.13.2"
 kotlin = "2.0.0"
 kotlinx-coroutines = "1.8.1"
@@ -55,9 +56,11 @@ androidx-preference = "1.2.1"
 exif = "1.3.7"
 ausweis-sdk = "2.1.1"
 jetbrains-navigation = "2.7.0-alpha07"
+cameraLifecycle = "1.3.4"
 buildconfig = "5.3.5"
 
 [libraries]
+face-detection = { module = "com.google.mlkit:face-detection", version.ref = "faceDetection" }
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 kotlin-test-junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref="kotlinx-coroutines" }
@@ -122,6 +125,7 @@ exifinterface = { module = "androidx.exifinterface:exifinterface", version.ref =
 ausweis-sdk = { module = "com.governikus:ausweisapp", version.ref = "ausweis-sdk"}
 jetbrains-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref="jetbrains-navigation" }
 jetbrains-navigation-runtime = { module = "org.jetbrains.androidx.navigation:navigation-runtime", version.ref="jetbrains-navigation" }
+camera-lifecycle = { group = "androidx.camera", name = "camera-lifecycle", version.ref = "cameraLifecycle" }
 
 [bundles]
 google-play-services = ["play-services-base", "play-services-basement", "play-services-tasks"]

--- a/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceRequestSelfieVideo.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceRequestSelfieVideo.kt
@@ -1,0 +1,10 @@
+package com.android.identity.issuance.evidence
+
+data class EvidenceRequestSelfieVideo(val poseSequence: List<Poses>): EvidenceRequest() {
+    enum class Poses {
+        FRONT,
+        SMILE,
+        TILT_HEAD_UP,
+        TILT_HEAD_DOWN
+    }
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceResponseSelfieVideo.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceResponseSelfieVideo.kt
@@ -1,0 +1,17 @@
+package com.android.identity.issuance.evidence
+
+data class EvidenceResponseSelfieVideo(val video: ByteArray)
+    : EvidenceResponse() {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as EvidenceResponseSelfieVideo
+
+        return video.contentEquals(other.video)
+    }
+
+    override fun hashCode(): Int {
+        return video.contentHashCode()
+    }
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/proofing/ProofingGraphBuilder.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/proofing/ProofingGraphBuilder.kt
@@ -7,6 +7,7 @@ import com.android.identity.issuance.evidence.EvidenceRequestMessage
 import com.android.identity.issuance.evidence.EvidenceRequestNotificationPermission
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionMultipleChoice
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionString
+import com.android.identity.issuance.evidence.EvidenceRequestSelfieVideo
 import com.android.identity.issuance.evidence.EvidenceResponse
 import com.android.identity.securearea.PassphraseConstraints
 import com.android.identity.issuance.proofing.ProofingGraph.Node
@@ -118,6 +119,21 @@ class ProofingGraphBuilder {
                 noAuthentication = map[choices.noAuthenticationGraph]!!
             )
         }
+    }
+
+    /** Sends [EvidenceRequestSelfieVideo]. */
+    fun createSelfieRequest(id: String) {
+        // For now, the list of poses is hardcoded here. In the future, this may come from the
+        // issuing authority.
+        val evidenceRequest = EvidenceRequestSelfieVideo(
+            listOf(
+                EvidenceRequestSelfieVideo.Poses.FRONT,
+                EvidenceRequestSelfieVideo.Poses.SMILE,
+                EvidenceRequestSelfieVideo.Poses.TILT_HEAD_UP,
+                EvidenceRequestSelfieVideo.Poses.TILT_HEAD_DOWN
+            )
+        )
+        chain.add { followUp -> ProofingGraph.SimpleNode(id, followUp, evidenceRequest) }
     }
 
     fun eId(id: String, optionalComponents: List<String> = listOf()) {

--- a/identity-issuance/src/main/java/com/android/identity/issuance/proofing/defaultGraph.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/proofing/defaultGraph.kt
@@ -158,6 +158,19 @@ fun defaultGraph(
                 }
             }
         }
+        if (developerModeEnabled) {
+            choice(
+                id = "choose_selfie",
+                message = "Verify using a selfie? $devNotice",
+                assets = devAssets,
+                acceptButtonText = "Continue"
+            ) {
+                on(id = "no_selfie", text = "No, skip selfie verification") {}
+                on(id = "use_selfie", text = "Yes, take a selfie for verification") {
+                    createSelfieRequest(id = "selfie_request")
+                }
+            }
+        }
         message(
             "message",
             message = """

--- a/wallet/build.gradle.kts
+++ b/wallet/build.gradle.kts
@@ -90,6 +90,7 @@ dependencies {
     implementation(project(":mrtd-reader-android"))
     implementation(project(":jpeg2k"))
 
+    implementation(libs.kotlinx.coroutines.guava)
     implementation(libs.kotlinx.datetime)
     implementation(libs.kotlinx.io.core)
     implementation(libs.kotlinx.io.bytestring)
@@ -109,6 +110,7 @@ dependencies {
     implementation(compose.components.resources)
     implementation(compose.components.uiToolingPreview)
     implementation(compose.material)
+    implementation(libs.camera.lifecycle)
 
     debugImplementation(compose.uiTooling)
     implementation(compose.preview)
@@ -124,6 +126,7 @@ dependencies {
     implementation(libs.nimbus.oauth2.oidc.sdk)
     implementation(libs.androidx.camera.view)
     implementation(libs.androidx.material)
+    implementation(libs.face.detection)
     implementation(libs.zxing.core)
 
     implementation(files("../third-party/play-services-identity-credentials-0.0.1-eap01.aar"))

--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -22,6 +22,8 @@
         android:name="android.hardware.camera.any"
         android:required="true" />
     <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28" />
 
     <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
 

--- a/wallet/src/main/java/com/android/identity/issuance/remote/StorageImpl.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/StorageImpl.kt
@@ -2,7 +2,10 @@ package com.android.identity.issuance.remote
 
 import android.content.ContentValues
 import android.content.Context
+import android.database.AbstractWindowedCursor
+import android.database.CursorWindow
 import android.database.sqlite.SQLiteDatabase
+import android.os.Build
 import com.android.identity.flow.server.Storage
 import com.android.identity.util.Logger
 import kotlinx.io.bytestring.ByteString
@@ -58,6 +61,15 @@ internal class StorageImpl(
                 null,
                 null
             )
+            // TODO: Older OS versions don't support setting the cursor window size.
+            //  What should we do with older OS versions?
+            //  Also note that a large window size may lead to longer delays when loading from the
+            //  database. And if we keep this, replace the magic number with a constant.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                // The default window size of 2MB is too small for video files.
+                (cursor as? AbstractWindowedCursor)?.window = CursorWindow(
+                    "Larger Window", 256 * 1024 * 1024)
+            }
             if (cursor.moveToFirst()) {
                 val bytes = cursor.getBlob(0)
                 cursor.close()

--- a/wallet/src/main/java/com/android/identity_credential/wallet/FaceImageClassifier.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/FaceImageClassifier.kt
@@ -1,0 +1,167 @@
+package com.android.identity_credential.wallet
+
+import android.content.Context
+import android.util.Size
+import androidx.annotation.OptIn
+import androidx.camera.core.ExperimentalGetImage
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.resolutionselector.ResolutionFilter
+import androidx.camera.core.resolutionselector.ResolutionSelector
+import androidx.core.content.ContextCompat
+import com.android.identity.issuance.evidence.EvidenceRequestSelfieVideo
+import com.android.identity.util.Logger
+import com.google.mlkit.vision.common.InputImage
+import com.google.mlkit.vision.face.Face
+import com.google.mlkit.vision.face.FaceDetection
+import com.google.mlkit.vision.face.FaceDetector
+import com.google.mlkit.vision.face.FaceDetectorOptions
+import kotlin.math.abs
+
+class FaceImageClassifier(private val onStateChange: (RecognitionState, EvidenceRequestSelfieVideo.Poses?) -> Unit,
+    private val context: Context) : ImageAnalysis.Analyzer {
+    private val detector: FaceDetector
+    val analysisUseCase: ImageAnalysis
+    private var expectedPose: EvidenceRequestSelfieVideo.Poses? = null
+
+    enum class RecognitionState {
+        NO_POSE_SELECTED,
+        WORKING,
+        TOO_MANY_FACES,
+        POSE_RECOGNIZED
+    }
+    private var recognitionState = RecognitionState.NO_POSE_SELECTED
+
+    companion object {
+        const val TAG = "FaceImageClassifier"
+        const val DEFAULT_REQUESTED_CAMERA_PREVIEW_WIDTH: Int = 480
+        const val DEFAULT_REQUESTED_CAMERA_PREVIEW_HEIGHT: Int = 360
+    }
+
+    init {
+        val options = FaceDetectorOptions.Builder()
+                .setClassificationMode(FaceDetectorOptions.CLASSIFICATION_MODE_ALL)
+                .enableTracking()
+                .build()
+        detector = FaceDetection.getClient(options)
+
+        val targetResolution = Size(DEFAULT_REQUESTED_CAMERA_PREVIEW_WIDTH, DEFAULT_REQUESTED_CAMERA_PREVIEW_HEIGHT)
+        val resolutionSelector = ResolutionSelector.Builder()
+            .setResolutionFilter(SizedResolutionFilter(targetResolution))
+            .build()
+        analysisUseCase = ImageAnalysis.Builder()
+            .setResolutionSelector(resolutionSelector)
+            .build()
+        analysisUseCase.setAnalyzer(ContextCompat.getMainExecutor(context), this)
+        Logger.i(TAG, "Created FaceImageClassifier")
+    }
+
+    fun setExpectedPose(pose: EvidenceRequestSelfieVideo.Poses?) {
+        expectedPose = pose
+        setRecognitionState(
+            if (pose == null) RecognitionState.NO_POSE_SELECTED
+            else RecognitionState.WORKING
+        )
+    }
+
+    private fun setRecognitionState(state: RecognitionState) {
+        if (recognitionState != state) {
+            recognitionState = state
+            Logger.d(TAG, "Recognition state changed to $state")
+            onStateChange(state, expectedPose)
+        }
+    }
+
+    private fun checkFace(face: Face, pose: EvidenceRequestSelfieVideo.Poses): Boolean {
+        Logger.d(TAG, "Checking face, pose $pose, smiling ${face.smilingProbability}, angle X ${face.headEulerAngleX}, angle Y ${face.headEulerAngleY}, angle Z ${face.headEulerAngleZ}")
+        return when (pose) {
+            EvidenceRequestSelfieVideo.Poses.FRONT -> {
+                abs(face.headEulerAngleX) < 15 &&
+                        abs(face.headEulerAngleY) < 15 &&
+                        abs(face.headEulerAngleZ) < 15
+            }
+            EvidenceRequestSelfieVideo.Poses.SMILE -> {
+                (face.smilingProbability ?: 0.0f) > 0.85f
+            }
+            EvidenceRequestSelfieVideo.Poses.TILT_HEAD_UP -> {
+                face.headEulerAngleX > 35 &&
+                        abs(face.headEulerAngleY) < 15 &&
+                        abs(face.headEulerAngleZ) < 15
+
+            }
+            EvidenceRequestSelfieVideo.Poses.TILT_HEAD_DOWN -> {
+                face.headEulerAngleX < -20 &&
+                        abs(face.headEulerAngleY) < 15 &&
+                        abs(face.headEulerAngleZ) < 15
+            }
+        }
+    }
+
+    @OptIn(ExperimentalGetImage::class)
+    override fun analyze(imageProxy: ImageProxy) {
+        if (expectedPose == null) {
+            imageProxy.close()
+            return
+        }
+
+        val mediaImage = imageProxy.image
+        if (mediaImage != null) {
+            val image = InputImage.fromMediaImage(mediaImage, imageProxy.imageInfo.rotationDegrees)
+
+            Logger.d(TAG, "Analyzing image, size ${image.width}x${image.height}")
+            detector.process(image)
+                .addOnSuccessListener { faces ->
+                    try {
+                        if (faces.isNotEmpty()) {
+                            if (faces.size > 1) {
+                                // Too many faces in the image. Only process the image if there's
+                                // only one.
+                                setRecognitionState(RecognitionState.TOO_MANY_FACES)
+                                return@addOnSuccessListener
+                            }
+
+                            val face = faces[0]
+                            val pose = expectedPose?: return@addOnSuccessListener
+                            if (checkFace(face, pose)) {
+                                setRecognitionState(RecognitionState.POSE_RECOGNIZED)
+                            } else {
+                                setRecognitionState(RecognitionState.WORKING)
+                            }
+                        }
+                    } catch (e: Exception) {
+                        Logger.e(TAG, "Error analyzing image", e)
+                    } finally {
+                        imageProxy.close()
+                    }
+                }
+                .addOnFailureListener { e ->
+                    throw e
+                }
+        }
+    }
+}
+
+class SizedResolutionFilter(private val targetResolution: Size): ResolutionFilter {
+    override fun filter(supportedSizes: List<Size>, rotationDegrees: Int): List<Size> {
+        if (supportedSizes.isEmpty()) {
+            return supportedSizes
+        }
+
+        fun linearDifference(size1: Size, size2: Size): Int {
+            return abs(size1.width - size2.width) + abs(size1.height - size2.height)
+        }
+        var bestLinearDifference = linearDifference(targetResolution, supportedSizes[0])
+        var bestResolution = supportedSizes[0]
+        for (size in supportedSizes) {
+            val currentLinearDifference = linearDifference(targetResolution, size)
+            Logger.d("SizedResolutionFilter",
+                "Available image size $size, linear difference $currentLinearDifference")
+            if (currentLinearDifference < bestLinearDifference) {
+                bestLinearDifference = currentLinearDifference
+                bestResolution = size
+            }
+        }
+        Logger.i("SizedResolutionFilter", "Selected resolution $bestResolution")
+        return listOf(bestResolution)
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/SelfieRecorder.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/SelfieRecorder.kt
@@ -1,0 +1,170 @@
+package com.android.identity_credential.wallet.ui
+
+import android.content.ContentValues
+import android.content.Context
+import android.os.Build
+import android.provider.MediaStore
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.MirrorMode.MIRROR_MODE_ON_FRONT_ONLY
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.video.FallbackStrategy
+import androidx.camera.video.FileOutputOptions
+import androidx.camera.video.MediaStoreOutputOptions
+import androidx.camera.video.OutputOptions
+import androidx.camera.video.Quality
+import androidx.camera.video.QualitySelector
+import androidx.camera.video.Recorder
+import androidx.camera.video.Recording
+import androidx.camera.video.VideoCapture
+import androidx.camera.video.VideoRecordEvent
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import com.android.identity.issuance.evidence.EvidenceRequestSelfieVideo
+import com.android.identity.util.Logger
+import com.android.identity_credential.wallet.FaceImageClassifier
+import kotlinx.coroutines.guava.await
+import java.io.File
+import java.text.SimpleDateFormat
+
+
+/**
+ * Video recorder to record a selfie video for identity verification.
+ */
+class SelfieRecorder(
+    private val lifecycleOwner: LifecycleOwner,
+    private val context: Context,
+    private val onRecordingStarted: () -> Unit,
+    private val onFinished: (ByteArray) -> Unit,
+    private val onStateChange: (FaceImageClassifier.RecognitionState, EvidenceRequestSelfieVideo.Poses?) -> Unit
+) {
+    companion object {
+        private const val TAG = "SelfieRecorder"
+        private const val FILENAME_TIME_FORMAT = "yyyy-MM-dd-HH-mm-ss-SSS"
+        private const val FILENAME_FORMAT = "VerificationSelfie-\$datetime.mp4"
+    }
+
+    private lateinit var cameraProvider: ProcessCameraProvider
+    private lateinit var videoCapture: VideoCapture<Recorder>
+    private var recording: Recording? = null
+    var faceClassifier: FaceImageClassifier? = null
+
+    /**
+     * Starts camera and prepares to record and return a video.
+     */
+    suspend fun launchCamera(surfaceProvider: Preview.SurfaceProvider) {
+        if (::cameraProvider.isInitialized) {
+            throw IllegalStateException("Camera already started.")
+        }
+        cameraProvider = ProcessCameraProvider.getInstance(context).await()
+
+        // Configure preview, so the user can see what they're recording:
+        val previewUseCase = Preview.Builder().build()
+        previewUseCase.setSurfaceProvider(surfaceProvider)
+
+        // Configure video recording:
+        val recorder = Recorder.Builder()
+            .setQualitySelector(QualitySelector.from(Quality.HIGHEST,
+                FallbackStrategy.higherQualityOrLowerThan(Quality.SD)))
+            .build()
+        videoCapture = VideoCapture.Builder(recorder)
+            .setMirrorMode(MIRROR_MODE_ON_FRONT_ONLY)
+            .build()
+
+        // Configure face classifier:
+        faceClassifier = FaceImageClassifier(onStateChange, context)
+
+        // Unbind any existing use cases and bind our own:
+        cameraProvider.unbindAll()
+        cameraProvider.bindToLifecycle(
+            lifecycleOwner, CameraSelector.DEFAULT_FRONT_CAMERA,
+            previewUseCase, videoCapture, faceClassifier!!.analysisUseCase
+        )
+    }
+
+    /**
+     * Returns a [MediaStoreOutputOptions] for recording a selfie video and saving it to a file
+     * in the MediaStore.
+     */
+    private fun getRecordingOptions(): FileOutputOptions {
+        // Save the recording to a local file while it's being created. It'll be uploaded once it's
+        // done.
+        val fileName = FILENAME_FORMAT.replace(
+            "\$datetime",
+            SimpleDateFormat(FILENAME_TIME_FORMAT)
+                .format(System.currentTimeMillis()))
+        val privateDirectory = context.filesDir
+        val outputFile = File(privateDirectory, fileName)
+        Logger.i(TAG, "Saving selfie video to ${outputFile.absolutePath}")
+
+        return FileOutputOptions.Builder(outputFile)
+            .setFileSizeLimit(256 * 1024 * 1024)
+            .build()
+    }
+
+    /**
+     * Starts video recording.
+     */
+    fun startRecording() {
+        if (!::cameraProvider.isInitialized || !::videoCapture.isInitialized) {
+            throw IllegalStateException("Recording requested when camera has not been started.")
+        }
+        if (recording != null) {
+            // The UI flow shouldn't allow multiple recordings at once.
+            throw IllegalStateException("Recording already in progress.")
+        }
+
+        recording = videoCapture.output
+            .prepareRecording(context, getRecordingOptions())
+            .start(ContextCompat.getMainExecutor(context)) { recordEvent ->
+                when(recordEvent) {
+                    is VideoRecordEvent.Start -> onRecordingStarted()
+                    is VideoRecordEvent.Finalize -> {
+                        recording?.close()
+                        recording = null
+                        if (recordEvent.hasError()) {
+                            Logger.e(TAG, "Selfie failed to record: ${recordEvent.error}")
+                            onFinished(ByteArray(0))
+                        } else {
+                            Logger.i(
+                                TAG,
+                                "Selfie recorded: ${recordEvent.outputResults.outputUri}"
+                            )
+                            val inputStream = context.contentResolver.openInputStream(
+                                recordEvent.outputResults.outputUri)
+                            // TODO(kdeus): readAllBytes is new in API level 33. For older versions,
+                            //  implement this ourselves. Or find a way to avoid loading the file
+                            //  into memory.
+                            val videoContents = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                                inputStream!!.readAllBytes()
+                            } else {
+                                TODO("VERSION.SDK_INT < TIRAMISU")
+                                ByteArray(0)
+                            }
+                            inputStream?.close()
+                            Logger.i(TAG, "Loaded video file into memory (${videoContents.size} bytes)")
+                            onFinished(videoContents)
+
+                            // Now that the file has been sent, we don't need it on disk anymore.
+                            Logger.i(TAG, "Deleting file ${recordEvent.outputResults.outputUri}")
+                            File(recordEvent.outputResults.outputUri.path!!).delete()
+                        }
+                    }
+                }
+            }
+    }
+
+    /**
+     * Stops the recording and calls the completion handler.
+     */
+    fun finish() {
+        if (recording == null) {
+            // The UI flow shouldn't allow finishing the recording if it hasn't started.
+            throw IllegalStateException("Can't stop recording if the recording hasn't started.")
+        }
+        recording?.stop()
+        recording = null
+
+        cameraProvider.unbindAll()
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
@@ -25,6 +25,7 @@ import com.android.identity.issuance.evidence.EvidenceRequestMessage
 import com.android.identity.issuance.evidence.EvidenceRequestNotificationPermission
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionMultipleChoice
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionString
+import com.android.identity.issuance.evidence.EvidenceRequestSelfieVideo
 import com.android.identity.issuance.evidence.EvidenceResponseCreatePassphrase
 import com.android.identity.issuance.evidence.EvidenceResponseQuestionMultipleChoice
 import com.android.identity.issuance.evidence.EvidenceResponseQuestionString
@@ -163,6 +164,16 @@ fun ProvisionDocumentScreen(
                             evidenceRequest,
                             provisioningViewModel = provisioningViewModel,
                             permissionTracker = permissionTracker
+                        )
+                    }
+
+                    is EvidenceRequestSelfieVideo -> {
+                        EvidenceRequestSelfieVideoView(
+                            evidenceRequest,
+                            provisioningViewModel = provisioningViewModel,
+                            permissionTracker = permissionTracker,
+                            walletServerProvider = walletServerProvider,
+                            documentStore = documentStore
                         )
                     }
 

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -356,5 +356,17 @@
     <string name="duration_hours_and_minutes">%1$s and %2$s</string>
     <string name="duration_time_ago">%1$s ago</string>
     <string name="duration_time_from_now">%1$s from now</string>
+    <string name="selfie_video_failed">Failed to record selfie video. Please tap Back and try again.</string>
+    <string name="record_selfie_title">Record a selfie video</string>
+    <string name="initial_selfie_video_instructions">Follow these instructions to record a selfie video to upload for identity verification. Press \"Start recording\" when ready.</string>
+    <string name="selfie_instructions_face_front">Face directly toward the camera</string>
+    <string name="selfie_instructions_tilt_head_up">Tilt your head up</string>
+    <string name="selfie_instructions_tilt_head_down">Tilt your head down</string>
+    <string name="selfie_video_start_recording_button">Start recording</string>
+    <string name="selfie_video_finish_button">Finish</string>
+    <string name="selfie_video_continue_to_next_pose_button">Continue</string>
+    <string name="selfie_instructions_finishing_video">Thank you. Finishing video...</string>
+    <string name="selfie_instructions_smile">Smile</string>
+    <string name="selfie_instructions_too_many_faces">Too many faces found. Please ensure you only have one person on camera.</string>
 
 </resources>


### PR DESCRIPTION
This adds ML Kit, hooks it into the Selfie camera recording code, detects
all the current poses we support (and adds support for detecting smiling),
and replaces the button to proceed to the next pose.

Fixes #680

- [X] Tests pass