### PR TITLE
Updates to Wallet UI so its more preseentable and appealing

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptEntryField.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptEntryField.kt
@@ -3,6 +3,7 @@ package com.android.identity_credential.wallet.ui.prompt.consent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.foundation.background
 import androidx.compose.foundation.focusGroup
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,6 +12,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
@@ -210,18 +212,20 @@ private fun ConsentPromptHeader(consentData: ConsentPromptEntryFieldData) {
     }
 
     Row(
-        modifier = Modifier.fillMaxWidth(),
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.Center
     ) {
         // show icon if icon bytes are present
         consentData.verifier?.displayIcon?.let { iconBytes ->
             Icon(
-                modifier = Modifier.size(24.dp),
+                modifier = Modifier.size(50.dp),
                 // TODO: we're computing a bitmap every recomposition and this could be slow
                 bitmap = iconBytes.toImageBitmap(),
                 contentDescription = stringResource(id = R.string.consent_prompt_icon_description)
             )
-        }
+        } ?: Spacer(modifier = Modifier.width(24.dp))
         Text(
             text = title,
             modifier = Modifier.fillMaxWidth(),
@@ -265,6 +269,7 @@ private fun DataElementsListView(
             .fillMaxWidth()
             .fillMaxHeight()
             .focusGroup()
+            .padding(start=10.dp)
     ) {
         items(groupedElements.size) { index ->
             val pair = groupedElements[index]
@@ -333,7 +338,8 @@ private fun DataElementView(
         label = {
             Text(
                 text = "• ${documentElement.displayName}",
-                fontWeight = FontWeight.Normal
+                fontWeight = FontWeight.Normal,
+                style = MaterialTheme.typography.bodyLarge
             )
         },
     )
@@ -356,7 +362,9 @@ private fun ConsentPromptActions(
     Column(modifier = Modifier.fillMaxHeight()) {
 
         Row(
-            horizontalArrangement = Arrangement.SpaceEvenly
+            horizontalArrangement = Arrangement.SpaceEvenly,
+            modifier = Modifier.padding(horizontal = 10.dp)
+
         ) {
             // Cancel button
             Button(
@@ -366,7 +374,7 @@ private fun ConsentPromptActions(
                 Text(text = stringResource(id = R.string.consent_prompt_button_cancel))
             }
 
-            Spacer(modifier = Modifier.width(8.dp))
+            Spacer(modifier = Modifier.width(10.dp))
 
             // Confirm button
             Button(

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphrasePinScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphrasePinScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.semantics.semantics
@@ -123,13 +124,12 @@ fun PassphrasePinScreen(
         Spacer(modifier = Modifier.height(50.dp))
         PassphrasePinScreenHeader(title = title, content = content)
 
-        Spacer(modifier = Modifier.height(50.dp))
+        Spacer(modifier = Modifier.height(30.dp))
         // prevent the keyboard from showing up in PassphraseEntryField and set the text to show
-        PassphraseEntryField(
+        PassphrasePromptInputField(
             constraints = constraints,
-            disableKeyboard = true,
-            setText = currentPin.value,
-            onChanged = { _, _, _ -> /* will never get called */ },
+            setPin = currentPin.value,
+            onChanged = { _, _ -> /* will never get called */ },
         )
 
         Spacer(modifier = Modifier.height(50.dp))
@@ -180,10 +180,8 @@ private fun PassphrasePinScreenHeader(title: String, content: String) {
             modifier = Modifier.fillMaxWidth(),
             text = title,
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.titleMedium,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onSurface
-
         )
 
         Text(
@@ -192,8 +190,7 @@ private fun PassphrasePinScreenHeader(title: String, content: String) {
                 .padding(top = 8.dp),
             text = content,
             textAlign = TextAlign.Center,
-            style = MaterialTheme.typography.bodySmall,
-            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleMedium,
             color = MaterialTheme.colorScheme.onSurface
         )
     }
@@ -235,48 +232,32 @@ private fun KeyPad(
 
 @Composable
 private fun KeyPadButtonView(button: KeyPadButton, onClick: (() -> Unit)? = null) {
-    Button(
-        modifier = Modifier
-            .size(100.dp)
-            .then(
-                if (button.isEmpty()) {
-                    Modifier.background(Color.Transparent)
-                } else {
-                    Modifier
-                    Modifier.background(
-                        color = if (isSystemInDarkTheme()) {
-                            MaterialTheme.colorScheme.surfaceBright
-                        } else {
-                            MaterialTheme.colorScheme.surfaceDim
-                        },
-                        shape = CircleShape
-                    )
-                }
-            ),
-        onClick = { onClick?.invoke() },
-        colors = ButtonDefaults.buttonColors(
-            containerColor = Color.Transparent,
-            contentColor = MaterialTheme.colorScheme.scrim
-        )
-    ) {
-        if (button.number != null) {
-            Column(
-                modifier = Modifier.semantics(mergeDescendants = true, properties = {}),
-                horizontalAlignment = Alignment.CenterHorizontally
-            ) {
-                Text(
-                    text = button.number.toString(),
-                    fontSize = 25.sp,
-                    color = MaterialTheme.colorScheme.onSecondary,
-                    fontWeight = FontWeight.Bold
-                )
-                if (button.chars != null) {
+    if (button.isEmpty()) {
+        Spacer(modifier = Modifier.width(100.dp))
+    } else {
+        Button(
+            modifier = Modifier
+                .size(100.dp)
+                .clip(CircleShape),
+            onClick = { onClick?.invoke() },
+        ) {
+            if (button.number != null) {
+                Column(
+                    modifier = Modifier.semantics(mergeDescendants = true, properties = {}),
+                    horizontalAlignment = Alignment.CenterHorizontally
+                ) {
                     Text(
-                        text = button.chars,
-                        modifier = Modifier.padding(top = 5.dp),
-                        color = MaterialTheme.colorScheme.onSecondary,
-                        fontSize = 14.sp
+                        text = button.number.toString(),
+                        style = MaterialTheme.typography.titleMedium,
+                        fontWeight = FontWeight.Bold
                     )
+                    if (button.chars != null) {
+                        Text(
+                            text = button.chars,
+                            modifier = Modifier.padding(top = 5.dp),
+                            style = MaterialTheme.typography.titleSmall,
+                        )
+                    }
                 }
             }
         }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphrasePrompt.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/passphrase/PassphrasePrompt.kt
@@ -28,7 +28,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.fragment.app.FragmentActivity
@@ -62,7 +61,6 @@ suspend fun showPassphrasePrompt(
     content: String,
 ): String? =
     suspendCancellableCoroutine { continuation ->
-
         val passphrasePrompt = PassphrasePrompt(
             constraints = constraints,
             title = title,
@@ -140,14 +138,6 @@ class PassphrasePrompt(
                 IdentityCredentialTheme {
                     var currPassphrase = ""
 
-                    // if fixed length, the IME action button shouldn't do anything because the user
-                    // needs to provide exactly the required number of characters; show an arrow icon
-                    // rather than a checkmark icon (since with fixed length, the user should not
-                    // have the option to "complete" the entry, rather it is completed inherently
-                    // when the required number of characters has been entered)
-                    val imeAction =
-                        if (constraints.isFixedLength()) ImeAction.Go else ImeAction.Done
-
                     /**
                      * Local function called to notify of passphrase submission.
                      */
@@ -194,10 +184,9 @@ class PassphrasePrompt(
                                         onCancel = { onCancel() }
                                     )
                                     PassphrasePromptHeader(title = title, content = content)
-                                    PassphraseEntryField(
+                                    PassphrasePromptInputField(
                                         constraints = constraints,
-                                        imeAction = imeAction,
-                                        onChanged = { passphrase, _, donePressed ->
+                                        onChanged = { passphrase, donePressed ->
                                             currPassphrase = passphrase
                                             if (!constraints.isFixedLength()) {
                                                 // notify of the typed passphrase when user taps 'Done' on the keyboard
@@ -231,7 +220,7 @@ class PassphrasePrompt(
                 modifier = Modifier.fillMaxWidth(),
                 text = title,
                 textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.titleMedium,
+                style = MaterialTheme.typography.headlineMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface
             )
@@ -242,7 +231,7 @@ class PassphrasePrompt(
                     .padding(top = 8.dp),
                 text = content,
                 textAlign = TextAlign.Center,
-                style = MaterialTheme.typography.bodySmall,
+                style = MaterialTheme.typography.titleMedium,
                 fontWeight = FontWeight.Bold,
                 color = MaterialTheme.colorScheme.onSurface
             )


### PR DESCRIPTION
- UI updates to Consent Prompt including larger font size, better alignment of action buttons cancel and done, better alignment of title and verifier icon.
- UI updates to Passphrase Prompt including larger font size and using the default background color for Keypad Buttons on PIN constraints.
- Cloned PassphraseEntryField into PassphrasePromptInputField to provide specific business logic related to the Passphrase/PIN Prompt and not related to PassphraseEntryField and its weak-passphrase logic.
- Reverted PassphraseEntryField to no longer accept params imeAction, disableKeyboard, or setText.
- PassphrasePromptInputField now accepts one parameter -setPin- which sets the Input Field text to be the value of -setPin- and is used to identify whether to disable the keyboard focus.
- Updated PassphrasePrompt and PassphrasePinScreen to use their own and new, PassphrasePromptInputField rather than PassphraseEntryField.

Test: Testing of all Passphrase-related functionalities in
	Light and Dark theme.
Test: Manually tested Wallet Presentment between real devices. Test: ./gradlew check
Test: ./gradlew connectedCheck


### Consent Prompt Light
<img width="443" alt="Screenshot 2024-08-21 at 4 11 05 AM" src="https://github.com/user-attachments/assets/bd2900ba-c376-4bce-a1c7-08b4e4d20c35">

### Passphrase Prompt (PIN) Light
<img width="441" alt="Screenshot 2024-08-21 at 4 11 30 AM" src="https://github.com/user-attachments/assets/9a4bff94-ad24-4f2a-b445-6555ce19bbb0">


### Consent Prompt Dark
<img width="439" alt="Screenshot 2024-08-21 at 4 12 18 AM" src="https://github.com/user-attachments/assets/eb46f722-18ba-4c38-9810-d8750b41b901">

### Passphrase Prompt (PIN) Dark
<img width="443" alt="Screenshot 2024-08-21 at 4 12 31 AM" src="https://github.com/user-attachments/assets/8133b25f-d98d-442d-bbbe-62140af7a8e1">

### Passphrase Prompt (Alphanumeric) Dark
<img width="440" alt="Screenshot 2024-08-21 at 4 13 03 AM" src="https://github.com/user-attachments/assets/db503731-e3bb-48ce-a048-4ca0def3b769">

