### PR TITLE
wallet: OpenID4VP presentation fixes.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -143,3 +143,4 @@ navigation-safe-args = { id = "androidx.navigation.safeargs.kotlin", version.ref
 kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 parcelable = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
+kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/wallet/build.gradle.kts
+++ b/wallet/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.buildconfig)
+    alias(libs.plugins.kotlinSerialization)
     id("kotlin-android")
 }
 

--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -63,12 +63,19 @@
             android:name=".presentation.OpenID4VPPresentationActivity"
             android:exported="true"
             android:label="@string/app_name_presentation"
-            android:theme="@style/Theme.IdentityCredential">
+            android:theme="@style/Theme.IdentityCredential"
+            android:windowSoftInputMode="adjustPan"
+            android:noHistory="true"
+            android:launchMode="singleInstance"
+            android:excludeFromRecents="true"
+            >
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
-                <data android:scheme="eudi-openid4vp" android:host="*" />
+                <data android:scheme="eudi-openid4vp"/>
+                <data android:scheme="mdoc-openid4vp"/>
+                <data android:host="*"/>
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Main fix here is to use `showPresentmentFlow()` just like Proximity and Credman presentations. Also simplifies code flows and shows an "error" and "success" graphics before switching back to the browser which invoked us. Also set the activity flags properly so the activity is single task, no history, and doesn't appear in recents.

Test: Manually tested.
