### PR TITLE
Ask the user to enable Bluetooth if it's disabled, when sharing a QR code

### DIFF
--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -393,5 +393,8 @@
     <string name="selfie_instructions_finishing_video">Thank you. Finishing video...</string>
     <string name="selfie_instructions_smile">Smile</string>
     <string name="selfie_instructions_too_many_faces">Too many faces found. Please ensure you only have one person on camera.</string>
+    <string name="qr_alert_dialog_bt_disabled_title">Bluetooth disabled</string>
+    <string name="qr_alert_dialog_bt_disabled_text">Bluetooth must be enabled to share a QR connection code</string>
+    <string name="qr_alert_dialog_bt_enable_button">Enable</string>
 
 </resources>


### PR DESCRIPTION
Ask the user to enable Bluetooth if it's disabled, when sharing a QR code.

Tested by:
- Manual testing through UI.
- ./gradlew check
- ./gradlew connectedCheck

Fixes #698

- [x] Tests pass
