### PR TITLE
Use Material3 in Compose Multiplatform.

### DIFF
--- a/identity-appsupport/build.gradle.kts
+++ b/identity-appsupport/build.gradle.kts
@@ -32,7 +32,7 @@ kotlin {
             dependencies {
                 implementation(compose.runtime)
                 implementation(compose.foundation)
-                implementation(compose.material)
+                implementation(compose.material3)
                 implementation(compose.ui)
                 implementation(compose.components.resources)
                 implementation(compose.components.uiToolingPreview)

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/PassphraseEntryField.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/PassphraseEntryField.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Divider
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
+import androidx.compose.material3.Divider
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -103,7 +103,7 @@ fun PassphraseEntryField(
                             .border(1.dp, Color.Gray, RoundedCornerShape(8.dp))
                             .padding(2.dp),
                         textAlign = TextAlign.Center,
-                        style = MaterialTheme.typography.h3,
+                        style = MaterialTheme.typography.headlineLarge,
                     )
                     Spacer(modifier = Modifier.width(8.dp))
                 }
@@ -145,7 +145,7 @@ fun PassphraseEntryField(
                 onChanged(inputText, passphraseAnalysis.meetsRequirements, false)
             },
             singleLine = true,
-            textStyle = MaterialTheme.typography.subtitle2,
+            textStyle = MaterialTheme.typography.headlineMedium,
             decorationBox = decorationBox,
             keyboardOptions = KeyboardOptions(
                 keyboardType = if (constraints.requireNumerical) KeyboardType.NumberPassword else KeyboardType.Password,
@@ -193,8 +193,8 @@ fun PassphraseEntryField(
         ) {
             Text(
                 text = it,
-                style = MaterialTheme.typography.body2,
-                color = MaterialTheme.colors.error
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.error
             )
         }
     }

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -50,7 +50,7 @@ kotlin {
         commonMain.dependencies {
             implementation(compose.runtime)
             implementation(compose.foundation)
-            implementation(compose.material)
+            implementation(compose.material3)
             implementation(compose.ui)
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -21,12 +21,12 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.ArrowBack
 import androidx.compose.material.icons.automirrored.filled.ArrowForward
@@ -269,7 +269,7 @@ fun ShowCapabilitiesDialog(capabilities: AndroidKeystoreSecureArea.Capabilities,
                     text = "Versions and Capabilities",
                     modifier = Modifier.padding(16.dp),
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.subtitle1
+                    style = MaterialTheme.typography.titleLarge
                 )
                 Column(
                     modifier = Modifier
@@ -286,7 +286,7 @@ fun ShowCapabilitiesDialog(capabilities: AndroidKeystoreSecureArea.Capabilities,
                                 "StrongBox KeyMint version: ${keymintVersionStrongBox}",
                         modifier = Modifier.padding(8.dp),
                         textAlign = TextAlign.Start,
-                        style = MaterialTheme.typography.subtitle2
+                        style = MaterialTheme.typography.bodyMedium
                     )
                     val userAuthText =
                         if (capabilities.multipleAuthenticationTypesSupported)
@@ -302,7 +302,7 @@ fun ShowCapabilitiesDialog(capabilities: AndroidKeystoreSecureArea.Capabilities,
                                 "Secure Lock Screen: $secureLockScreenText",
                         modifier = Modifier.padding(8.dp),
                         textAlign = TextAlign.Start,
-                        style = MaterialTheme.typography.subtitle2
+                        style = MaterialTheme.typography.bodyMedium
                     )
                     Text(
                         text = "Attest Key support (TEE): ${capabilities.attestKeySupported}\n" +
@@ -310,7 +310,7 @@ fun ShowCapabilitiesDialog(capabilities: AndroidKeystoreSecureArea.Capabilities,
                                 "Curve 25519 support (TEE): ${capabilities.curve25519Supported}",
                         modifier = Modifier.padding(8.dp),
                         textAlign = TextAlign.Start,
-                        style = MaterialTheme.typography.subtitle2
+                        style = MaterialTheme.typography.bodyMedium
                     )
                     Text(
                         text = "StrongBox Available: ${capabilities.strongBoxSupported}\n" +
@@ -319,7 +319,7 @@ fun ShowCapabilitiesDialog(capabilities: AndroidKeystoreSecureArea.Capabilities,
                                 "Curve 25519 support (StrongBox): ${capabilities.strongBoxCurve25519Supported}",
                         modifier = Modifier.padding(8.dp),
                         textAlign = TextAlign.Start,
-                        style = MaterialTheme.typography.subtitle2
+                        style = MaterialTheme.typography.bodyMedium
                     )
                 }
                 Row(
@@ -360,14 +360,14 @@ fun ShowCertificateDialog(attestation: X509CertChain,
                     text = "Certificates",
                     modifier = Modifier.padding(16.dp),
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.subtitle1
+                    style = MaterialTheme.typography.titleLarge
                 )
                 Row() {
                     Text(
                         text = "Certificate ${certNumber + 1} of ${attestation.certificates.size}",
                         modifier = Modifier.padding(8.dp),
                         textAlign = TextAlign.Start,
-                        style = MaterialTheme.typography.body1,
+                        style = MaterialTheme.typography.bodyLarge,
                         fontWeight = FontWeight.Bold
                     )
                     IconButton(
@@ -396,7 +396,7 @@ fun ShowCertificateDialog(attestation: X509CertChain,
                         //text = attestation[certNumber].toString(),
                         modifier = Modifier.padding(8.dp),
                         textAlign = TextAlign.Start,
-                        style = MaterialTheme.typography.subtitle2
+                        style = MaterialTheme.typography.bodyMedium
                     )
                 }
                 Row(

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
@@ -2,18 +2,20 @@ package com.android.identity.testapp
 
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Scaffold
-import androidx.compose.material.SnackbarDuration
-import androidx.compose.material.SnackbarHost
-import androidx.compose.material.SnackbarHostState
-import androidx.compose.material.SnackbarResult
-import androidx.compose.material.Text
-import androidx.compose.material.TopAppBar
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarDuration
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -137,6 +139,7 @@ class App {
 /**
  * Composable that displays the topBar and displays back button if back navigation is possible.
  */
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AppBar(
     currentScreen: Screen,
@@ -146,9 +149,9 @@ fun AppBar(
 ) {
     TopAppBar(
         title = { Text(stringResource(currentScreen.title)) },
-        //colors = TopAppBarDefaults.mediumTopAppBarColors(
-        //    containerColor = MaterialTheme.colorScheme.primaryContainer
-        //),
+        colors = TopAppBarDefaults.mediumTopAppBarColors(
+            containerColor = MaterialTheme.colorScheme.primaryContainer
+        ),
         modifier = modifier,
         navigationIcon = {
             if (canNavigateBack) {

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/AboutScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/AboutScreen.kt
@@ -3,7 +3,7 @@ package com.android.identity.testapp.ui
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.Text
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PassphraseEntryFieldScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PassphraseEntryFieldScreen.kt
@@ -9,10 +9,10 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Card
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -121,7 +121,7 @@ fun ShowEntry(constraints: PassphraseConstraints,
                     text = "PassphraseEntryField",
                     modifier = Modifier.padding(16.dp),
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.subtitle1
+                    style = MaterialTheme.typography.titleLarge
                 )
 
                 PassphraseEntryField(

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SoftwareSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SoftwareSecureAreaScreen.kt
@@ -10,13 +10,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.KeyboardOptions
-import androidx.compose.material.Card
-import androidx.compose.material.Icon
-import androidx.compose.material.IconButton
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
-import androidx.compose.material.TextField
+import androidx.compose.material3.Card
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextField
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Visibility
 import androidx.compose.material.icons.filled.VisibilityOff
@@ -177,21 +177,21 @@ private fun ShowPassphraseDialog(
                     text = "Enter passphrase to use key",
                     modifier = Modifier.padding(16.dp),
                     textAlign = TextAlign.Center,
-                    style = MaterialTheme.typography.body1
+                    style = MaterialTheme.typography.bodyLarge
                 )
 
                 Text(
                     text = "The passphrase is '1111'.",
                     modifier = Modifier.padding(16.dp),
                     textAlign = TextAlign.Start,
-                    style = MaterialTheme.typography.body2
+                    style = MaterialTheme.typography.bodyMedium
                 )
 
                 TextField(
                     value = passphraseTextField,
                     maxLines = 3,
                     onValueChange = { passphraseTextField = it },
-                    textStyle = MaterialTheme.typography.body2,
+                    textStyle = MaterialTheme.typography.bodyMedium,
                     visualTransformation = if (showPassphrase) {
                         VisualTransformation.None
                     } else {

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/StartScreen.kt
@@ -3,10 +3,10 @@ package com.android.identity.testapp.ui
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Surface
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -26,7 +26,7 @@ import org.jetbrains.compose.resources.stringResource
 fun StartScreen(navController: NavHostController) {
     Surface(
         modifier = Modifier.fillMaxSize(),
-        color = MaterialTheme.colors.background
+        color = MaterialTheme.colorScheme.background
     ) {
         LazyColumn(
             modifier = Modifier.padding(8.dp)

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
@@ -1,8 +1,8 @@
 package com.android.identity.testapp.ui
 
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto


### PR DESCRIPTION
For some reason the port of samples/testapp to Compose Multiplatform made the switch to use Material instead of Material3. Switch back to Material3.

Test: Manually tested on Android and iOS.
Test: ./gradlew check
Test: ./gradlew connectedCheck

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR