### PR TITLE
Adding logging for presentation activity and corresponding viewer

### DIFF
--- a/wallet/build.gradle.kts
+++ b/wallet/build.gradle.kts
@@ -4,6 +4,7 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.buildconfig)
     alias(libs.plugins.kotlinSerialization)
+    alias(libs.plugins.ksp)
     id("kotlin-android")
 }
 
@@ -79,6 +80,7 @@ android {
 }
 
 dependencies {
+    ksp(project(":processor"))
     implementation(project(":processor-annotations"))
     implementation(project(":identity"))
     implementation(project(":identity-doctypes"))

--- a/wallet/src/main/java/com/android/identity_credential/wallet/EventInfo.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/EventInfo.kt
@@ -1,0 +1,8 @@
+package com.android.identity_credential.wallet
+
+import android.graphics.Bitmap
+
+data class EventInfo(
+    val timestamp: String,
+    val requestedFields: String,
+)

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -61,13 +61,11 @@ import com.android.identity.issuance.DocumentExtensions.documentConfiguration
 import com.android.identity.mdoc.credential.MdocCredential
 import com.android.identity.mdoc.request.DeviceRequestParser
 import com.android.identity.mdoc.response.DeviceResponseGenerator
-import com.android.identity.mdoc.util.MdocUtil
 import com.android.identity.trustmanagement.TrustPoint
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.presentation.UserCanceledPromptException
 import com.android.identity_credential.wallet.presentation.showMdocPresentmentFlow
-import com.android.identity_credential.wallet.ui.prompt.consent.ConsentField
 import com.android.identity_credential.wallet.ui.prompt.consent.MdocConsentField
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
@@ -392,13 +390,25 @@ class PresentationActivity : FragmentActivity() {
                             if (deviceResponseGenerator.isEmpty()) {
                                 throw NoMatchingDocumentException("No documents found.")
                             }
+                            val deviceResponse = deviceResponseGenerator.generate()
                             deviceRetrievalHelper?.sendDeviceResponse(
-                                deviceResponseGenerator.generate(),
+                                deviceResponse,
                                 Constants.SESSION_DATA_STATUS_SESSION_TERMINATION
                             )
                             showResult(
                                 R.string.presentation_result_success_message,
                                 R.drawable.presentment_result_status_success)
+                            resultStringId = R.string.presentation_result_success_message
+                            resultDrawableId = R.drawable.presentment_result_status_success
+                            phase.value = Phase.SHOW_RESULT
+
+                            // Add the PresentationActivity entry
+                            walletApp.eventLogger.addMDocPresentationEntry(
+                                walletApp.settingsModel.focusedCardId.value.toString(),
+                                deviceRetrievalHelper!!.sessionTranscript,
+                                deviceRequestByteArray!!,
+                                deviceResponse
+                            )
                         } catch (e: Throwable) {
                             if (e is UserCanceledPromptException) {
                                 phase.value = Phase.CANCELED

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SettingsModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SettingsModel.kt
@@ -22,6 +22,7 @@ class SettingsModel(
     // Settings that are visible in the Settings screen
     val developerModeEnabled = MutableLiveData(false)
     val loggingEnabled = MutableLiveData(false)
+    val activityLoggingEnabled = MutableLiveData(false)
     val walletServerUrl = MutableLiveData(WalletApplicationConfiguration.WALLET_SERVER_DEFAULT_URL)
     val minServerUrl = MutableLiveData(WalletApplicationConfiguration.MIN_SERVER_DEFAULT_URL)
     val cloudSecureAreaUrl = MutableLiveData(WalletApplicationConfiguration.CLOUD_SECURE_AREA_DEFAULT_URL)
@@ -35,9 +36,9 @@ class SettingsModel(
 
     companion object {
         private const val TAG = "SettingsModel"
-        
         private const val PREFERENCE_DEVELOPER_MODE_ENABLED = "developer_mode_enabled"
         private const val PREFERENCE_LOGGING_ENABLED = "logging_enabled"
+        private const val PREFERENCE_ACTIVITY_LOGGING_ENABLED = "activity_logging_enabled"
         private const val PREFERENCE_WALLET_SERVER_URL = "wallet_server_url"
         private const val PREFERENCE_MIN_SERVER_URL = "min_server_url"
         private const val PREFERENCE_CLOUD_SECURE_AREA_URL = "cloud_secure_area_url"
@@ -96,7 +97,7 @@ class SettingsModel(
             if (logToFile) {
                 SystemFileSystem.createDirectories(logDir)
                 Logger.startLoggingToFile(logFile)
-                Logger.i(TAG, "Started logging to a file")
+                Logger.i(TAG, "Started logging to a file $logFile")
             } else {
                 Logger.i(TAG, "Stopped logging to a file")
                 Logger.stopLoggingToFile()
@@ -124,6 +125,18 @@ class SettingsModel(
             }
         }
 
+        // Observe changes to Activity Logging and save to SharedPreferences
+        this.activityLoggingEnabled.value = sharedPreferences.getBoolean(PREFERENCE_ACTIVITY_LOGGING_ENABLED, true)
+        this.activityLoggingEnabled.observeForever { activityLogging ->
+            sharedPreferences.edit {
+                putBoolean(PREFERENCE_ACTIVITY_LOGGING_ENABLED, activityLogging)
+            }
+            if (activityLogging) {
+                walletApplication.eventLogger.startLoggingEvents()
+            } else {
+                walletApplication.eventLogger.stopLoggingEvents()
+            }
+        }
         updateScreenLockIsSetup()
     }
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -47,6 +47,7 @@ import com.android.identity.storage.StorageEngine
 import com.android.identity.trustmanagement.TrustManager
 import com.android.identity.trustmanagement.TrustPoint
 import com.android.identity.util.Logger
+import com.android.identity_credential.wallet.logging.EventLogger
 import com.android.identity_credential.wallet.util.toByteArray
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -106,6 +107,7 @@ class WalletApplication : Application() {
     lateinit var settingsModel: SettingsModel
     lateinit var documentModel: DocumentModel
     lateinit var readerModel: ReaderModel
+    lateinit var eventLogger: EventLogger
     private lateinit var androidKeystoreSecureArea: AndroidKeystoreSecureArea
     private lateinit var softwareSecureArea: SoftwareSecureArea
     lateinit var walletServerProvider: WalletServerProvider
@@ -123,8 +125,6 @@ class WalletApplication : Application() {
         Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
         Security.addProvider(BouncyCastleProvider())
 
-        settingsModel = SettingsModel(this, sharedPreferences)
-
         // init documentTypeRepository
         documentTypeRepository = DocumentTypeRepository()
         documentTypeRepository.addDocumentType(DrivingLicense.getDocumentType())
@@ -133,6 +133,11 @@ class WalletApplication : Application() {
         // init storage
         val storageFile = Path(applicationContext.noBackupFilesDir.path, "identity.bin")
         storageEngine = AndroidStorageEngine.Builder(applicationContext, storageFile).build()
+
+        // init EventLogger
+        eventLogger = EventLogger(storageEngine as AndroidStorageEngine)
+
+        settingsModel = SettingsModel(this, sharedPreferences)
 
         // init AndroidKeyStoreSecureArea
         androidKeystoreSecureArea = AndroidKeystoreSecureArea(applicationContext, storageEngine)

--- a/wallet/src/main/java/com/android/identity_credential/wallet/logging/DocumentUpdateCheckEvent.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/logging/DocumentUpdateCheckEvent.kt
@@ -1,0 +1,9 @@
+package com.android.identity_credential.wallet.logging
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+data class DocumentUpdateCheckEvent(
+    override var timestamp: Instant = Clock.System.now(),
+    var documentId: String = "",
+    ) : Event(timestamp)

--- a/wallet/src/main/java/com/android/identity_credential/wallet/logging/Event.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/logging/Event.kt
@@ -1,0 +1,11 @@
+package com.android.identity_credential.wallet.logging
+
+import com.android.identity.cbor.annotation.CborSerializable
+import kotlinx.datetime.Instant
+
+@CborSerializable
+sealed class Event(
+    open val timestamp: Instant,
+) {
+    companion object
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/logging/EventLogger.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/logging/EventLogger.kt
@@ -1,0 +1,95 @@
+package com.android.identity_credential.wallet.logging
+
+import com.android.identity.storage.StorageEngine
+import com.android.identity.util.Logger
+import com.android.identity.util.UUID
+import kotlinx.datetime.Clock
+
+/**
+ * Event Logging facility.
+ *
+ * This saves events in Cbor format using storageEngine.
+ */
+
+private const val TAG = "EventLogger"
+
+private var eventLoggingEnabled = false
+
+class EventLogger(private val storageEngine: StorageEngine) {
+    companion object {
+        const val STORAGE_KEY_PREFIX = "event_log_"
+    }
+
+    fun startLoggingEvents() {
+        eventLoggingEnabled = true
+        Logger.i(TAG, "Enabling event logging")
+    }
+
+    fun stopLoggingEvents() {
+        eventLoggingEnabled = false
+        Logger.i(TAG, "Disabling event logging")
+    }
+
+    fun isLoggingEnabled(): Boolean {
+        return eventLoggingEnabled
+    }
+
+    fun addMDocPresentationEntry(
+        documentId: String,
+        sessionTranscript: ByteArray,
+        deviceRequestCbor: ByteArray,
+        deviceResponseCbor: ByteArray
+    ) {
+        if (!eventLoggingEnabled) {
+            Logger.i(TAG, "Logging is disabled")
+            return // Exit immediately if logging is disabled
+        }
+
+        val uniqueId = Clock.System.now()
+        val serializedEntry: ByteArray
+
+        val event = MdocPresentationEvent(
+            timestamp = uniqueId,
+            documentId = documentId,
+            sessionTranscript = sessionTranscript,
+            deviceRequestCbor = deviceRequestCbor,
+            deviceResponseCbor = deviceResponseCbor,
+        )
+        serializedEntry = event.toCbor()//Cbor.encode(event.toDataItem())
+
+        val key = STORAGE_KEY_PREFIX + uniqueId
+        storageEngine.put(key, serializedEntry)
+    }
+
+    fun getEntries(documentId: String): List<Event> {
+        val entries = mutableListOf<Event>()
+        for (key in storageEngine.enumerate()) {
+            if (key.startsWith(STORAGE_KEY_PREFIX)) {
+                val value = storageEngine[key]
+                if (value != null) {
+                    when (val event = Event.fromCbor(value)) {
+                        is MdocPresentationEvent -> if (event.documentId == documentId) entries.add(event)
+                        is DocumentUpdateCheckEvent -> if (event.documentId == documentId) entries.add(event)
+                        // No need for an else branch here, as other Event subclasses don't have documentId
+                    }
+                }
+            }
+        }
+        return entries
+    }
+
+    fun deleteEntries(entries: List<Event>) {
+        for (entry in entries) {
+            val key = STORAGE_KEY_PREFIX + entry.timestamp
+            storageEngine.delete(key)
+            Logger.i(TAG, "Deleted entry with key: $key")
+        }
+    }
+
+    fun deleteEntriesForDocument(documentId: String) {
+        val entriesToDelete = getEntries(documentId)
+        deleteEntries(entriesToDelete)
+        Logger.i(TAG, "Deleted all entries for documentId: $documentId")
+    }
+}
+

--- a/wallet/src/main/java/com/android/identity_credential/wallet/logging/MdocPresentationEvent.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/logging/MdocPresentationEvent.kt
@@ -1,0 +1,12 @@
+package com.android.identity_credential.wallet.logging
+
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+
+data class MdocPresentationEvent (
+    override var timestamp: Instant = Clock.System.now(),
+    var documentId: String = "",
+    var sessionTranscript: ByteArray,
+    var deviceRequestCbor: ByteArray,
+    var deviceResponseCbor: ByteArray,
+) : Event(timestamp)

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
@@ -42,6 +42,12 @@ sealed class WalletDestination(val routeEnum: Route) : DestinationArguments() {
                     nullable = true
                 }
             ),
+            ACTIVITIES( // Add a new argument for the "activities" section
+                navArgument("activities") {
+                    type = NavType.StringType
+                    nullable = true
+                }
+            ),
             CREDENTIALS( // this argument is optional, sections like 'credentials' can be passed
                 navArgument("section") {
                     type = NavType.StringType
@@ -176,6 +182,7 @@ enum class Route(val routeName: String, val argumentsStr: String = "") {
     ADD_TO_WALLET("add_to_wallet"),
     DOCUMENT_INFO("document_info",
         "documentId={documentId}&section={section}&auth_required={auth_required}"),
+    ACTIVITY_LOG("activity_log","documentId={documentId}"),
     PROVISION_DOCUMENT("provision_document"),
     QR_ENGAGEMENT("qr_engagement"),
     READER("reader_select_request"),

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -16,6 +16,7 @@ import com.android.identity_credential.wallet.ui.destination.addtowallet.AddToWa
 import com.android.identity_credential.wallet.ui.destination.document.DocumentDetailsScreen
 import com.android.identity_credential.wallet.ui.destination.document.DocumentInfoScreen
 import com.android.identity_credential.wallet.ui.destination.document.CredentialInfoScreen
+import com.android.identity_credential.wallet.ui.destination.document.EventLogScreen
 import com.android.identity_credential.wallet.ui.destination.main.MainScreen
 import com.android.identity_credential.wallet.ui.destination.provisioncredential.ProvisionDocumentScreen
 import com.android.identity_credential.wallet.ui.destination.qrengagement.QrEngagementScreen
@@ -133,6 +134,13 @@ fun WalletNavigation(
                         documentId = cardId,
                         documentModel = documentModel,
                         requireAuthentication = requireAuthentication,
+                        onNavigate = navigateTo,
+                    )
+                }
+                "activities" -> {
+                    EventLogScreen(
+                        documentId = cardId,
+                        documentModel = documentModel,
                         onNavigate = navigateTo,
                     )
                 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
@@ -1,8 +1,8 @@
 package com.android.identity_credential.wallet.ui.destination.document
 
 import android.content.Context
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
@@ -50,11 +50,17 @@ import com.android.identity_credential.wallet.navigation.WalletDestination
 import com.android.identity_credential.wallet.ui.KeyValuePairText
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
 import com.android.identity_credential.wallet.ui.durationFromNowText
+import com.android.identity_credential.wallet.util.asFormattedDateTimeInCurrentTimezone
 import kotlinx.coroutines.launch
-import java.util.Locale
+import kotlinx.datetime.Instant
+import java.util.*
 
 
 private const val TAG = "DocumentInfoScreen"
+
+fun formatDate(timestamp: Instant): String {
+    return timestamp.asFormattedDateTimeInCurrentTimezone
+}
 
 @Composable
 fun DocumentInfoScreen(
@@ -182,19 +188,12 @@ fun DocumentInfoScreen(
         title = stringResource(R.string.document_info_screen_title),
         onBackButtonClick = { onNavigate(WalletDestination.PopBackStack.route) },
         actions = {
-            IconButton(onClick = { showMenu = true }) {
-                Icon(Icons.Default.Menu, contentDescription = null)
-            }
-            DropdownMenu(
-                expanded = showMenu,
-                onDismissRequest = { showMenu = false }
-            ) {
+            IconButton(onClick = { showMenu = true }) { Icon(Icons.Default.Menu, contentDescription = null) }
+            DropdownMenu(expanded = showMenu, onDismissRequest = { showMenu = false }) {
                 DropdownMenuItem(
                     text = { Text(text = stringResource(R.string.document_info_screen_menu_item_check_for_update)) },
                     leadingIcon = { Icon(Icons.Outlined.Refresh, contentDescription = null) },
                     onClick = {
-                        showMenu = false
-
                         coroutineScope.launch {
                             try {
                                 documentModel.refreshCard(documentInfo)
@@ -243,10 +242,23 @@ fun DocumentInfoScreen(
                     }
                 )
                 DropdownMenuItem(
+                    text = { Text(text = stringResource(R.string.document_info_screen_menu_activities_log)) },
+                    leadingIcon = { Icon(Icons.Outlined.Info, contentDescription = null) },
+                    onClick = {
+                        onNavigate(WalletDestination.DocumentInfo.getRouteWithArguments(
+                            listOf(
+                                Pair(WalletDestination.DocumentInfo.Argument.DOCUMENT_ID, documentInfo.documentId),
+                                Pair(WalletDestination.DocumentInfo.Argument.SECTION, "activities")
+                            )
+                        ))
+                        showMenu = false
+                    }
+                )
+                DropdownMenuItem(
                     text = { Text(text = stringResource(R.string.document_info_screen_menu_item_delete)) },
                     leadingIcon = { Icon(Icons.Outlined.Delete, contentDescription = null) },
                     onClick = {
-                        showMenu = false
+                        showMenu = false;
                         showDeleteConfirmationDialog = true
                     }
                 )
@@ -323,17 +335,13 @@ fun DocumentInfoScreen(
                     modifier = Modifier.padding(8.dp)
                 )
             }
-            Spacer(modifier = Modifier.weight(0.5f))
+            Spacer(modifier = Modifier.height(8.dp))
             KeyValuePairText(stringResource(R.string.document_info_screen_data_name), documentInfo.name)
             KeyValuePairText(stringResource(R.string.document_info_screen_data_issuer), documentInfo.issuerName)
             KeyValuePairText(stringResource(R.string.document_info_screen_data_status), documentInfo.status)
             KeyValuePairText(
                 stringResource(R.string.document_info_screen_data_last_update_check),
-                durationFromNowText(documentInfo.lastRefresh).replaceFirstChar {
-                    if (it.isLowerCase()) it.titlecase(
-                        Locale.US
-                    ) else it.toString()
-                }
+                durationFromNowText(documentInfo.lastRefresh).replaceFirstChar { if (it.isLowerCase()) it.titlecase(Locale.US) else it.toString() }
             )
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/EventLogScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/EventLogScreen.kt
@@ -1,0 +1,95 @@
+package com.android.identity_credential.wallet.ui.destination.document
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.runtime.remember
+import com.android.identity_credential.wallet.DocumentModel
+import com.android.identity_credential.wallet.EventInfo
+import com.android.identity_credential.wallet.R
+import com.android.identity_credential.wallet.navigation.WalletDestination
+import com.android.identity_credential.wallet.ui.KeyValuePairText
+import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
+
+private const val TAG = "EventLogScreen"
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun EventLogScreen(documentId: String, documentModel: DocumentModel, onNavigate: (String) -> Unit) {
+    val eventInfos = remember {
+        mutableStateListOf<EventInfo>().apply {
+            addAll(documentModel.getEventInfos(documentId))
+        }
+    }
+
+    Box(
+        modifier = Modifier.fillMaxHeight()
+    ) {
+        ScreenWithAppBarAndBackButton(
+            title = stringResource(R.string.document_info_screen_menu_activities_log),
+            onBackButtonClick = { onNavigate(WalletDestination.PopBackStack.route) }
+        ) {
+            if (eventInfos.isEmpty()) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.Center,
+                ) {
+                    Text(
+                        modifier = Modifier.padding(8.dp),
+                        text = stringResource(R.string.document_info_screen_menu_activities_log_screen_empty),
+                        style = MaterialTheme.typography.titleLarge,
+                        textAlign = TextAlign.Center
+                    )
+                }
+            } else {
+                Column(modifier = Modifier.weight(1f)) {
+                LazyColumn {
+                        items(eventInfos) { eventInfo ->
+                            Row(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(4.dp),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                KeyValuePairText(eventInfo.timestamp, eventInfo.requestedFields)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (eventInfos.isNotEmpty()) {
+            Row(
+                horizontalArrangement = Arrangement.End,
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .fillMaxWidth()
+                    .padding(16.dp)
+            ) {
+                Button(onClick = {
+                    documentModel.deleteEventInfos(documentId)
+                    eventInfos.clear()
+                }) {
+                    Text("Delete All")
+                }
+            }
+        }
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.text.ClickableText
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Menu
+import androidx.compose.material.icons.filled.MoreVert
 import androidx.compose.material.icons.outlined.Delete
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.AlertDialog
@@ -189,6 +190,13 @@ fun SettingsScreen(
                 isChecked = settingsModel.loggingEnabled.observeAsState(false).value,
                 onCheckedChange = { settingsModel.loggingEnabled.value = it }
             )
+            SettingToggle(
+                title = stringResource(R.string.settings_screen_activities_logging_title),
+                subtitleOn = stringResource(R.string.settings_screen_activities_logging_subtitle_on),
+                subtitleOff = stringResource(R.string.settings_screen_activities_logging_subtitle_off),
+                isChecked = settingsModel.activityLoggingEnabled.observeAsState(false).value,
+                onCheckedChange = { settingsModel.activityLoggingEnabled.value = it }
+            )
             if (WalletApplicationConfiguration.WALLET_SERVER_SETTING_AVAILABLE) {
                 SettingString(
                     title = stringResource(R.string.settings_screen_wallet_server_title),
@@ -347,3 +355,4 @@ internal abstract class ConfirmServerChange(
 ) {
     abstract fun onConfirm()
 }
+

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -134,6 +134,9 @@
     <string name="settings_screen_log_to_file_title">Logging</string>
     <string name="settings_screen_log_to_file_subtitle_on">Diagnostic messages are being logged</string>
     <string name="settings_screen_log_to_file_subtitle_off">Diagnostic messages are not being logged</string>
+    <string name="settings_screen_activities_logging_title">Show Activity</string>
+    <string name="settings_screen_activities_logging_subtitle_on">Activities are being logged</string>
+    <string name="settings_screen_activities_logging_subtitle_off">Activities are not being logged</string>
     <string name="settings_screen_log_to_file_clear_button">Clear log</string>
     <string name="settings_screen_log_to_file_share_button">Share log</string>
     <string name="settings_screen_log_to_file_chooser_title">Share Log</string>
@@ -202,6 +205,8 @@
     <string name="document_info_screen_menu_item_show_data">Show Data</string>
     <string name="document_info_screen_menu_item_show_credentials">Show Credentials</string>
     <string name="document_info_screen_menu_item_request_update">Request Update</string>
+    <string name="document_info_screen_menu_activities_log">Activities Log</string>
+    <string name="document_info_screen_menu_activities_log_screen_empty">No activities logged yet</string>
     <string name="document_info_screen_request_update_title">Request Update</string>
     <string name="document_info_screen_request_update_message">
         This is a Developer Mode feature to request a document update from the Issuing Authority.
@@ -496,5 +501,4 @@
     <string name="qr_alert_dialog_bt_disabled_text">Bluetooth must be enabled to share a QR connection code</string>
     <string name="qr_alert_dialog_bt_enable_button">Enable</string>
     <string name="presentation_result_no_matching_document_message">No available documents can fulfill the request.</string>
-
 </resources>

--- a/wallet/src/test/java/com/android/identity_credential/wallet/logging/EventLoggerTest.kt
+++ b/wallet/src/test/java/com/android/identity_credential/wallet/logging/EventLoggerTest.kt
@@ -1,0 +1,57 @@
+package com.android.identity_credential.wallet.logging
+
+import com.android.identity.storage.EphemeralStorageEngine
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+import kotlin.test.assertTrue
+
+class EventLoggerTest {
+
+    private lateinit var mockStorage: EphemeralStorageEngine
+    private lateinit var activityLogger: EventLogger // Create an instance
+
+    @Before
+    fun setUp() {
+        mockStorage = EphemeralStorageEngine()
+        activityLogger = EventLogger(mockStorage) // Initialize the instance
+    }
+
+    @Test
+    fun testLoggingEnabled() {
+        activityLogger.startLoggingEvents()
+        assertTrue(activityLogger.isLoggingEnabled())
+    }
+
+    @Test
+    fun testLoggingDisabled() {
+        activityLogger.stopLoggingEvents()
+        assertFalse(activityLogger.isLoggingEnabled())
+    }
+
+    @Test
+    fun testDeleteEntries() {
+        // Start logging events
+        activityLogger.startLoggingEvents()
+
+        // Add an MdocPresentationEntry to the logger
+        activityLogger.addMDocPresentationEntry(
+            documentId = "doc123",
+            sessionTranscript = "sessionTranscript".toByteArray(),
+            deviceRequestCbor = "request data".toByteArray(),
+            deviceResponseCbor = "response data".toByteArray()
+        )
+
+        // Retrieve the entries for the given documentId
+        val entries = activityLogger.getEntries("doc123")
+
+        // Ensure that entries were added correctly
+        assertTrue(entries.isNotEmpty(), "Entries should not be empty after adding an event")
+
+        // Delete the entries retrieved
+        activityLogger.deleteEntries(entries)
+
+        // Check that the storage is empty after deletion
+        assertTrue(mockStorage.enumerate().isEmpty(), "Storage should be empty after deleting all entries")
+    }
+}


### PR DESCRIPTION
ActivityLogger is added and used to capture the credman presentation activity. Once an activity is made on a card, when the user view that card, they can click on the top right corner and see the corresponding activities.

Tested by: local testing for presentment activity and viewing of the event.

Signed-off-by: Hamzeh Zawawy/hamzeh@google.com

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR