### PR TITLE
Remove the UI that indicated when a requested value was not returned.

### DIFF
--- a/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
@@ -833,7 +833,6 @@ class VerifierServlet : HttpServlet() {
         val missingClaims = requestedClaimsSet - disclosedClaims
         for (missingClaim in missingClaims.sorted()) {
             Logger.w(TAG, "Value not disclosed for key: $missingClaim")
-            lines.add(OpenID4VPResultLine("Value not disclosed:", missingClaim))
         }
 
         val json = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
This was useful for debugging, but we don't want it surfaced in the UI anymore.

Tested by:
- Manual testing
- ./gradlew check

- [x] Tests pass