### PR TITLE
Add support for SD-JWT verification.

### DIFF
--- a/identity/src/commonMain/kotlin/com/android/identity/document/Document.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/document/Document.kt
@@ -209,9 +209,7 @@ class Document private constructor(
         var candidate: Credential? = null
         _certifiedCredentials.filter {
             it.domain == domain && (
-                    now != null
-                            && (now >= it.validFrom)
-                            && (now <= it.validUntil)
+                    now == null || (now >= it.validFrom && now <= it.validUntil)
                     )
         }.forEach { credential ->
             // If we already have a candidate, prefer this one if its usage count is lower

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -24,6 +24,7 @@ dependencies {
     implementation(project(":identity-issuance"))
     implementation(project(":identity-csa"))
     implementation(project(":identity-mdoc"))
+    implementation(project(":identity-sdjwt"))
 
     implementation(libs.javax.servlet.api)
     implementation(libs.kotlinx.datetime)

--- a/server/src/main/webapp/verifier.html
+++ b/server/src/main/webapp/verifier.html
@@ -27,6 +27,11 @@
                 </button>
             </li>
             <li class="nav-item" role="presentation">
+                <button class="nav-link" id="pills-pid_sdjwt-tab" data-bs-toggle="pill" data-bs-target="#pills-pid_sdjwt" type="button" role="tab" aria-controls="pills-home" aria-selected="true">
+                    PID (SD-JWT VC)
+                </button>
+            </li>
+            <li class="nav-item" role="presentation">
                 <button class="nav-link" id="pills-mdl_mdoc-tab" data-bs-toggle="pill" data-bs-target="#pills-mdl_mdoc" type="button" role="tab" aria-controls="pills-profile" aria-selected="false">
                     mDL (mdoc)
                 </button>
@@ -45,7 +50,16 @@
                         Request PID (Full)
                     </button>
                 </div>
-
+            </div>
+            <div class="tab-pane fade" id="pills-pid_sdjwt" role="tabpanel" aria-labelledby="pills-pid_sdjwt-tab" tabindex="0">
+                <div class="d-grid gap-2 mx-auto">
+                    <button type="button" class="btn btn-primary btn-lg" onclick="requestDocument('pid_sdjwt_mandatory')">
+                        Request PID (Mandatory Claims)
+                    </button>
+                    <button type="button" class="btn btn-primary btn-lg" onclick="requestDocument('pid_sdjwt_full')">
+                        Request PID (Full)
+                    </button>
+                </div>
             </div>
             <div class="tab-pane fade" id="pills-mdl_mdoc" role="tabpanel" aria-labelledby="pills-mdl_mdoc-tab" tabindex="0">
                 <div class="d-grid gap-2 mx-auto">

--- a/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/PresentationActivity.kt
@@ -66,7 +66,7 @@ import com.android.identity.trustmanagement.TrustPoint
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.presentation.UserCanceledPromptException
-import com.android.identity_credential.wallet.presentation.showPresentmentFlow
+import com.android.identity_credential.wallet.presentation.showMdocPresentmentFlow
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Clock
@@ -361,11 +361,11 @@ class PresentationActivity : FragmentActivity() {
 
                                 // show the Presentation Flow for and get the response bytes for
                                 // the generated Document
-                                val documentCborBytes = showPresentmentFlow(
+                                val documentCborBytes = showMdocPresentmentFlow(
                                     activity = this@PresentationActivity,
                                     walletApp = walletApp,
                                     documentRequest = MdocUtil.generateDocumentRequest(docRequest),
-                                    mdocCredential = mdocCredential,
+                                    credential = mdocCredential,
                                     trustPoint = trustPoint,
                                     encodedSessionTranscript = deviceRetrievalHelper!!.sessionTranscript
                                 )

--- a/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/credman/CredmanPresentationActivity.kt
@@ -22,32 +22,17 @@ import android.util.Base64
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.lifecycleScope
 import com.android.identity.android.mdoc.util.CredmanUtil
-import com.android.identity.android.securearea.AndroidKeystoreKeyUnlockData
-import com.android.identity.android.securearea.UserAuthenticationType
-import com.android.identity.cbor.Cbor
-import com.android.identity.credential.Credential
 import com.android.identity.mdoc.credential.MdocCredential
 import com.android.identity.document.DocumentRequest
-import com.android.identity.document.NameSpacedData
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
-import com.android.identity.crypto.EcPublicKey
 import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
-import com.android.identity.issuance.DocumentExtensions.documentConfiguration
-import com.android.identity.mdoc.mso.MobileSecurityObjectParser
-import com.android.identity.mdoc.mso.StaticAuthDataParser
 import com.android.identity.mdoc.response.DeviceResponseGenerator
-import com.android.identity.mdoc.response.DocumentGenerator
-import com.android.identity.mdoc.util.MdocUtil
-import com.android.identity.securearea.KeyLockedException
-import com.android.identity.securearea.KeyUnlockData
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
-import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.WalletApplication
-import com.android.identity_credential.wallet.presentation.showPresentmentFlow
-import com.android.identity_credential.wallet.ui.prompt.biometric.showBiometricPrompt
+import com.android.identity_credential.wallet.presentation.showMdocPresentmentFlow
 import org.json.JSONObject
 
 import com.google.android.gms.identitycredentials.GetCredentialResponse
@@ -292,11 +277,11 @@ class CredmanPresentationActivity : FragmentActivity() {
         encodedSessionTranscript: ByteArray,
     ): ByteArray {
         val mdocCredential = getMdocCredentialForCredentialId(credentialId)
-        val documentCborBytes = showPresentmentFlow(
+        val documentCborBytes = showMdocPresentmentFlow(
             activity = this@CredmanPresentationActivity,
             walletApp = walletApp,
             documentRequest = DocumentRequest(dataElements),
-            mdocCredential = mdocCredential,
+            credential = mdocCredential,
             // TODO: Need to extend TrustManager with a verify() variants which takes a domain or appId
             trustPoint = null,
             encodedSessionTranscript = encodedSessionTranscript,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptEntryFieldData.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/prompt/consent/ConsentPromptEntryFieldData.kt
@@ -4,6 +4,7 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import com.android.identity.document.DocumentRequest
 import com.android.identity.document.NameSpacedData
+import com.android.identity.issuance.CredentialFormat
 import com.android.identity.trustmanagement.TrustPoint
 
 /**
@@ -16,11 +17,13 @@ data class ConsentPromptEntryFieldData(
     // Object extracted from the document request
     val documentRequest: DocumentRequest,
     // Requested doc type
-    val docType: String,
+    val docType: String?,
     // Document name of credential being used to respond with requested data
     val documentName: String,
     // Data in the credential
     val credentialData: NameSpacedData,
+    // Credential format
+    val credentialFormat: CredentialFormat,
     // Id of credential that provides documentName - used after Consent Prompt succeeds
     val credentialId: String,
     // Party requesting to verify user's data

--- a/wallet/src/test/java/com/android/identity_credential/wallet/OpenID4VPTest.kt
+++ b/wallet/src/test/java/com/android/identity_credential/wallet/OpenID4VPTest.kt
@@ -19,6 +19,31 @@ class OpenID4VPTest {
     private val eudiAgeOver18RequestObject = "eyJ4NWMiOlsiTUlJREtqQ0NBckNnQXdJQkFnSVVmeTl1NlNMdGdOdWY5UFhZYmgvUURxdVh6NTB3Q2dZSUtvWkl6ajBFQXdJd1hERWVNQndHQTFVRUF3d1ZVRWxFSUVsemMzVmxjaUJEUVNBdElGVlVJREF4TVMwd0t3WURWUVFLRENSRlZVUkpJRmRoYkd4bGRDQlNaV1psY21WdVkyVWdTVzF3YkdWdFpXNTBZWFJwYjI0eEN6QUpCZ05WQkFZVEFsVlVNQjRYRFRJME1ESXlOakF5TXpZek0xb1hEVEkyTURJeU5UQXlNell6TWxvd2FURWRNQnNHQTFVRUF3d1VSVlZFU1NCU1pXMXZkR1VnVm1WeWFXWnBaWEl4RERBS0JnTlZCQVVUQXpBd01URXRNQ3NHQTFVRUNnd2tSVlZFU1NCWFlXeHNaWFFnVW1WbVpYSmxibU5sSUVsdGNHeGxiV1Z1ZEdGMGFXOXVNUXN3Q1FZRFZRUUdFd0pWVkRCWk1CTUdCeXFHU000OUFnRUdDQ3FHU000OUF3RUhBMElBQk1iV0JBQzFHaitHRE8veUNTYmdiRndwaXZQWVdMekV2SUxOdGRDdjdUeDFFc3hQQ3hCcDNEWkI0RklyNEJsbVZZdEdhVWJvVklpaFJCaVFEbzNNcFdpamdnRkJNSUlCUFRBTUJnTlZIUk1CQWY4RUFqQUFNQjhHQTFVZEl3UVlNQmFBRkxOc3VKRVhITmVrR21ZeGgwTGhpOEJBekpVYk1DVUdBMVVkRVFRZU1CeUNHblpsY21sbWFXVnlMV0poWTJ0bGJtUXVaWFZrYVhjdVpHVjJNQklHQTFVZEpRUUxNQWtHQnlpQmpGMEZBUVl3UXdZRFZSMGZCRHd3T2pBNG9EYWdOSVl5YUhSMGNITTZMeTl3Y21Wd2NtOWtMbkJyYVM1bGRXUnBkeTVrWlhZdlkzSnNMM0JwWkY5RFFWOVZWRjh3TVM1amNtd3dIUVlEVlIwT0JCWUVGRmdtQWd1QlN2U25tNjhaem81SVN0SXYyZk0yTUE0R0ExVWREd0VCL3dRRUF3SUhnREJkQmdOVkhSSUVWakJVaGxKb2RIUndjem92TDJkcGRHaDFZaTVqYjIwdlpYVXRaR2xuYVhSaGJDMXBaR1Z1ZEdsMGVTMTNZV3hzWlhRdllYSmphR2wwWldOMGRYSmxMV0Z1WkMxeVpXWmxjbVZ1WTJVdFpuSmhiV1YzYjNKck1Bb0dDQ3FHU000OUJBTUNBMmdBTUdVQ01RREdmZ0xLbmJLaGlPVkYzeFNVMGFlanUvbmVHUVVWdU5ic1F3MExlRER3SVcrckxhdGViUmdvOWhNWERjM3dybFVDTUFJWnlKN2xSUlZleU1yM3dqcWtCRjJsOVliMHdPUXBzblpCQVZVQVB5STV4aFdYMlNBYXpvbTJKanNOL2FLQWtRPT0iLCJNSUlESFRDQ0FxT2dBd0lCQWdJVVZxamd0SnFmNGhVWUprcWRZemkrMHh3aHdGWXdDZ1lJS29aSXpqMEVBd013WERFZU1Cd0dBMVVFQXd3VlVFbEVJRWx6YzNWbGNpQkRRU0F0SUZWVUlEQXhNUzB3S3dZRFZRUUtEQ1JGVlVSSklGZGhiR3hsZENCU1pXWmxjbVZ1WTJVZ1NXMXdiR1Z0Wlc1MFlYUnBiMjR4Q3pBSkJnTlZCQVlUQWxWVU1CNFhEVEl6TURrd01URTRNelF4TjFvWERUTXlNVEV5TnpFNE16UXhObG93WERFZU1Cd0dBMVVFQXd3VlVFbEVJRWx6YzNWbGNpQkRRU0F0SUZWVUlEQXhNUzB3S3dZRFZRUUtEQ1JGVlVSSklGZGhiR3hsZENCU1pXWmxjbVZ1WTJVZ1NXMXdiR1Z0Wlc1MFlYUnBiMjR4Q3pBSkJnTlZCQVlUQWxWVU1IWXdFQVlIS29aSXpqMENBUVlGSzRFRUFDSURZZ0FFRmc1U2hmc3hwNVIvVUZJRUtTM0wyN2R3bkZobmpTZ1VoMmJ0S09RRW5mYjNkb3llcU1BdkJ0VU1sQ2xoc0YzdWVmS2luQ3cwOE5CMzFyd0MrZHRqNlgvTEUzbjJDOWpST0lVTjhQcm5sTFM1UXM0UnM0WlU1T0lnenRvYU84RzlvNElCSkRDQ0FTQXdFZ1lEVlIwVEFRSC9CQWd3QmdFQi93SUJBREFmQmdOVkhTTUVHREFXZ0JTemJMaVJGeHpYcEJwbU1ZZEM0WXZBUU15Vkd6QVdCZ05WSFNVQkFmOEVEREFLQmdncmdRSUNBQUFCQnpCREJnTlZIUjhFUERBNk1EaWdOcUEwaGpKb2RIUndjem92TDNCeVpYQnliMlF1Y0d0cExtVjFaR2wzTG1SbGRpOWpjbXd2Y0dsa1gwTkJYMVZVWHpBeExtTnliREFkQmdOVkhRNEVGZ1FVczJ5NGtSY2MxNlFhWmpHSFF1R0x3RURNbFJzd0RnWURWUjBQQVFIL0JBUURBZ0VHTUYwR0ExVWRFZ1JXTUZTR1VtaDBkSEJ6T2k4dloybDBhSFZpTG1OdmJTOWxkUzFrYVdkcGRHRnNMV2xrWlc1MGFYUjVMWGRoYkd4bGRDOWhjbU5vYVhSbFkzUjFjbVV0WVc1a0xYSmxabVZ5Wlc1alpTMW1jbUZ0WlhkdmNtc3dDZ1lJS29aSXpqMEVBd01EYUFBd1pRSXdhWFVBM2orK3hsL3RkRDc2dFhFV0Npa2ZNMUNhUno0dnpCQzdOUzB3Q2RJdEtpejZIWmVWOEVQdE5DbnNmS3BOQWpFQXFyZGVLRG5yNUt3ZjhCQTd0QVRlaHhObE9WNEhuYzEwWE8xWFVMdGlnQ3diNDlScGtxbFMySHVsK0RwcU9iVXMiXSwidHlwIjoib2F1dGgtYXV0aHotcmVxK2p3dCIsImFsZyI6IkVTMjU2In0.eyJyZXNwb25zZV91cmkiOiJodHRwczovL3ZlcmlmaWVyLWJhY2tlbmQuZXVkaXcuZGV2L3dhbGxldC9kaXJlY3RfcG9zdCIsImNsaWVudF9pZF9zY2hlbWUiOiJ4NTA5X3Nhbl9kbnMiLCJyZXNwb25zZV90eXBlIjoidnBfdG9rZW4iLCJub25jZSI6IjliNGYwNGEzLTgzMjgtNGE4Ny1iMGYxLTIzNTBmNjJkNDczNiIsImNsaWVudF9pZCI6InZlcmlmaWVyLWJhY2tlbmQuZXVkaXcuZGV2IiwicmVzcG9uc2VfbW9kZSI6ImRpcmVjdF9wb3N0Lmp3dCIsImF1ZCI6Imh0dHBzOi8vc2VsZi1pc3N1ZWQubWUvdjIiLCJzY29wZSI6IiIsInByZXNlbnRhdGlvbl9kZWZpbml0aW9uIjp7ImlkIjoiMzJmNTQxNjMtNzE2Ni00OGYxLTkzZDgtZmYyMTdiZGIwNjUzIiwiaW5wdXRfZGVzY3JpcHRvcnMiOlt7ImlkIjoiZXUuZXVyb3BhLmVjLmV1ZGl3LnBpZC4xIiwibmFtZSI6IkVVREkgUElEIiwicHVycG9zZSI6IldlIG5lZWQgdG8gdmVyaWZ5IHlvdXIgaWRlbnRpdHkiLCJmb3JtYXQiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiIsIkVkRFNBIiwiRVNCMjU2IiwiRVNCMzIwIiwiRVNCMzg0IiwiRVNCNTEyIl19fSwiY29uc3RyYWludHMiOnsiZmllbGRzIjpbeyJwYXRoIjpbIiRbJ2V1LmV1cm9wYS5lYy5ldWRpdy5waWQuMSddWydhZ2Vfb3Zlcl8xOCddIl0sImludGVudF90b19yZXRhaW4iOmZhbHNlfV19fV19LCJzdGF0ZSI6IjQ0elo3Rm1yTTRuU3VvNWNKb1FYMkd4MXBLaW9Bd1ZiTl9nT2FTT1IxTi1HR2kySmZDa3k2NDFSMVVzU0pUNmJLMkFMTzR6VVE3U09WeWMwbWR5NWt3IiwiaWF0IjoxNzE2MjIxMDExLCJjbGllbnRfbWV0YWRhdGEiOnsiYXV0aG9yaXphdGlvbl9lbmNyeXB0ZWRfcmVzcG9uc2VfYWxnIjoiRUNESC1FUyIsImF1dGhvcml6YXRpb25fZW5jcnlwdGVkX3Jlc3BvbnNlX2VuYyI6IkExMjhDQkMtSFMyNTYiLCJpZF90b2tlbl9lbmNyeXB0ZWRfcmVzcG9uc2VfYWxnIjoiUlNBLU9BRVAtMjU2IiwiaWRfdG9rZW5fZW5jcnlwdGVkX3Jlc3BvbnNlX2VuYyI6IkExMjhDQkMtSFMyNTYiLCJqd2tzX3VyaSI6Imh0dHBzOi8vdmVyaWZpZXItYmFja2VuZC5ldWRpdy5kZXYvd2FsbGV0L2phcm0vNDR6WjdGbXJNNG5TdW81Y0pvUVgyR3gxcEtpb0F3VmJOX2dPYVNPUjFOLUdHaTJKZkNreTY0MVIxVXNTSlQ2YksyQUxPNHpVUTdTT1Z5YzBtZHk1a3cvandrcy5qc29uIiwic3ViamVjdF9zeW50YXhfdHlwZXNfc3VwcG9ydGVkIjpbInVybjppZXRmOnBhcmFtczpvYXV0aDpqd2stdGh1bWJwcmludCJdLCJpZF90b2tlbl9zaWduZWRfcmVzcG9uc2VfYWxnIjoiUlMyNTYifX0.xLzRWy-mPHPC3oaczv71R1eaz_7kumUVC1CIx3wpt2v6HjZa6vQIhyISGGNgdqANBvAs-xiSXzFYp-zcVOQCDQ"
     // the request object in ISO 18013-7 Annex B
     private val annexBRequestObject = "eyJ4NWMiOlsiTUlJQ1B6Q0NBZVdnQXdJQkFnSVVEbUJYeDcrMTlLaHdqbHREYkJXNEJFMENSUkV3Q2dZSUtvWkl6ajBFQXdJd2FURUxNQWtHIEExVUVCaE1DVlZReER6QU5CZ05WQkFnTUJsVjBiM0JwWVRFTk1Bc0dBMVVFQnd3RVEybDBlVEVTTUJBR0ExVUVDZ3dKUVVOTlIgU0JEYjNKd01SQXdEZ1lEVlFRTERBZEpWQ0JFWlhCME1SUXdFZ1lEVlFRRERBdGxlR0Z0Y0d4bExtTnZiVEFlRncweU16RXdNRCBNeE5EUTVNemhhRncweU5EQTVNak14TkRRNU16aGFNR2t4Q3pBSkJnTlZCQVlUQWxWVU1ROHdEUVlEVlFRSURBWlZkRzl3YVdFIHhEVEFMQmdOVkJBY01CRU5wZEhreEVqQVFCZ05WQkFvTUNVRkRUVVVnUTI5eWNERVFNQTRHQTFVRUN3d0hTVlFnUkdWd2RERVUgTUJJR0ExVUVBd3dMWlhoaGJYQnNaUzVqYjIwd1dUQVRCZ2NxaGtqT1BRSUJCZ2dxaGtqT1BRTUJCd05DQUFSZkxoK2NXWHE1ZiBXUmY5Q3dvOFZSa3A5QUFPT0xhUDNVQ2kzWVkxVkRISEV4N2xBbjlNQ1hvL3ZuaXFMODhWRkVpMVB0VDlPRGFJTlZJWFpGRmpPIHJZbzJzd2FUQWRCZ05WSFE0RUZnUVV4djZIdFJRazlxN0FTUUNVcU9xRXVuNVM4UVF3SHdZRFZSMGpCQmd3Rm9BVXh2Nkh0UlEgazlxN0FTUUNVcU9xRXVuNVM4UVF3RHdZRFZSMFRBUUgvQkFVd0F3RUIvekFXQmdOVkhSRUVEekFOZ2d0bGVHRnRjR3hsTG1OdiBiVEFLQmdncWhrak9QUVFEQWdOSUFEQkZBaUJ0NS9tYWl4SnlhV05LRzhXOWRBZVBodmhoNU9IanN3SmFFamN5WWlxb29nSWhBIE53VEdUZGcxMlJFelFNZlFTWFRTVnROcDFqakpNUHNpcHFSN2tJSzFKZFQiXSwidHlwIjoiSldUIiwiYWxnIjoiRVMyNTYifQ.eyJhdWQiOiJodHRwczovL3NlbGYtaXNzdWVkLm1lL3YyIiwicmVzcG9uc2VfdHlwZSI6InZwX3Rva2VuIiwicHJlc2VudGF0aW9uX2RlZmluaXRpb24iOnsiaWQiOiJtREwtc2FtcGxlLXJlcSIsImlucHV0X2Rlc2NyaXB0b3JzIjpbeyJpZCI6Im9yZy5pc28uMTgwMTMuNS4xLm1ETCAiLCJmb3JtYXQiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiIsIkVkRFNBIiwiRVNCMjU2IiwiRVNCMzIwIiwiRVNCMzg0IiwiRVNCNTEyIl19fSwiY29uc3RyYWludHMiOnsiZmllbGRzIjpbeyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2JpcnRoX2RhdGUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2RvY3VtZW50X251bWJlciddIl0sImludGVudF90b19yZXRhaW4iOmZhbHNlfSx7InBhdGgiOlsiJFsnb3JnLmlzby4xODAxMy41LjEnXVsnZHJpdmluZ19wcml2aWxlZ2VzJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWydleHBpcnlfZGF0ZSddIl0sImludGVudF90b19yZXRhaW4iOmZhbHNlfSx7InBhdGgiOlsiJFsnb3JnLmlzby4xODAxMy41LjEnXVsnZmFtaWx5X25hbWUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2dpdmVuX25hbWUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2lzc3VlX2RhdGUnXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ2lzc3VpbmdfYXV0aG9yaXR5J10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWydpc3N1aW5nX2NvdW50cnknXSJdLCJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZX0seyJwYXRoIjpbIiRbJ29yZy5pc28uMTgwMTMuNS4xJ11bJ3BvcnRyYWl0J10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9LHsicGF0aCI6WyIkWydvcmcuaXNvLjE4MDEzLjUuMSddWyd1bl9kaXN0aW5ndWlzaGluZ19zaWduJ10iXSwiaW50ZW50X3RvX3JldGFpbiI6ZmFsc2V9XSwibGltaXRfZGlzY2xvc3VyZSI6InJlcXVpcmVkIn19XX0sImNsaWVudF9tZXRhZGF0YSI6eyJqd2tzIjp7ImtleXMiOlt7Imt0eSI6IkVDIiwidXNlIjoiZW5jIiwiY3J2IjoiUC0yNTYiLCJ4IjoieFZMdFphUFBLLXh2cnVoMWZFQ2xOVlRSNlJDWkJzUWFpMi1Ecm55S2t4ZyIsInkiOiItNS1RdEZxSnFHd09qRUwzVXQ4OW5yRTBNZWFVcDVSb3prc0tIcEJpeXcwIiwiYWxnIjoiRUNESC1FUyIsImtpZCI6IlA4cDB2aXJSbGg2ZkFraDUtWVNlSHQ0RUl2LWhGR25lWWsxNGQ4REY1MXcifV19LCJhdXRob3JpemF0aW9uX2VuY3J5cHRlZF9yZXNwb25zZV9hbGciOiJFQ0RILUVTIiwiYXV0aG9yaXphdGlvbl9lbmNyeXB0ZWRfcmVzcG9uc2VfZW5jIjoiQTI1NkdDTSIsInZwX2Zvcm1hdHMiOnsibXNvX21kb2MiOnsiYWxnIjpbIkVTMjU2IiwiRVMzODQiLCJFUzUxMiIsIkVkRFNBIiwiRVNCMjU2IiwiRVNCMzIwIiwiRVNCMzg0IiwiRVNCNTEyIl19fX0sInN0YXRlIjoiMzRhc2ZkMzRfMzQkMzQiLCJub25jZSI6IlNhZmRhZXKnJDQ1XzMzNDIiLCJjbGllbnRfaWQiOiJleGFtcGxlLmNvbSAiLCJjbGllbnRfaWRfc2NoZW1lIjoieDUwOV9zYW5fZG5zIiwicmVzcG9uc2VfbW9kZSI6ImRpcmVjdF9wb3N0Lmp3dCIsInJlc3BvbnNlX3VyaSI6Imh0dHBzOi8vZXhhbXBsZS5jb20vMTIzNDUvcmVzcG9uc2UifQ.DIEllOaSydngto5RYP-W5eWifqcqylKuRXYoZwtSo8ekWPkTE1_IfabbpkYCS9Y42HuAbuKiVQCN2OKAyabEwA"
+    // Test example created by our verifier servlet.
+    private val sdjwtRequestObject = "eyJ4NWMiOlsiTUlJQkZqQ0J2YUFEQWdFQ0FnRUJNQW9HQ0NxR1NNNDlCQU1DTUJVe" +
+            "EV6QVJCZ05WQkFNTUNsSmxZV1JsY2lCTFpYa3dIaGNOTWpRd09ERXlNak0wT0RNMldoY05NelF3T0RFeU1qT" +
+            "TBPRE0yV2pBVk1STXdFUVlEVlFRRERBcFNaV0ZrWlhJZ1MyVjVNRmt3RXdZSEtvWkl6ajBDQVFZSUtvWkl6a" +
+            "jBEQVFjRFFnQUV6bXNVckdCM3NYWjFBTGh2VWRyVXdUNDkyNktHVVV2MXI0TDFPdjBEM2lfQzFNN0p0c0RuT" +
+            "TYzS2V2czVXTU91QVpTUkRKaUJneS16OFFsMXdtUXh4akFLQmdncWhrak9QUVFEQWdOSUFEQkZBaUVBN1Vjc" +
+            "WRqRjlINUROM1VELWdjdy1JM0Q1cVBxc3ltNGF1akhRMWhBeTVkMENJSGt6VTFvMF9HZzZiQmI2UFdjendPO" +
+            "Dg1blF4dk5RSHd1Mjh1TEl0T0VObSJdLCJ0eXAiOiJvYXV0aC1hdXRoei1yZXErand0IiwiYWxnIjoiRVMyN" +
+            "TYifQ.eyJyZXNwb25zZV91cmkiOiJodHRwOi8vLzE5Mi4xNjguOTQuMzc6ODA4MC9zZXJ2ZXIvdmVyaWZpZX" +
+            "Ivb3BlbmlkNHZwUmVzcG9uc2U_c2Vzc2lvbklkPWIyNjE5YzYyMzM0YzkxZDE2ZGZjZmFlM2EzNmQ2MGNiIi" +
+            "wicmVzcG9uc2VfdHlwZSI6InZwX3Rva2VuIiwicHJlc2VudGF0aW9uX2RlZmluaXRpb24iOnsiaW5wdXRfZG" +
+            "VzY3JpcHRvcnMiOlt7ImZvcm1hdCI6eyJqd3RfdnAiOnsiYWxnIjpbIkVTMjU2Il19fSwiaWQiOiJodHRwcz" +
+            "ovL2V4YW1wbGUuYm1pLmJ1bmQuZGUvY3JlZGVudGlhbC9waWQvMS4wIiwiY29uc3RyYWludHMiOnsibGltaX" +
+            "RfZGlzY2xvc3VyZSI6InJlcXVpcmVkIiwiZmllbGRzIjpbeyJpbnRlbnRfdG9fcmV0YWluIjpmYWxzZSwicG" +
+            "F0aCI6WyIkWydodHRwczovL2V4YW1wbGUuYm1pLmJ1bmQuZGUvY3JlZGVudGlhbC9waWQvMS4wJ11bJ2FnZV" +
+            "9vdmVyXzE4J10iXX1dfX1dLCJpZCI6InJlcXVlc3QtVE9ETy1pZCJ9LCJzdGF0ZSI6ImIyNjE5YzYyMzM0Yz" +
+            "kxZDE2ZGZjZmFlM2EzNmQ2MGNiIiwibm9uY2UiOiJhYzQxZDAwYTlmMDEwYmRiM2VlNzMwZmFlNmJiZTM4OC" +
+            "IsImNsaWVudF9pZCI6Imh0dHA6Ly8xMC4wLjIuMjo4MDgwL3NlcnZlciIsImNsaWVudF9tZXRhZGF0YSI6ey" +
+            "JhdXRob3JpemF0aW9uX2VuY3J5cHRlZF9yZXNwb25zZV9hbGciOiJFQ0RILUVTIiwiYXV0aG9yaXphdGlvbl" +
+            "9lbmNyeXB0ZWRfcmVzcG9uc2VfZW5jIjoiQTEyOENCQy1IUzI1NiIsImp3a3MiOlt7Imt0eSI6IkVDIiwidX" +
+            "NlIjoiZW5jIiwiY3J2IjoiUC0yNTYiLCJ4IjoiMEdpVXlVejFJamhFMDZCdml3LVFLcHNMV2NvUVl6RVhLM3" +
+            "NCZUhlMjd1byIsInkiOiJMSC04c3dwaTZOem15aU5Oa1dBb3lOcG5Yd0xNVFh1M2VSLUg2dTQzUzhvIiwiYW" +
+            "xnIjoiRUNESC1FUyJ9XSwicmVzcG9uc2VfbW9kZSI6ImRpcmVjdF9wb3N0Lmp3dCJ9LCJyZXNwb25zZV9tb2" +
+            "RlIjoiZGlyZWN0X3Bvc3Quand0In0.6VvDuIZ6QhLbzVyncJ-3mEkykYAadSqmgpjxd72j6zxeivNxGpnPh0" +
+            "c7YxCHbGNHY47ZZ7STu6LxbJY6EOWHHw"
 
     @Test
     fun testParsePath() {
@@ -133,6 +158,53 @@ class OpenID4VPTest {
             DocumentRequest.DataElement("org.iso.18013.5.1", "issuing_country", false),
             DocumentRequest.DataElement("org.iso.18013.5.1", "portrait", false),
             DocumentRequest.DataElement("org.iso.18013.5.1", "un_distinguishing_sign", false))
+        Assert.assertEquals(expectedRequestedElems, docRequest.requestedDataElements)
+    }
+
+    @Test
+    fun sdjwtResponse() {
+        val authRequest = getAuthRequestFromJwt(SignedJWT.parse(sdjwtRequestObject), "http://10.0.2.2:8080/server")
+        Assert.assertEquals(parseToJsonElement(
+            "{\"input_descriptors\":[" +
+                    "{\"format\":{\"jwt_vp\":{\"alg\":[\"ES256\"]}}," +
+                    "\"id\":\"https://example.bmi.bund.de/credential/pid/1.0\"," +
+                    "\"constraints\":{\"limit_disclosure\":\"required\",\"fields\":[" +
+                    "{\"intent_to_retain\":false,\"path\":[\"$['https://example.bmi.bund.de/credential/pid/1.0']['age_over_18']\"]}]" +
+                    "}}]," +
+                    "\"id\":\"request-TODO-id\"}"),
+            authRequest.presentationDefinition)
+        Assert.assertEquals("http://10.0.2.2:8080/server", authRequest.clientId)
+        Assert.assertEquals("ac41d00a9f010bdb3ee730fae6bbe388", authRequest.nonce)
+        Assert.assertEquals("http:///192.168.94.37:8080/server/verifier/openid4vpResponse?sessionId=b2619c62334c91d16dfcfae3a36d60cb",
+            authRequest.responseUri)
+        Assert.assertEquals("b2619c62334c91d16dfcfae3a36d60cb",
+            authRequest.state)
+        Assert.assertEquals(parseToJsonElement(
+            "{\"authorization_encrypted_response_alg\":\"ECDH-ES\"," +
+                    "\"authorization_encrypted_response_enc\":\"A128CBC-HS256\"," +
+                    "\"jwks\":[{" +
+                    "        \"kty\":\"EC\"," +
+                    "        \"use\":\"enc\"," +
+                    "        \"crv\":\"P-256\"," +
+                    "        \"x\":\"0GiUyUz1IjhE06Bviw-QKpsLWcoQYzEXK3sBeHe27uo\"," +
+                    "        \"y\":\"LH-8swpi6NzmyiNNkWAoyNpnXwLMTXu3eR-H6u43S8o\"," +
+                    "        \"alg\":\"ECDH-ES\"}]," +
+                    "\"response_mode\":\"direct_post.jwt\"}"),
+            authRequest.clientMetadata!!)
+
+        val presentationSubmission = createPresentationSubmission(authRequest)
+        Assert.assertEquals("request-TODO-id",
+            presentationSubmission.definitionId)
+        val descriptorMaps = presentationSubmission.descriptorMaps
+        for (descriptorMap: DescriptorMap in descriptorMaps) {
+            Assert.assertEquals("https://example.bmi.bund.de/credential/pid/1.0", descriptorMap.id)
+            Assert.assertEquals("jwt_vp", descriptorMap.format)
+            Assert.assertEquals("$", descriptorMap.path)
+        }
+
+        val docRequest = formatAsDocumentRequest(authRequest.presentationDefinition["input_descriptors"]!!.jsonArray[0].jsonObject)
+        val expectedRequestedElems = listOf(
+            DocumentRequest.DataElement("https://example.bmi.bund.de/credential/pid/1.0", "age_over_18", false))
         Assert.assertEquals(expectedRequestedElems, docRequest.requestedDataElements)
     }
 }


### PR DESCRIPTION
This adds support to the verifier server to request an SD-JWT PID, then check and display the results. There are corresponding changes to the oid4vp presentation code in the client.

This contains a number of shortcuts that should probably be refactored in the future to make the code cleaner, including:
- Display names in the consent prompt code, rather than a new document type that describes all the known SD-JWT fields.
- Several "if mdoc / if sdjwt" patterns that would be cleaner if this functionality were moved into corresponding classes.
- Special handling for several fields that exist in the SD-JWT but are not in the list of disclosures.

The request and checks in the server likely have differences from the standard. Please file bugs for any differences you find.

Tested by:
- Manual tests from an emulated device to a local verifier server.
- Manual tests from a real device to a local verifier server.
- Manual tests using our Utopia PIDs.
- Manual tests using the Funke-provided PID using SD-JWT.
- ./gradlew check

- [x] Tests pass
