### PR TITLE
wallet: Make proximity presentations work even if app isn't running.

### DIFF
--- a/wallet/src/main/AndroidManifest.xml
+++ b/wallet/src/main/AndroidManifest.xml
@@ -54,8 +54,10 @@
 
         <activity
             android:name=".PresentationActivity"
+            android:enabled="true"
             android:exported="true"
             android:label="@string/app_name_presentation"
+            android:launchMode="singleInstance"
             android:theme="@android:style/Theme.Translucent.NoTitleBar"
             android:windowSoftInputMode="adjustPan"/>
 
@@ -84,7 +86,7 @@
             android:name=".credman.CredmanPresentationActivity"
             android:enabled="true"
             android:exported="true"
-            android:theme="@android:style/Theme.Translucent.NoTitleBar.Fullscreen">
+            android:theme="@android:style/Theme.Translucent.NoTitleBar">
             <intent-filter>
                 <action android:name="androidx.identitycredentials.action.GET_CREDENTIALS" />
                 <category android:name="android.intent.category.DEFAULT" />

--- a/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
@@ -17,7 +17,6 @@ import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
 import com.android.identity.util.Logger
 import com.android.identity.util.UUID
-import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.launch
 
 class QrEngagementViewModel(val context: Application) : AndroidViewModel(context)  {
@@ -52,6 +51,7 @@ class QrEngagementViewModel(val context: Application) : AndroidViewModel(context
 
                     override fun onDeviceConnecting() {
                         Logger.i(TAG, "onDeviceConnecting")
+                        PresentationActivity.engagementDetected(context)
                     }
 
                     override fun onDeviceConnected(transport: DataTransport) {

--- a/wallet/src/main/res/drawable/waiting_for_reader.xml
+++ b/wallet/src/main/res/drawable/waiting_for_reader.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="137dp" android:tint="#6C6CF6" android:viewportHeight="24" android:viewportWidth="24" android:width="137dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M18,4H6C3.79,4 2,5.79 2,8v8c0,2.21 1.79,4 4,4h12c2.21,0 4,-1.79 4,-4V8C22,5.79 20.21,4 18,4zM16.14,13.77c-0.24,0.2 -0.57,0.28 -0.88,0.2L4.15,11.25C4.45,10.52 5.16,10 6,10h12c0.67,0 1.26,0.34 1.63,0.84L16.14,13.77zM6,6h12c1.1,0 2,0.9 2,2v0.55C19.41,8.21 18.73,8 18,8H6C5.27,8 4.59,8.21 4,8.55V8C4,6.9 4.9,6 6,6z"/>
+    
+</vector>

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -196,8 +196,10 @@
     <string name="presentation_lskf_warning_dismiss_btn">Ok</string>
     <string name="presentation_lskf_warning_dialog_title">Unable to Present Document</string>
     <string name="presentation_lskf_warning_dialog_text">In order to present the document, your device must have a lock-screen pin/password/pattern</string>
+    <string name="presentation_waiting_for_reader">Waiting for reader to connect…</string>
     <string name="presentation_result_success_message">The information was shared</string>
     <string name="presentation_result_error_message">An error occurred</string>
+    <string name="presentation_result_error_message_reader_timeout">Timed out waiting for reader to connect</string>
 
 
     <!-- Credential issuance -->


### PR DESCRIPTION
This change also shows a "Waiting for reader to connect…" right after the NFC tap / QR code scan. This is very helpful for users insofar they see that something in happening sooner.

Also simplify the flow/state management in `PresentationActivity.kt`.

Test: Manually tested.

See [this video](https://photos.app.goo.gl/dqAp6dy9Xy5B19ke7) for an example of what it looks like.