### PR TITLE
First cut for Funke option C/C' issuance.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/IssuingAuthorityConfiguration.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/IssuingAuthorityConfiguration.kt
@@ -40,6 +40,21 @@ data class IssuingAuthorityConfiguration(
      * A [DocumentConfiguration] that can be used while proofing is pending for a document.
      */
     val pendingDocumentInformation: DocumentConfiguration,
+
+    /**
+     * Recommended number of credentials to request.
+     */
+    val numberOfCredentialsToRequest: Int?,
+
+    /**
+     * Minimum validity in milliseconds
+     */
+    val minCredentialValidityMillis: Long?,
+
+    /**
+     * Maximum number a single credential should be used
+     */
+    val maxUsesPerCredentials: Int?,
 ) {
     companion object
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/KeyPossessionChallenge.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/KeyPossessionChallenge.kt
@@ -1,0 +1,9 @@
+package com.android.identity.issuance
+
+import com.android.identity.cbor.annotation.CborSerializable
+import kotlinx.io.bytestring.ByteString
+
+@CborSerializable
+data class KeyPossessionChallenge(
+    val messageToSign: ByteString
+)

--- a/identity-issuance/src/main/java/com/android/identity/issuance/KeyPossessionProof.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/KeyPossessionProof.kt
@@ -1,0 +1,9 @@
+package com.android.identity.issuance
+
+import com.android.identity.cbor.annotation.CborSerializable
+import kotlinx.io.bytestring.ByteString
+
+@CborSerializable
+data class KeyPossessionProof(
+    val signature: ByteString
+)

--- a/identity-issuance/src/main/java/com/android/identity/issuance/RequestCredentialsFlow.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/RequestCredentialsFlow.kt
@@ -35,5 +35,8 @@ interface RequestCredentialsFlow : FlowBase {
      * @throws IllegalArgumentException if the issuer rejects the one or more of the requests.
      */
     @FlowMethod
-    suspend fun sendCredentials(credentialRequests: List<CredentialRequest>)
+    suspend fun sendCredentials(credentialRequests: List<CredentialRequest>): List<KeyPossessionChallenge>
+
+    @FlowMethod
+    suspend fun sendPossessionProofs(keyPossessionProofs: List<KeyPossessionProof>)
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceRequestGermanEid.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceRequestGermanEid.kt
@@ -5,5 +5,6 @@ package com.android.identity.issuance.evidence
  * according to BSI TR-03127.
  */
 data class EvidenceRequestGermanEid(
+    val tcTokenUrl: String,
     val optionalComponents: List<String>
 ) : EvidenceRequest()

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FormUrlEncoder.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FormUrlEncoder.kt
@@ -1,0 +1,25 @@
+package com.android.identity.issuance.funke
+
+import java.lang.StringBuilder
+import java.net.URLEncoder
+
+class FormUrlEncoder(block: FormUrlEncoder.() -> Unit) {
+    private val buffer = StringBuilder()
+
+    init {
+        this.block()
+    }
+
+    fun add(name: String, value: String) {
+        if (buffer.isNotEmpty()) {
+            buffer.append("&")
+        }
+        buffer.append(URLEncoder.encode(name, "UTF-8"))
+        buffer.append("=")
+        buffer.append(URLEncoder.encode(value, "UTF-8"))
+    }
+
+    override fun toString(): String {
+        return buffer.toString()
+    }
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeCredentialRequest.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeCredentialRequest.kt
@@ -3,11 +3,13 @@ package com.android.identity.issuance.funke
 import com.android.identity.cbor.annotation.CborSerializable
 import com.android.identity.crypto.EcPublicKey
 import com.android.identity.issuance.CredentialFormat
+import com.android.identity.issuance.CredentialRequest
 import kotlinx.io.bytestring.ByteString
 
 @CborSerializable
 data class FunkeCredentialRequest(
-    val authenticationKey: EcPublicKey,
+    val request: CredentialRequest,
     val format: CredentialFormat,
-    val data: ByteString,
+    val proofOfPossessionJwtHeaderAndBody: String,
+    var proofOfPossessionJwtSignature: String? = null
 )

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuerDocument.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuerDocument.kt
@@ -1,18 +1,24 @@
 package com.android.identity.issuance.funke
 
 import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.issuance.CredentialData
 import com.android.identity.issuance.DocumentCondition
 import com.android.identity.issuance.DocumentConfiguration
 import com.android.identity.issuance.RegistrationResponse
+import com.android.identity.issuance.evidence.EvidenceRequestSetupCloudSecureArea
 import com.android.identity.issuance.evidence.EvidenceResponseGermanEid
+import com.android.identity.securearea.SecureArea
 
 @CborSerializable
 data class FunkeIssuerDocument(
     val registrationResponse: RegistrationResponse,
     var state: DocumentCondition,
-    var evidence: EvidenceResponseGermanEid?,
+    var dpopNonce: String?,
+    var token: String?,
     var documentConfiguration: DocumentConfiguration?,
-    var simpleCredentialRequests: MutableList<FunkeCredentialRequest>
+    var secureAreaIdentifier: String?,
+    val credentialRequests: MutableList<FunkeCredentialRequest>,
+    val credentials: MutableList<CredentialData>
 ) {
     companion object
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuingAuthorityState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuingAuthorityState.kt
@@ -1,50 +1,87 @@
 package com.android.identity.issuance.funke
 
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborMap
 import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+import com.android.identity.crypto.EcCurve
+import com.android.identity.document.NameSpacedData
+import com.android.identity.documenttype.DocumentType
 import com.android.identity.documenttype.DocumentTypeRepository
 import com.android.identity.documenttype.knowntypes.EUPersonalID
 import com.android.identity.flow.annotation.FlowJoin
 import com.android.identity.flow.annotation.FlowMethod
 import com.android.identity.flow.annotation.FlowState
 import com.android.identity.flow.server.FlowEnvironment
+import com.android.identity.flow.server.Resources
 import com.android.identity.flow.server.Storage
+import com.android.identity.issuance.CredentialConfiguration
 import com.android.identity.issuance.CredentialData
+import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.DocumentCondition
 import com.android.identity.issuance.DocumentConfiguration
 import com.android.identity.issuance.DocumentState
 import com.android.identity.issuance.IssuingAuthority
 import com.android.identity.issuance.IssuingAuthorityConfiguration
 import com.android.identity.issuance.IssuingAuthorityNotification
+import com.android.identity.issuance.MdocDocumentConfiguration
 import com.android.identity.issuance.RegistrationResponse
-import com.android.identity.issuance.WalletServerSettings
+import com.android.identity.issuance.SdJwtVcDocumentConfiguration
 import com.android.identity.issuance.common.AbstractIssuingAuthorityState
 import com.android.identity.issuance.common.cache
+import com.android.identity.securearea.KeyPurpose
 import com.android.identity.util.Logger
+import com.android.identity.util.fromBase64
+import com.android.identity.util.toBase64
+import io.ktor.client.HttpClient
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
 import kotlinx.datetime.Clock
 import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.days
 
 @FlowState(
     flowInterface = IssuingAuthority::class
 )
 @CborSerializable
 class FunkeIssuingAuthorityState(
-    val clientId: String
+    val clientId: String,
+    val credentialFormat: CredentialFormat
 ) : AbstractIssuingAuthorityState() {
     companion object {
         private const val TAG = "FunkeIssuingAuthorityState"
 
         private const val DOCUMENT_TABLE = "FunkeIssuerDocument"
 
-        fun getConfiguration(env: FlowEnvironment): IssuingAuthorityConfiguration {
-            return env.cache(IssuingAuthorityConfiguration::class, "funke") { configuration, resources ->
+        fun getConfiguration(env: FlowEnvironment, credentialFormat: CredentialFormat): IssuingAuthorityConfiguration {
+            val id = when (credentialFormat) {
+                CredentialFormat.SD_JWT_VC -> "funkeSdJwtVc"
+                CredentialFormat.MDOC_MSO -> "funkeMdocMso"
+            }
+            val issuingAuthorityName = when (credentialFormat) {
+                CredentialFormat.SD_JWT_VC -> "Funke PID Issuer (SD-JWT)"
+                CredentialFormat.MDOC_MSO -> "Funke PID Issuer (MDOC)"
+            }
+            return env.cache(IssuingAuthorityConfiguration::class, id) { configuration, resources ->
                 val logoPath = "funke/logo.png"
                 val logo = resources.getRawResource(logoPath)!!
                 val artPath = "funke/card_art.png"
                 val art = resources.getRawResource(artPath)!!
-                val requireUserAuthenticationToViewDocument = true
+                val requireUserAuthenticationToViewDocument = false
                 IssuingAuthorityConfiguration(
-                    identifier = "funke",
-                    issuingAuthorityName = "Funke PID Issuer",
+                    identifier = id,
+                    issuingAuthorityName = issuingAuthorityName,
                     issuingAuthorityLogo = logo.toByteArray(),
                     issuingAuthorityDescription = "Funke",
                     pendingDocumentInformation = DocumentConfiguration(
@@ -54,7 +91,10 @@ class FunkeIssuingAuthorityState(
                         requireUserAuthenticationToViewDocument = requireUserAuthenticationToViewDocument,
                         mdocConfiguration = null,
                         sdJwtVcDocumentConfiguration = null
-                    )
+                    ),
+                    numberOfCredentialsToRequest = 1,
+                    minCredentialValidityMillis = 30 * 24 * 3600L,
+                    maxUsesPerCredentials = Int.MAX_VALUE,
                 )
             }
         }
@@ -66,7 +106,7 @@ class FunkeIssuingAuthorityState(
 
     @FlowMethod
     fun getConfiguration(env: FlowEnvironment): IssuingAuthorityConfiguration {
-        return FunkeIssuingAuthorityState.getConfiguration(env)
+        return getConfiguration(env, credentialFormat)
     }
 
     @FlowMethod
@@ -77,6 +117,9 @@ class FunkeIssuingAuthorityState(
                 DocumentCondition.PROOFING_REQUIRED,
                 null,
                 null,
+                null,
+                null,
+                mutableListOf(),
                 mutableListOf()
             )
         )
@@ -91,8 +134,11 @@ class FunkeIssuingAuthorityState(
             FunkeIssuerDocument(
                 registrationState.response!!,
                 DocumentCondition.PROOFING_REQUIRED,
+                null,
                 null, // no evidence yet
                 null,  // no initial document configuration
+                null,
+                mutableListOf(),
                 mutableListOf()           // cpoRequests - initially empty
             ))
     }
@@ -112,9 +158,9 @@ class FunkeIssuingAuthorityState(
 
         val issuerDocument = loadIssuerDocument(env, documentId)
 
-        if (issuerDocument.state == DocumentCondition.PROOFING_PROCESSING
-            && issuerDocument.evidence != null) {
-            issuerDocument.state = if (issuerDocument.evidence?.url != null) {
+        val token = issuerDocument.token
+        if (issuerDocument.state == DocumentCondition.PROOFING_PROCESSING && token != null) {
+            issuerDocument.state = if (token.isNotEmpty()) {
                 DocumentCondition.CONFIGURATION_AVAILABLE
             } else {
                 DocumentCondition.PROOFING_FAILED
@@ -132,19 +178,24 @@ class FunkeIssuingAuthorityState(
             now,
             issuerDocument.state,
             0,
-            issuerDocument.simpleCredentialRequests.count()
+            issuerDocument.credentials.size
         )
     }
 
     @FlowMethod
-    fun proof(env: FlowEnvironment, documentId: String): FunkeProofingState {
-        return FunkeProofingState(documentId)
+    suspend fun proof(env: FlowEnvironment, documentId: String): FunkeProofingState {
+        val pkceCodeVerifier = Random.Default.nextBytes(32).toBase64()
+        val tcTokenUrl = performPushedAuthorizationRequest(env, pkceCodeVerifier)
+        return FunkeProofingState(clientId, documentId, tcTokenUrl, pkceCodeVerifier)
     }
 
     @FlowJoin
     suspend fun completeProof(env: FlowEnvironment, state: FunkeProofingState) {
         val issuerDocument = loadIssuerDocument(env, state.documentId)
-        issuerDocument.evidence = state.evidence
+        issuerDocument.state = DocumentCondition.PROOFING_PROCESSING
+        issuerDocument.dpopNonce = state.dpopNonce
+        issuerDocument.token = state.token
+        issuerDocument.secureAreaIdentifier = state.secureAreaIdentifier
         updateIssuerDocument(env, state.documentId, issuerDocument)
     }
 
@@ -153,8 +204,14 @@ class FunkeIssuingAuthorityState(
         env: FlowEnvironment,
         documentId: String
     ): DocumentConfiguration {
-        // TODO
-        throw RuntimeException()
+        val issuerDocument = loadIssuerDocument(env, documentId)
+        check(issuerDocument.state == DocumentCondition.CONFIGURATION_AVAILABLE)
+        issuerDocument.state = DocumentCondition.READY
+        if (issuerDocument.documentConfiguration == null) {
+            issuerDocument.documentConfiguration = generateDocumentConfiguration(env)
+        }
+        updateIssuerDocument(env, documentId, issuerDocument)
+        return issuerDocument.documentConfiguration!!
     }
 
     @FlowMethod
@@ -162,14 +219,127 @@ class FunkeIssuingAuthorityState(
         env: FlowEnvironment,
         documentId: String
     ): FunkeRequestCredentialsState {
-        // TODO
-        throw RuntimeException()
+        val document = loadIssuerDocument(env, documentId)
+        val token = Json.parseToJsonElement(document.token!!) as JsonObject
+        val cNonce = token["c_nonce"]!!.jsonPrimitive.content
+        val configuration = if (document.secureAreaIdentifier!!.startsWith("CloudSecureArea?")) {
+            val purposes = setOf(KeyPurpose.SIGN, KeyPurpose.AGREE_KEY)
+            CredentialConfiguration(
+                cNonce.toByteArray(),
+                document.secureAreaIdentifier!!,
+                Cbor.encode(
+                    CborMap.builder()
+                        .put("passphraseRequired", true)
+                        .put("userAuthenticationRequired", true)
+                        .put("userAuthenticationTimeoutMillis", 0L)
+                        .put("userAuthenticationTypes", 3 /* LSKF + Biometrics */)
+                        .put("purposes", KeyPurpose.encodeSet(purposes))
+                        .end().build()
+                )
+            )
+        } else {
+            CredentialConfiguration(
+                cNonce.toByteArray(),
+                document.secureAreaIdentifier!!,
+                Cbor.encode(
+                    CborMap.builder()
+                        .put("curve", EcCurve.P256.coseCurveIdentifier)
+                        .put("purposes", KeyPurpose.encodeSet(setOf(KeyPurpose.SIGN)))
+                        .put("userAuthenticationRequired", true)
+                        .put("userAuthenticationTimeoutMillis", 0L)
+                        .put("userAuthenticationTypes", 3 /* LSKF + Biometrics */)
+                        .end().build()
+                )
+            )
+        }
+        return FunkeRequestCredentialsState(documentId, configuration, cNonce)
+    }
+
+    @FlowJoin
+    suspend fun completeRequestCredentials(env: FlowEnvironment, state: FunkeRequestCredentialsState) {
+        val document = loadIssuerDocument(env, state.documentId)
+
+        val proofs = state.credentialRequests!!.map {
+            JsonPrimitive(it.proofOfPossessionJwtHeaderAndBody + "." + it.proofOfPossessionJwtSignature)
+        }
+
+        val request = mutableMapOf<String, JsonElement>(
+            if (proofs.size == 1) {
+                "proof" to JsonObject(
+                    mapOf(
+                        "jwt" to proofs[0],
+                        "proof_type" to JsonPrimitive("jwt")
+                    )
+                )
+            } else {
+                "proofs" to JsonObject(
+                    mapOf(
+                        "jwt" to JsonArray(proofs)
+                    )
+                )
+            }
+        )
+
+        val format = state.format
+        when (format) {
+            CredentialFormat.SD_JWT_VC -> {
+                request["format"] = JsonPrimitive("vc+sd-jwt")
+                request["vct"] = JsonPrimitive(FunkeUtil.SD_JWT_VCT)
+            }
+            CredentialFormat.MDOC_MSO -> {
+                request["format"] = JsonPrimitive("mso_mdoc")
+                request["doctype"] = JsonPrimitive("eu.europa.ec.eudi.pid.1")
+            }
+            null -> throw IllegalStateException("Credential format was not specified")
+        }
+
+        val token = Json.parseToJsonElement(document.token!!) as JsonObject
+        val accessToken = token["access_token"]!!.jsonPrimitive.content
+        val credentialUrl = "${FunkeUtil.BASE_URL}/c/credential"
+        val dpop = FunkeUtil.generateDPoP(env, clientId, credentialUrl, document.dpopNonce!!, accessToken)
+        val httpClient = env.getInterface(HttpClient::class)!!
+        val credentialResponse = httpClient.post(credentialUrl) {
+            headers {
+                append("Authorization", "DPoP $accessToken")
+                append("DPoP", dpop)
+                append("Content-Type", "application/json")
+            }
+            setBody(JsonObject(request).toString())
+        }
+        if (credentialResponse.status != HttpStatusCode.OK) {
+            val responseText = String(credentialResponse.readBytes())
+            Logger.e(TAG, "Credential request error: ${credentialResponse.status} $responseText")
+            throw IllegalStateException("Credential request error")
+        }
+        Logger.i(TAG, "Got successful response for credential request")
+        val responseText = String(credentialResponse.readBytes())
+
+        val response = Json.parseToJsonElement(responseText) as JsonObject
+        val credentials = if (proofs.size == 1) {
+            JsonArray(listOf(response["credential"]!!))
+        } else {
+            response["credentials"] as JsonArray
+        }
+        check(credentials.size == state.credentialRequests!!.size)
+        document.credentials.addAll(credentials.zip(state.credentialRequests!!).map {
+            val credential = it.first.jsonPrimitive.content
+            val publicKey = it.second.request.secureAreaBoundKeyAttestation.publicKey
+            val now = Clock.System.now()
+            // TODO: where do we get this in SD-JWT world?
+            val expiration = Clock.System.now() + 14.days
+            when (format) {
+                CredentialFormat.SD_JWT_VC ->
+                    CredentialData(publicKey, now, expiration, CredentialFormat.SD_JWT_VC, credential.toByteArray())
+                CredentialFormat.MDOC_MSO ->
+                    CredentialData(publicKey, now, expiration, CredentialFormat.MDOC_MSO, credential.fromBase64())
+            }
+        })
+        updateIssuerDocument(env, state.documentId, document, true)
     }
 
     @FlowMethod
     suspend fun getCredentials(env: FlowEnvironment, documentId: String): List<CredentialData> {
-        // TODO
-        throw RuntimeException()
+        return loadIssuerDocument(env, documentId).credentials
     }
 
     @FlowMethod
@@ -179,8 +349,6 @@ class FunkeIssuingAuthorityState(
         requestRemoteDeletion: Boolean,
         notifyApplicationOfUpdate: Boolean
     ) {
-        // TODO
-        throw RuntimeException()
     }
 
     private suspend fun issuerDocumentExists(env: FlowEnvironment, documentId: String): Boolean {
@@ -239,5 +407,90 @@ class FunkeIssuingAuthorityState(
         if (emitNotification) {
             emit(env, IssuingAuthorityNotification(documentId))
         }
+    }
+
+    private suspend fun performPushedAuthorizationRequest(env: FlowEnvironment, pkceCodeVerifier: String): String {
+        val codeChallenge = Crypto.digest(Algorithm.SHA256, pkceCodeVerifier.toByteArray()).toBase64()
+        val assertion = FunkeUtil.createParJwtAssertion(env, clientId)
+        val req = FormUrlEncoder {
+            add("client_assertion_type", "urn:ietf:params:oauth:client-assertion-type:jwt-client-attestation")
+            add("scope", "pid")
+            add("response_type", "code")
+            add("code_challenge_method", "S256")
+            add("redirect_uri", "https://secure.redirect.com")  // TODO: It's arbitrary in our case, right?
+            add("client_assertion", assertion)
+            add("code_challenge", codeChallenge)
+            add("client_id", FunkeUtil.CLIENT_ID)
+        }
+        val httpClient = env.getInterface(HttpClient::class)!!
+        val response = httpClient.post("${FunkeUtil.BASE_URL}/c/par") {
+            headers {
+                append("Content-Type", "application/x-www-form-urlencoded")
+            }
+            setBody(req.toString())
+        }
+        if (response.status != HttpStatusCode.Created) {
+            Logger.e(TAG, "PAR request error: ${response.status}")
+            throw IllegalStateException("PAR request error")
+        }
+        val parsedResponse = Json.parseToJsonElement(String(response.readBytes())) as JsonObject
+        val requestUri = parsedResponse["request_uri"]
+        if (requestUri !is JsonPrimitive) {
+            Logger.e(TAG, "PAR response error")
+            throw IllegalStateException("PAR response error")
+        }
+        Logger.i(TAG, "Request uri: $requestUri")
+        return "${FunkeUtil.BASE_URL}/c/authorize?" + FormUrlEncoder {
+            add("client_id", FunkeUtil.CLIENT_ID)
+            add("request_uri", requestUri.content)
+        }
+    }
+
+    private suspend fun generateDocumentConfiguration(
+        env: FlowEnvironment
+    ): DocumentConfiguration {
+        val artPath = "funke/card_art.png"
+        val art = env.getInterface(Resources::class)!!.getRawResource(artPath)!!
+
+        return when (credentialFormat) {
+            CredentialFormat.SD_JWT_VC ->
+                DocumentConfiguration(
+                    "Funke",
+                    "Personal ID (SD-JWT)",
+                    art.toByteArray(),
+                    false,
+                    null,
+                    SdJwtVcDocumentConfiguration(FunkeUtil.SD_JWT_VCT)
+                )
+            CredentialFormat.MDOC_MSO -> DocumentConfiguration(
+                "Funke",
+                "Personal ID (MDOC)",
+                art.toByteArray(),
+                false,
+                MdocDocumentConfiguration(
+                    EUPersonalID.EUPID_DOCTYPE,
+                    staticData = fillInSampleData(
+                        documentTypeRepository.getDocumentTypeForMdoc(EUPersonalID.EUPID_DOCTYPE)!!
+                    ).build()
+                ),
+                null
+            )
+        }
+    }
+
+    private fun fillInSampleData(documentType: DocumentType): NameSpacedData.Builder {
+        val builder = NameSpacedData.Builder()
+        for ((namespaceName, namespace) in documentType.mdocDocumentType!!.namespaces) {
+            for ((dataElementName, dataElement) in namespace.dataElements) {
+                if (dataElement.attribute.sampleValue != null) {
+                    builder.putEntry(
+                        namespaceName,
+                        dataElementName,
+                        Cbor.encode(dataElement.attribute.sampleValue!!)
+                    )
+                }
+            }
+        }
+        return builder
     }
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
@@ -1,14 +1,34 @@
 package com.android.identity.issuance.funke
 
 import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.crypto.Crypto
 import com.android.identity.flow.annotation.FlowMethod
 import com.android.identity.flow.annotation.FlowState
 import com.android.identity.flow.server.FlowEnvironment
 import com.android.identity.issuance.ProofingFlow
 import com.android.identity.issuance.evidence.EvidenceRequest
 import com.android.identity.issuance.evidence.EvidenceRequestGermanEid
+import com.android.identity.issuance.evidence.EvidenceRequestQuestionMultipleChoice
+import com.android.identity.issuance.evidence.EvidenceRequestSetupCloudSecureArea
 import com.android.identity.issuance.evidence.EvidenceResponse
 import com.android.identity.issuance.evidence.EvidenceResponseGermanEid
+import com.android.identity.issuance.evidence.EvidenceResponseQuestionMultipleChoice
+import com.android.identity.issuance.evidence.EvidenceResponseSetupCloudSecureArea
+import com.android.identity.securearea.PassphraseConstraints
+import com.android.identity.util.Logger
+import com.android.identity.util.toBase64
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import java.net.URLEncoder
+import kotlin.random.Random
 
 
 @FlowState(
@@ -16,22 +36,114 @@ import com.android.identity.issuance.evidence.EvidenceResponseGermanEid
 )
 @CborSerializable
 class FunkeProofingState(
+    val clientId: String,
     val documentId: String,
-    var evidence: EvidenceResponseGermanEid? = null
+    val tcTokenUrl: String,
+    val pkceCodeVerifier: String,
+    var dpopNonce: String? = null,
+    var token: String? = null,
+    var secureAreaIdentifier: String? = null,
+    var secureAreaPinSet: Boolean = false
 ) {
-    companion object
+    companion object {
+        private const val TAG = "FunkeProofingState"
+    }
 
     @FlowMethod
     fun getEvidenceRequests(env: FlowEnvironment): List<EvidenceRequest> {
-        return if (evidence != null) {
-            emptyList()
+        return if (token == null) {
+            listOf(EvidenceRequestGermanEid(tcTokenUrl, listOf()))
+        } else if (secureAreaIdentifier == null) {
+            listOf(
+                EvidenceRequestQuestionMultipleChoice(
+                    message = "Choose Secure Area",
+                    assets = emptyMap(),
+                    possibleValues = mapOf(
+                        "android" to "Android Secure Area (Option C)",
+                        "cloud" to "Cloud Secure Area (Option C')"
+                    ),
+                    acceptButtonText = "Continue"
+                )
+            )
+        } else if (secureAreaIdentifier!!.startsWith("CloudSecureArea?") && !secureAreaPinSet) {
+            listOf(
+                EvidenceRequestSetupCloudSecureArea(
+                    cloudSecureAreaIdentifier = secureAreaIdentifier!!,
+                    passphraseConstraints = PassphraseConstraints.PIN_SIX_DIGITS,
+                    message = "## Choose 6-digit PIN\n\nChoose the PIN to use for the document.\n\nThis is asked every time the document is presented so make sure you memorize it and don't share it with anyone else.",
+                    verifyMessage = "## Verify PIN\n\nEnter the PIN you chose in the previous screen.",
+                    assets = emptyMap()
+                )
+            )
         } else {
-            listOf(EvidenceRequestGermanEid(listOf()))
+            emptyList()
         }
     }
 
     @FlowMethod
     suspend fun sendEvidence(env: FlowEnvironment, evidenceResponse: EvidenceResponse) {
-        evidence = evidenceResponse as EvidenceResponseGermanEid
+        when (evidenceResponse) {
+            is EvidenceResponseGermanEid -> processGermanEId(env, evidenceResponse)
+            is EvidenceResponseQuestionMultipleChoice -> {
+                secureAreaIdentifier = if (evidenceResponse.answerId == "cloud") {
+                    "CloudSecureArea?id=${documentId}&url=/csa"
+                } else {
+                    "AndroidKeystoreSecureArea"
+                }
+            }
+            is EvidenceResponseSetupCloudSecureArea -> {
+                secureAreaPinSet = true
+                check(evidenceResponse.success)
+            }
+            else -> throw IllegalArgumentException("Unexpected evidence type")
+        }
+    }
+
+    private suspend fun processGermanEId(
+        env: FlowEnvironment,
+        evidenceResponse: EvidenceResponseGermanEid
+    ) {
+        token = ""
+        if (evidenceResponse.url == null) {
+            // Error
+            return
+        }
+        val httpClient = env.getInterface(HttpClient::class)!!
+        val response = httpClient.get(evidenceResponse.url) {
+
+        }
+        val dpopNonce = response.headers["DPoP-Nonce"]
+        val location = response.headers["Location"]
+        val code = location!!.substring(location.indexOf("code=") + 5)
+        if (dpopNonce == null) {
+            // Error
+            return
+        }
+        val tokenUrl = "${FunkeUtil.BASE_URL}/c/token"
+        val dpop = FunkeUtil.generateDPoP(env, clientId, tokenUrl, dpopNonce)
+        val tokenRequest = FormUrlEncoder {
+            add("code", code)
+            add("grant_type", "authorization_code")
+            add("redirect_uri", "https://secure.redirect.com")  // TODO: It's arbitrary in our case, right?
+            add("code_verifier", pkceCodeVerifier)
+        }
+        val tokenResponse = httpClient.post(tokenUrl) {
+            headers {
+                append("DPoP", dpop)
+                append("Content-Type", "application/x-www-form-urlencoded")
+            }
+            setBody(tokenRequest.toString())
+        }
+        if (tokenResponse.status != HttpStatusCode.OK) {
+            Logger.e(TAG, "Token request error: ${response.status}")
+            throw IllegalStateException("Token request error")
+        }
+        this.dpopNonce = tokenResponse.headers["DPoP-Nonce"]
+        if (this.dpopNonce == null) {
+            Logger.e(TAG, "No DPoP nonce in token response")
+            throw IllegalStateException("No DPoP nonce in token response")
+        }
+        this.token = String(tokenResponse.readBytes())
+        Logger.i(TAG, "Token request: got DPoP nonce and a token")
     }
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeRequestCredentialsState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeRequestCredentialsState.kt
@@ -1,28 +1,83 @@
 package com.android.identity.issuance.funke
 
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborMap
 import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.crypto.EcCurve
 import com.android.identity.flow.annotation.FlowMethod
 import com.android.identity.flow.annotation.FlowState
 import com.android.identity.flow.server.FlowEnvironment
 import com.android.identity.issuance.CredentialConfiguration
 import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.CredentialRequest
+import com.android.identity.issuance.KeyPossessionChallenge
+import com.android.identity.issuance.KeyPossessionProof
 import com.android.identity.issuance.RequestCredentialsFlow
+import com.android.identity.securearea.KeyPurpose
+import com.android.identity.util.toBase64
+import kotlinx.datetime.Clock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
 
 @FlowState(
     flowInterface = RequestCredentialsFlow::class
 )
 @CborSerializable
-class FunkeRequestCredentialsState {
+class FunkeRequestCredentialsState(
+    val documentId: String = "",
+    val credentialConfiguration: CredentialConfiguration,
+    val nonce: String,
+    var format: CredentialFormat? = null,
+    var credentialRequests: List<FunkeCredentialRequest>? = null
+) {
     companion object
 
     @FlowMethod
-    fun getCredentialConfiguration(env: FlowEnvironment, format: CredentialFormat): CredentialConfiguration {
-        throw RuntimeException()
+    fun getCredentialConfiguration(
+        env: FlowEnvironment,
+        format: CredentialFormat
+    ): CredentialConfiguration {
+        this.format = format
+        return credentialConfiguration
     }
 
     @FlowMethod
-    fun sendCredentials(env: FlowEnvironment, credentialRequests: List<CredentialRequest>) {
-        throw RuntimeException()
+    fun sendCredentials(
+        env: FlowEnvironment,
+        newCredentialRequests: List<CredentialRequest>
+    ): List<KeyPossessionChallenge> {
+        if (credentialRequests != null) {
+            throw IllegalStateException("Credentials were already sent")
+        }
+        val requests = newCredentialRequests.map { request ->
+            val header = JsonObject(mapOf(
+                "typ" to JsonPrimitive("openid4vci-proof+jwt"),
+                "alg" to JsonPrimitive("ES256"),
+                "jwk" to request.secureAreaBoundKeyAttestation.publicKey.toJson(null)
+            )).toString().toByteArray().toBase64()
+            val body = JsonObject(mapOf(
+                "iss" to JsonPrimitive(FunkeUtil.CLIENT_ID),
+                "aud" to JsonPrimitive(FunkeUtil.BASE_URL + "/c"),
+                "iat" to JsonPrimitive(Clock.System.now().epochSeconds),
+                "nonce" to JsonPrimitive(nonce)
+            )).toString().toByteArray().toBase64()
+            FunkeCredentialRequest(request, format!!, "$header.$body")
+        }
+        credentialRequests = requests
+        return requests.map {
+            KeyPossessionChallenge(ByteString(it.proofOfPossessionJwtHeaderAndBody.toByteArray()))
+        }
+    }
+
+    @FlowMethod
+    fun sendPossessionProofs(env: FlowEnvironment, keyPossessionProofs: List<KeyPossessionProof>) {
+        if (keyPossessionProofs.size != credentialRequests?.size) {
+            throw IllegalStateException("wrong number of key possession proofs: ${keyPossessionProofs.size}")
+        }
+        credentialRequests!!.zip(keyPossessionProofs).map {
+            it.first.proofOfPossessionJwtSignature = it.second.signature.toByteArray().toBase64()
+        }
     }
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
@@ -1,0 +1,101 @@
+package com.android.identity.issuance.funke
+
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+import com.android.identity.flow.server.FlowEnvironment
+import com.android.identity.sdjwt.util.JsonWebKey
+import com.android.identity.securearea.CreateKeySettings
+import com.android.identity.securearea.KeyInfo
+import com.android.identity.securearea.SecureArea
+import com.android.identity.util.toBase64
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.random.Random
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.seconds
+
+internal object FunkeUtil {
+    const val BASE_URL = "https://demo.pid-issuer.bundesdruckerei.de"
+    const val CLIENT_ID = "fed79862-af36-4fee-8e64-89e3c91091ed"
+    const val SD_JWT_VCT = "urn:eu.europa.ec.eudi:pid:1"
+
+    private val keyCreationMutex = Mutex()
+
+    suspend fun communicationKey(env: FlowEnvironment, clientId: String): KeyInfo {
+        val secureArea = env.getInterface(SecureArea::class)!!
+        val alias = "FunkeComm_" + clientId
+        return try {
+            secureArea.getKeyInfo(alias)
+        } catch (_: Exception) {
+            keyCreationMutex.withLock {
+                try {
+                    secureArea.getKeyInfo(alias)
+                } catch (_: Exception) {
+                    secureArea.createKey(alias, CreateKeySettings())
+                    secureArea.getKeyInfo(alias)
+                }
+            }
+        }
+    }
+
+    fun communicationSign(env: FlowEnvironment, clientId: String, message: ByteArray): ByteArray {
+        val secureArea = env.getInterface(SecureArea::class)!!
+        val alias = "FunkeComm_" + clientId
+        val sig = secureArea.sign(alias, Algorithm.ES256, message, null)
+        return sig.toCoseEncoded()
+    }
+
+    suspend fun createParJwtAssertion(env: FlowEnvironment, clientId: String): String {
+        val now = Clock.System.now()
+        val notBefore = now - 1.seconds
+        val exp = now + 1.days
+        val keyInfo = communicationKey(env, clientId).publicKey.toJson(clientId)
+        val payload = JsonObject(mapOf(
+            "iss" to JsonPrimitive(CLIENT_ID),
+            "sub" to JsonPrimitive(clientId),
+            "cnf" to JsonObject(mapOf(
+                "jwk" to keyInfo
+            )),
+            "nbf" to JsonPrimitive(notBefore.epochSeconds),
+            "exp" to JsonPrimitive(exp.epochSeconds),
+            "iat" to JsonPrimitive(now.epochSeconds)
+        )).toString().toByteArray().toBase64()
+        // TODO: get our JWT signed by our server once it is implemented and keys are issued
+        val head = "eyJ0eXAiOiJKV1QiLCJhbGciOiJQUzI1NiIsImp3ayI6eyJrdHkiOiJSU0EiLCJlIjoiQVFBQiIsIm4iOiJpOHVFQXFFNUFoYnJmcjZLUWdfRDJTenJoOENuS2VxUUx2czNWVFRwNTdQYlZoV3l0MkhjOUV3Uzl6MnFiNHNZX1lpOVRQX24zZlBMc3M1UUtGSzZNUDcwN2hQSjlZNDlaZ3Y0cGV5ak9lWHlrYnNIWFN0ZHNkNXd0QmpoMmJoOHdMdVlTREhtekdJQ3hXWDc0QVFlS25LRTVObC15TUhoWW5PUWwwdW5OWWd6LUQteGZLRGZFR0E0LVdmQXVQQ013Uks5eGNudkM1Q0ZUZngyaTlRS0lYM25ZcWp6MFhETGVobExScGFrQ3RGS1Jjb2ZMeWlXZFN4MUVRazhfX0xCZHZBUV81R1ZtSGROU2RXQ2Z6bmlrQzVndFZGenV4cTY3dFB1ZGtVa1VKNEIxOGRRclI1dnpTaWlYYnVwc19TOWRsbW8zUm8zN3NjV2hkbUZuLVlNR1EifX0"
+        val signature = "CLpyn3ZLAWC3yQsZH62zZt0w0ITeM22zwJuDC4RnGqdFbXGRi3UUYACdA02kFNIvy4lfoA1bveLFq6Y7J0D0TvGT1Ixcr353F6JqO2AjR1zSFDs-f9aYKyCrMSJ2-MfQzzL-sT0j3Pl4mV2JhUy35T08zCRxydKzHlBzS2vX8cctso-kqPVIagbo2f7JyZt68mDAAxzEfeglGlmaOEsomNDc8vegodKE6IgX7CmrEqQhntVkV2e6QvEOoEtzUbSmh5319eseUYQCtmSqO76g4tMVtVj-oE1izdtG_1sk9NdfMddeNCaNIh576cAnSg5lqYT"
+        return "$head.$payload.$signature"
+    }
+
+    suspend fun generateDPoP(
+        env: FlowEnvironment,
+        clientId: String,
+        requestUrl: String,
+        dpopNonce: String,
+        accessToken: String? = null
+    ): String {
+        val keyInfo = communicationKey(env, clientId)
+        val header = buildJsonObject {
+            put("typ", JsonPrimitive("dpop+jwt"))
+            put("alg", JsonPrimitive(keyInfo.publicKey.curve.defaultSigningAlgorithm.jwseAlgorithmIdentifier))
+            put("jwk", keyInfo.publicKey.toJson(clientId))
+        }.toString().toByteArray().toBase64()
+        val bodyMap = mutableMapOf(
+            "htm" to JsonPrimitive("POST"),
+            "htu" to JsonPrimitive(requestUrl),
+            "iat" to JsonPrimitive(Clock.System.now().epochSeconds),
+            "nonce" to JsonPrimitive(dpopNonce),
+            "jti" to JsonPrimitive(Random.Default.nextBytes(15).toBase64())
+        )
+        if (accessToken != null) {
+            bodyMap["ath"] = JsonPrimitive(Crypto.digest(Algorithm.SHA256, accessToken.toByteArray()).toBase64())
+        }
+        val body = JsonObject(bodyMap).toString().toByteArray().toBase64()
+        val message = "$header.$body"
+        val signature = communicationSign(env, clientId, message.toByteArray()).toBase64()
+        return "$message.$signature"
+    }
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/JwtUtils.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/JwtUtils.kt
@@ -1,0 +1,16 @@
+package com.android.identity.issuance.funke
+
+import com.android.identity.crypto.EcPublicKey
+import com.android.identity.sdjwt.util.JsonWebKey
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+internal fun EcPublicKey.toJson(keyId: String?): JsonObject {
+    return JsonWebKey(this).toRawJwk {
+        if (keyId != null) {
+            put("kid", JsonPrimitive(keyId))
+        }
+        put("alg", JsonPrimitive(curve.defaultSigningAlgorithm.jwseAlgorithmIdentifier))
+        put("use", JsonPrimitive("sig"))
+    }
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/IssuingAuthorityState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/IssuingAuthorityState.kt
@@ -130,7 +130,10 @@ class IssuingAuthorityState(
                         requireUserAuthenticationToViewDocument = requireUserAuthenticationToViewDocument,
                         mdocConfiguration = null,
                         sdJwtVcDocumentConfiguration = null
-                    )
+                    ),
+                    numberOfCredentialsToRequest = 3,
+                    minCredentialValidityMillis = 30 * 24 * 3600L,
+                    maxUsesPerCredentials = 1
                 )
             }
         }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/RequestCredentialsState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/RequestCredentialsState.kt
@@ -7,6 +7,8 @@ import com.android.identity.flow.server.FlowEnvironment
 import com.android.identity.issuance.CredentialConfiguration
 import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.CredentialRequest
+import com.android.identity.issuance.KeyPossessionChallenge
+import com.android.identity.issuance.KeyPossessionProof
 import com.android.identity.issuance.RequestCredentialsFlow
 
 /**
@@ -22,7 +24,6 @@ class RequestCredentialsState(
 ) {
     companion object {}
 
-
     @FlowMethod
     fun getCredentialConfiguration(env: FlowEnvironment, format: CredentialFormat): CredentialConfiguration {
         // TODO: make use of the format
@@ -32,7 +33,13 @@ class RequestCredentialsState(
     }
 
     @FlowMethod
-    fun sendCredentials(env: FlowEnvironment, credentialRequests: List<CredentialRequest>) {
+    fun sendCredentials(env: FlowEnvironment, credentialRequests: List<CredentialRequest>): List<KeyPossessionChallenge> {
         this.credentialRequests.addAll(credentialRequests)
+        return emptyList()
+    }
+
+    @FlowMethod
+    fun sendPossessionProofs(env: FlowEnvironment, keyPossessionProofs: List<KeyPossessionProof>) {
+        throw IllegalStateException()  // should not be called
     }
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/proofing/ProofingGraphBuilder.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/proofing/ProofingGraphBuilder.kt
@@ -155,9 +155,9 @@ class ProofingGraphBuilder {
         chain.add { followUp -> ProofingGraph.SimpleNode(id, followUp, evidenceRequest) }
     }
 
-    fun eId(id: String, optionalComponents: List<String> = listOf()) {
+    fun eId(id: String, tcTokenUrl: String, optionalComponents: List<String> = listOf()) {
         chain.add { followUp ->
-            ProofingGraph.SimpleNode(id, followUp, EvidenceRequestGermanEid(optionalComponents))
+            ProofingGraph.SimpleNode(id, followUp, EvidenceRequestGermanEid(tcTokenUrl, optionalComponents))
         }
     }
 

--- a/identity-issuance/src/main/java/com/android/identity/issuance/proofing/defaultGraph.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/proofing/defaultGraph.kt
@@ -58,7 +58,7 @@ fun defaultGraph(
                 }
             }
             on(id = "germanEid", text = "Yes, derive the document from PIN-protected German eID") {
-                eId("germanEidCard")
+                eId("germanEidCard", "https://test.governikus-eid.de/AusweisAuskunft/WebServiceRequesterServlet")
             }
         }
         if (developerModeEnabled) {
@@ -468,7 +468,6 @@ fun defaultCredentialConfiguration(
                         .end().build()
                 )
             )
-
         }
 
         else -> {

--- a/identity-issuance/src/main/java/com/android/identity/issuance/wallet/WalletServerState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/wallet/WalletServerState.kt
@@ -8,6 +8,7 @@ import com.android.identity.flow.handler.FlowDispatcherLocal
 import com.android.identity.flow.server.Configuration
 import com.android.identity.flow.server.Resources
 import com.android.identity.flow.server.FlowEnvironment
+import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.DocumentConfiguration
 import com.android.identity.issuance.IssuingAuthorityConfiguration
 import com.android.identity.issuance.WalletServer
@@ -54,7 +55,10 @@ class WalletServerState(
                     requireUserAuthenticationToViewDocument = true,
                     mdocConfiguration = null,
                     sdJwtVcDocumentConfiguration = null
-                )
+                ),
+                numberOfCredentialsToRequest = 3,
+                minCredentialValidityMillis = 30 * 24 * 3600L,
+                maxUsesPerCredentials = 1
             )
         }
 
@@ -96,14 +100,18 @@ class WalletServerState(
                 IssuingAuthorityState.getConfiguration(env, idElem)
             }
         }
-        return fromConfig + listOf(FunkeIssuingAuthorityState.getConfiguration(env))
+        return fromConfig + listOf(
+            FunkeIssuingAuthorityState.getConfiguration(env, CredentialFormat.SD_JWT_VC),
+            FunkeIssuingAuthorityState.getConfiguration(env, CredentialFormat.MDOC_MSO)
+        )
     }
 
     @FlowMethod
     fun getIssuingAuthority(env: FlowEnvironment, identifier: String): AbstractIssuingAuthorityState {
         check(clientId.isNotEmpty())
         return when (identifier) {
-            "funke" -> FunkeIssuingAuthorityState(clientId)
+            "funkeSdJwtVc" -> FunkeIssuingAuthorityState(clientId, CredentialFormat.SD_JWT_VC)
+            "funkeMdocMso" -> FunkeIssuingAuthorityState(clientId, CredentialFormat.MDOC_MSO)
             else -> IssuingAuthorityState(clientId, identifier)
         }
     }

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/mso/StaticAuthDataParser.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/mso/StaticAuthDataParser.kt
@@ -73,7 +73,11 @@ class StaticAuthDataParser(private val encodedStaticAuthData: ByteArray) {
         internal fun parse(encodedStaticAuthData: ByteArray) =
             Cbor.decode(encodedStaticAuthData).run {
                 issuerAuth = Cbor.encode(this["issuerAuth"])
-                parseDigestIdMapping(this["digestIdMapping"])
+                if (this.hasKey("digestIdMapping")) {
+                    parseDigestIdMapping(this["digestIdMapping"])
+                } else if (this.hasKey("nameSpaces")) {
+                    parseDigestIdMapping(this["nameSpaces"])
+                }
             }
 
     }

--- a/identity-sdjwt/src/main/java/com/android/identity/sdjwt/util/JsonWebKey.kt
+++ b/identity-sdjwt/src/main/java/com/android/identity/sdjwt/util/JsonWebKey.kt
@@ -7,6 +7,7 @@ import com.android.identity.crypto.EcPublicKeyOkp
 import com.android.identity.util.fromBase64
 import com.android.identity.util.toBase64
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
@@ -46,23 +47,28 @@ class JsonWebKey {
 
     val asJwk: JsonObject
         get() = buildJsonObject {
-            put("jwk", buildJsonObject {
-                when (pubKey) {
-                    is EcPublicKeyOkp -> {
-                        put("kty", JsonPrimitive("OKP"))
-                        put("crv", JsonPrimitive(pubKey.curve.jwkName))
-                        put("x", JsonPrimitive(pubKey.x.toBase64()))
-                    }
-                    is EcPublicKeyDoubleCoordinate -> {
-                        put("kty", JsonPrimitive("EC"))
-                        put("crv", JsonPrimitive(pubKey.curve.jwkName))
-                        put("x", JsonPrimitive(pubKey.x.toBase64()))
-                        put("y", JsonPrimitive(pubKey.y.toBase64()))
-                    }
-                    else -> throw IllegalStateException("Unsupported key $pubKey")
-                }
-            })
+            put("jwk", toRawJwk {})
         }
+
+    fun toRawJwk(block: JsonObjectBuilder.() -> Unit): JsonObject {
+        return buildJsonObject {
+            when (pubKey) {
+                is EcPublicKeyOkp -> {
+                    put("kty", JsonPrimitive("OKP"))
+                    put("crv", JsonPrimitive(pubKey.curve.jwkName))
+                    put("x", JsonPrimitive(pubKey.x.toBase64()))
+                }
+                is EcPublicKeyDoubleCoordinate -> {
+                    put("kty", JsonPrimitive("EC"))
+                    put("crv", JsonPrimitive(pubKey.curve.jwkName))
+                    put("x", JsonPrimitive(pubKey.x.toBase64()))
+                    put("y", JsonPrimitive(pubKey.y.toBase64()))
+                }
+                else -> throw IllegalStateException("Unsupported key $pubKey")
+            }
+            block()
+        }
+    }
 
     private companion object {
 

--- a/server/src/main/java/com/android/identity/wallet/server/ServerEnvironment.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/ServerEnvironment.kt
@@ -29,7 +29,9 @@ class ServerEnvironment(
         settings.databaseConnection ?: defaultDatabase(),
         settings.databaseUser ?: "",
         settings.databasePassword ?: "")
-    private val httpClient = HttpClient(Java)
+    private val httpClient = HttpClient(Java) {
+        followRedirects = false
+    }
     private val secureArea = SoftwareSecureArea(StorageAdapter(storage, "ServerKeys"))
     internal var notifications: FlowNotifications? = null
 

--- a/wallet/src/main/java/com/android/identity/issuance/remote/LocalDevelopmentEnvironment.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/LocalDevelopmentEnvironment.kt
@@ -32,7 +32,9 @@ class LocalDevelopmentEnvironment(
     private val configuration = ConfigurationImpl(context)
     private val storage = StorageImpl(context, "dev_local_data")
     private val resources = ResourcesImpl(context)
-    private val httpClient = HttpClient(Android)
+    private val httpClient = HttpClient(Android) {
+        followRedirects = false
+    }
 
     override fun <T : Any> getInterface(clazz: KClass<T>): T? {
         return clazz.cast(when(clazz) {

--- a/wallet/src/main/java/com/android/identity/issuance/simple/SimpleIssuingAuthorityRequestCredentialsFlow.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/simple/SimpleIssuingAuthorityRequestCredentialsFlow.kt
@@ -4,6 +4,8 @@ import com.android.identity.cbor.DataItem
 import com.android.identity.issuance.CredentialConfiguration
 import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.CredentialRequest
+import com.android.identity.issuance.KeyPossessionChallenge
+import com.android.identity.issuance.KeyPossessionProof
 import com.android.identity.issuance.RequestCredentialsFlow
 
 class SimpleIssuingAuthorityRequestCredentialsFlow(
@@ -18,9 +20,14 @@ class SimpleIssuingAuthorityRequestCredentialsFlow(
         return credentialConfiguration
     }
 
-    override suspend fun sendCredentials(credentialRequests: List<CredentialRequest>) {
+    override suspend fun sendCredentials(credentialRequests: List<CredentialRequest>): List<KeyPossessionChallenge> {
         // TODO: should check attestations
         issuingAuthority.addCpoRequests(documentId, format, credentialRequests)
+        return emptyList()
+    }
+
+    override suspend fun sendPossessionProofs(keyPossessionProofs: List<KeyPossessionProof>) {
+        throw UnsupportedOperationException()
     }
 
     override suspend fun complete() {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
@@ -59,6 +59,12 @@ class MainActivity : FragmentActivity() {
     override fun onStart() {
         super.onStart()
         application.settingsModel.updateScreenLockIsSetup()
+        application.documentModel.attachToActivity(this)
+    }
+
+    override fun onStop() {
+        super.onStop()
+        application.documentModel.detachFromActivity(this)
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedEuPidIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedEuPidIssuingAuthority.kt
@@ -64,7 +64,10 @@ class SelfSignedEuPidIssuingAuthority(
                     requireUserAuthenticationToViewDocument = false,
                     mdocConfiguration = null,
                     sdJwtVcDocumentConfiguration = null
-                )
+                ),
+                numberOfCredentialsToRequest = 3,
+                minCredentialValidityMillis = 30 * 24 * 3600L,
+                maxUsesPerCredentials = 1
             )
         }
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdlIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedMdlIssuingAuthority.kt
@@ -63,7 +63,10 @@ class SelfSignedMdlIssuingAuthority(
                     requireUserAuthenticationToViewDocument = false,
                     mdocConfiguration = null,
                     sdJwtVcDocumentConfiguration = null
-                )
+                ),
+                numberOfCredentialsToRequest = 3,
+                minCredentialValidityMillis = 30 * 24 * 3600L,
+                maxUsesPerCredentials = 1
             )
         }
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -200,6 +200,7 @@ class WalletApplication : Application() {
 
         documentModel = DocumentModel(
             applicationContext,
+
             settingsModel,
             documentStore,
             secureAreaRepository,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/AusweisModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/AusweisModel.kt
@@ -35,6 +35,7 @@ class AusweisModel(
     private val context: Context,
     private val status: MutableState<Status?>,
     private val navController: NavController,
+    private val tcTokenUrl: String,
     private val requiredComponents: List<String>,
     private val coroutineScope: CoroutineScope,
     private val onResult: (result: EvidenceResponseGermanEid) -> Unit
@@ -160,7 +161,7 @@ class AusweisModel(
             sdk.send(sessionId, """
                 {
                   "cmd": "RUN_AUTH",
-                  "tcTokenURL": "https://test.governikus-eid.de/AusweisAuskunft/WebServiceRequesterServlet",
+                  "tcTokenURL": "$tcTokenUrl",
                   "developerMode": $useSimulatedCard,
                   "handleInterrupt": false,
                   "status": true

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/EvidenceRequest.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/EvidenceRequest.kt
@@ -1030,6 +1030,7 @@ fun EvidenceRequestEIdView(
     permissionTracker: PermissionTracker
 ) {
     AusweisView(
+        evidenceRequest.tcTokenUrl,
         evidenceRequest.optionalComponents,
         permissionTracker
     ) { evidence ->
@@ -1043,6 +1044,7 @@ fun EvidenceRequestEIdView(
 
 @Composable
 fun AusweisView(
+    tcTokenUrl: String,
     requiredComponents: List<String>,
     permissionTracker: PermissionTracker,
     onResult: (evidence: EvidenceResponseGermanEid) -> Unit
@@ -1056,6 +1058,7 @@ fun AusweisView(
             context,
             status,
             navController,
+            tcTokenUrl,
             requiredComponents,
             coroutineScope,
             onResult
@@ -1131,6 +1134,11 @@ fun AusweisView(
                                 "FamilyName" -> stringResource(R.string.eid_access_right_last_name)
                                 "BirthName" -> stringResource(R.string.eid_access_right_maiden_name)
                                 "DateOfBirth" -> stringResource(R.string.eid_access_right_date_of_birth)
+                                "Address" -> stringResource(R.string.eid_access_right_address)
+                                "Nationality" -> stringResource(R.string.eid_access_right_nationality)
+                                "PlaceOfBirth" -> stringResource(R.string.eid_access_right_place_of_birth)
+                                "Pseudonym" -> stringResource(R.string.eid_access_right_pseudonym)
+                                "AgeVerification" -> stringResource(R.string.eid_access_right_age_verification)
                                 // TODO: all others
                                 else -> "Item [$component]"
                             },

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -200,6 +200,10 @@
     <string name="presentation_result_error_message">An error occurred</string>
 
 
+    <!-- Credential issuance -->
+    <string name="issuance_biometric_prompt_title">Use your screen lock</string>
+    <string name="issuance_biometric_prompt_subtitle">Authentication is required to bind issued credential to this device</string>
+
     <!-- QR screen -->
     <string name="qr_title">Share using QR code</string>
     <string name="qr_instructions">Present QR code to verifier</string>
@@ -260,6 +264,11 @@
     <string name="eid_access_right_last_name">Last name</string>
     <string name="eid_access_right_maiden_name">Birth (maiden) name</string>
     <string name="eid_access_right_date_of_birth">Date of birth</string>
+    <string name="eid_access_right_place_of_birth">Place of birth</string>
+    <string name="eid_access_right_address">Address</string>
+    <string name="eid_access_right_nationality">Nationality</string>
+    <string name="eid_access_right_pseudonym">Pseudonym</string>
+    <string name="eid_access_right_age_verification">Age</string>
     <string name="eid_access_right_allow">Allow</string>
     <string name="eid_nfc_scanning">Scanning eID using NFC</string>
     <string name="eid_enter_pin">Enter your PIN</string>

--- a/wallet/src/test/java/com/android/identity_credential/wallet/TestIssuingAuthority.kt
+++ b/wallet/src/test/java/com/android/identity_credential/wallet/TestIssuingAuthority.kt
@@ -47,7 +47,10 @@ class TestIssuingAuthority: SimpleIssuingAuthority(EphemeralStorageEngine(), {})
                     NameSpacedData.Builder().build(),
                 ),
                 sdJwtVcDocumentConfiguration = null,
-            )
+            ),
+            maxUsesPerCredentials = 1,
+            minCredentialValidityMillis = 1000L,
+            numberOfCredentialsToRequest = 3
         )
 
         // This is used in testing, see SelfSignedMdlTest


### PR DESCRIPTION
Added two new issuing authority instances, one for Funke sd-jwt, the other for mdoc. Added tweaks to the issuance protocol and DocumentModel so that both our existing issuance and Funke option C work correctly. Option C' (Cloud Secure Area) also works, but requires standalone (not built-in) wallet server due to lack of separate configuration. 
