### PR TITLE
Better handling of error conditions for Funke issuing authority.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/IssuingAuthorityException.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/IssuingAuthorityException.kt
@@ -1,0 +1,13 @@
+package com.android.identity.issuance
+
+import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.flow.annotation.FlowException
+
+/**
+ * Represents a generic error in issuer with the human-readable message.
+ */
+@FlowException
+@CborSerializable
+class IssuingAuthorityException(message: String?) : Exception(message) {
+    companion object
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
@@ -5,6 +5,7 @@ import com.android.identity.flow.annotation.FlowMethod
 import com.android.identity.flow.annotation.FlowState
 import com.android.identity.flow.server.Configuration
 import com.android.identity.flow.server.FlowEnvironment
+import com.android.identity.issuance.IssuingAuthorityException
 import com.android.identity.issuance.ProofingFlow
 import com.android.identity.issuance.WalletServerSettings
 import com.android.identity.issuance.evidence.EvidenceRequest
@@ -118,7 +119,7 @@ class FunkeProofingState(
             // Error
             return
         }
-        val tokenUrl = "${FunkeUtil.BASE_URL}/c/token"
+        val tokenUrl = "${FunkeUtil.BASE_URL}/token"
         val dpop = FunkeUtil.generateDPoP(env, clientId, tokenUrl, dpopNonce)
         val tokenRequest = FormUrlEncoder {
             add("code", code)
@@ -135,7 +136,7 @@ class FunkeProofingState(
         }
         if (tokenResponse.status != HttpStatusCode.OK) {
             Logger.e(TAG, "Token request error: ${response.status}")
-            throw IllegalStateException("Token request error")
+            throw IssuingAuthorityException("eID card rejected by the issuer")
         }
         this.dpopNonce = tokenResponse.headers["DPoP-Nonce"]
         if (this.dpopNonce == null) {

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeRequestCredentialsState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeRequestCredentialsState.kt
@@ -59,7 +59,7 @@ class FunkeRequestCredentialsState(
             )).toString().toByteArray().toBase64()
             val body = JsonObject(mapOf(
                 "iss" to JsonPrimitive(FunkeUtil.CLIENT_ID),
-                "aud" to JsonPrimitive(FunkeUtil.BASE_URL + "/c"),
+                "aud" to JsonPrimitive(FunkeUtil.BASE_URL),
                 "iat" to JsonPrimitive(Clock.System.now().epochSeconds),
                 "nonce" to JsonPrimitive(nonce)
             )).toString().toByteArray().toBase64()

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
@@ -3,7 +3,6 @@ package com.android.identity.issuance.funke
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
 import com.android.identity.flow.server.FlowEnvironment
-import com.android.identity.sdjwt.util.JsonWebKey
 import com.android.identity.securearea.CreateKeySettings
 import com.android.identity.securearea.KeyInfo
 import com.android.identity.securearea.SecureArea
@@ -19,8 +18,15 @@ import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.seconds
 
 internal object FunkeUtil {
-    const val BASE_URL = "https://demo.pid-issuer.bundesdruckerei.de"
+    // Endpoint for PID issuer, could be /c or /c1
+    const val BASE_URL = "https://demo.pid-issuer.bundesdruckerei.de/c"
+
+    // client ID is from sample request/responses, this will need to be replaced with the
+    // registered client id once we have client attestation (probably should come from the
+    // attestation server).
     const val CLIENT_ID = "fed79862-af36-4fee-8e64-89e3c91091ed"
+
+    const val EU_PID_MDOC_DOCTYPE = "eu.europa.ec.eudi.pid.1"
     const val SD_JWT_VCT = "urn:eu.europa.ec.eudi:pid:1"
 
     private val keyCreationMutex = Mutex()

--- a/identity-issuance/src/main/java/com/android/identity/issuance/wallet/WalletServerState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/wallet/WalletServerState.kt
@@ -5,12 +5,14 @@ import com.android.identity.flow.annotation.FlowJoin
 import com.android.identity.flow.annotation.FlowMethod
 import com.android.identity.flow.annotation.FlowState
 import com.android.identity.flow.handler.FlowDispatcherLocal
+import com.android.identity.flow.handler.FlowExceptionMap
 import com.android.identity.flow.server.Configuration
 import com.android.identity.flow.server.Resources
 import com.android.identity.flow.server.FlowEnvironment
 import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.DocumentConfiguration
 import com.android.identity.issuance.IssuingAuthorityConfiguration
+import com.android.identity.issuance.IssuingAuthorityException
 import com.android.identity.issuance.WalletServer
 import com.android.identity.issuance.WalletServerSettings
 import com.android.identity.issuance.common.AbstractIssuingAuthorityState
@@ -24,6 +26,7 @@ import com.android.identity.issuance.funke.FunkeProofingState
 import com.android.identity.issuance.funke.FunkeRegistrationState
 import com.android.identity.issuance.funke.FunkeRequestCredentialsState
 import com.android.identity.issuance.funke.register
+import com.android.identity.issuance.register
 import kotlinx.io.bytestring.buildByteString
 import kotlin.random.Random
 
@@ -60,6 +63,10 @@ class WalletServerState(
                 minCredentialValidityMillis = 30 * 24 * 3600L,
                 maxUsesPerCredentials = 1
             )
+        }
+
+        fun registerExceptions(exceptionMapBuilder: FlowExceptionMap.Builder) {
+            IssuingAuthorityException.register(exceptionMapBuilder)
         }
 
         fun registerAll(dispatcher: FlowDispatcherLocal.Builder) {

--- a/server/src/main/java/com/android/identity/wallet/server/FlowServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/FlowServlet.kt
@@ -67,6 +67,8 @@ class FlowServlet : HttpServlet() {
 
             serverEnvironment = ServerEnvironment(servletConfig)
 
+            val exceptionMapBuilder = FlowExceptionMap.Builder()
+            WalletServerState.registerExceptions(exceptionMapBuilder)
             val dispatcherBuilder = FlowDispatcherLocal.Builder()
             WalletServerState.registerAll(dispatcherBuilder)
             val storage = serverEnvironment.getInterface(Storage::class)!!
@@ -96,7 +98,7 @@ class FlowServlet : HttpServlet() {
             val localDispatcher = dispatcherBuilder.build(
                 serverEnvironment,
                 cipher,
-                FlowExceptionMap.Builder().build()
+                exceptionMapBuilder.build()
             )
 
             httpHandler = HttpHandler(localDispatcher, localPoll)

--- a/wallet/src/main/java/com/android/identity/issuance/remote/WalletServerProvider.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/WalletServerProvider.kt
@@ -176,7 +176,8 @@ class WalletServerProvider(
     private suspend fun getWalletServerUnlocked(): WalletServer {
         val dispatcher: FlowDispatcher
         val notifier: FlowNotifier
-        val exceptionMap = FlowExceptionMap.Builder().build()
+        val exceptionMapBuilder = FlowExceptionMap.Builder()
+        WalletServerState.registerExceptions(exceptionMapBuilder)
         if (baseUrl == "dev:") {
             val builder = FlowDispatcherLocal.Builder()
             WalletServerState.registerAll(builder)
@@ -186,7 +187,7 @@ class WalletServerProvider(
             dispatcher = WrapperFlowDispatcher(builder.build(
                 environment,
                 noopCipher,
-                exceptionMap
+                exceptionMapBuilder.build()
             ))
         } else {
             val httpClient = WalletHttpTransport(baseUrl)
@@ -195,7 +196,7 @@ class WalletServerProvider(
             CoroutineScope(Dispatchers.IO).launch {
                 notifier.loop()
             }
-            dispatcher = FlowDispatcherHttp(httpClient, exceptionMap)
+            dispatcher = FlowDispatcherHttp(httpClient, exceptionMapBuilder.build())
         }
 
         // "root" is the entry point for the server, see FlowState annotation on

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ProvisioningViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ProvisioningViewModel.kt
@@ -15,6 +15,7 @@ import com.android.identity.issuance.DocumentExtensions.refreshState
 import com.android.identity.issuance.DocumentExtensions.state
 import com.android.identity.issuance.RegistrationResponse
 import com.android.identity.issuance.IssuingAuthority
+import com.android.identity.issuance.IssuingAuthorityException
 import com.android.identity.issuance.ProofingFlow
 import com.android.identity.issuance.evidence.EvidenceRequest
 import com.android.identity.issuance.evidence.EvidenceRequestIcaoNfcTunnel

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
@@ -35,6 +35,8 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -279,6 +281,11 @@ fun DocumentInfoScreen(
                 Image(
                     bitmap = documentInfo.documentArtwork.asImageBitmap(),
                     contentDescription = stringResource(R.string.accessibility_artwork_for, documentInfo.name),
+                    colorFilter = if (documentInfo.attentionNeeded) {
+                        ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0.1f) })
+                    } else {
+                        null
+                    },
                     modifier = Modifier
                         .height(200.dp).fillMaxSize()
                         .clickable(

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/main/MainScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/main/MainScreen.kt
@@ -28,7 +28,6 @@ import androidx.compose.material.icons.filled.Add
 import androidx.compose.material.icons.filled.Fingerprint
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Menu
-import androidx.compose.material.icons.filled.Nfc
 import androidx.compose.material.icons.filled.Settings
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
@@ -61,6 +60,8 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.ColorMatrix
 import androidx.compose.ui.graphics.asImageBitmap
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
@@ -480,6 +481,11 @@ fun MainScreenDocumentPager(
                     bitmap = card.documentArtwork.asImageBitmap(),
                     contentDescription =
                     stringResource(R.string.accessibility_artwork_for, card.name),
+                    colorFilter = if (card.attentionNeeded) {
+                        ColorFilter.colorMatrix(ColorMatrix().apply { setToSaturation(0.1f) })
+                    } else {
+                        null
+                    },
                     modifier = Modifier.fillMaxSize().clickable(onClick = {
                         onNavigate(
                             WalletDestination.DocumentInfo

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
@@ -18,6 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.android.identity.document.DocumentStore
+import com.android.identity.issuance.IssuingAuthorityException
 import com.android.identity.issuance.evidence.EvidenceRequestCreatePassphrase
 import com.android.identity.issuance.evidence.EvidenceRequestGermanEid
 import com.android.identity.issuance.evidence.EvidenceRequestIcaoNfcTunnel
@@ -254,12 +255,17 @@ fun ProvisionDocumentScreen(
                     modifier = Modifier.fillMaxWidth(),
                     horizontalArrangement = Arrangement.Center
                 ) {
+                    val error = provisioningViewModel.error
                     Text(
                         modifier = Modifier.padding(8.dp),
-                        style = MaterialTheme.typography.bodyMedium,
+                        style = MaterialTheme.typography.titleLarge,
                         textAlign = TextAlign.Center,
-                        text = stringResource(R.string.provisioning_error,
-                            provisioningViewModel.error.toString())
+                        text = if (error is IssuingAuthorityException) {
+                            error.message!!  // Human-readable message from the server
+                        } else {
+                            stringResource(R.string.provisioning_error,
+                                provisioningViewModel.error.toString())
+                        }
                     )
                 }
             }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -318,7 +318,7 @@
 
     <!-- eID reading -->
     <string name="eid_status_preparing">Initializing eID reading module</string>
-    <string name="eid_status_ready">Ready to read eID</string>
+    <string name="eid_status_ready">Ready to read eID card</string>
     <string name="eid_status_started">Initializing…</string>
     <string name="eid_start_workflow">Start</string>
     <string name="eid_start_workflow_with_simulator">Start using Simulator</string>


### PR DESCRIPTION
Created an exception type to deliver issuer-side errors to the client and handle it on the client. Got Funke issuer to throw that exception when issuance network requests fail.

Also adjusted end-point for the issuer, so it is easier to flip between option C and option C' endpoints.

Tested by artificially creating malformed requests to the issuance server.