### PR TITLE
verifier: Add support for W3C Digital Credentials API.

### DIFF
--- a/identity-doctypes/src/commonMain/kotlin/com/android/identity/documenttype/knowntypes/DrivingLicense.kt
+++ b/identity-doctypes/src/commonMain/kotlin/com/android/identity/documenttype/knowntypes/DrivingLicense.kt
@@ -759,8 +759,9 @@ object DrivingLicense {
                 null
             )
             .addSampleRequest(
-                "US Transportation",
-                mapOf(
+                id = "us-transportation",
+                displayName = "US Transportation",
+                mdocDataElements = mapOf(
                     Pair(MDL_NAMESPACE, listOf(
                         "sex",
                         "portrait",
@@ -778,8 +779,19 @@ object DrivingLicense {
                 ),
             )
             .addSampleRequest(
-                "Age Over 21 + Portrait",
-                mapOf(
+                id ="age_over_18_and_portrait",
+                displayName ="Age Over 18 + Portrait",
+                mdocDataElements = mapOf(
+                    Pair(MDL_NAMESPACE, listOf(
+                        "age_over_18",
+                        "portrait"
+                    ))
+                ),
+            )
+            .addSampleRequest(
+                id ="age_over_21_and_portrait",
+                displayName ="Age Over 21 + Portrait",
+                mdocDataElements = mapOf(
                     Pair(MDL_NAMESPACE, listOf(
                         "age_over_21",
                         "portrait"
@@ -787,8 +799,19 @@ object DrivingLicense {
                 ),
             )
             .addSampleRequest(
-                "Mandatory Data Elements",
-                mapOf(
+                id ="age_over_21_and_portrait",
+                displayName ="Age Over 21 + Portrait",
+                mdocDataElements = mapOf(
+                    Pair(MDL_NAMESPACE, listOf(
+                        "age_over_21",
+                        "portrait"
+                    ))
+                ),
+            )
+            .addSampleRequest(
+                id = "mandatory",
+                displayName = "Mandatory Data Elements",
+                mdocDataElements = mapOf(
                     Pair(MDL_NAMESPACE, listOf(
                         "family_name",
                         "given_name",
@@ -805,8 +828,9 @@ object DrivingLicense {
                 )
             )
             .addSampleRequest(
-                "All Data Elements",
-                mapOf(
+                id = "full",
+                displayName ="All Data Elements",
+                mdocDataElements = mapOf(
                     Pair(MDL_NAMESPACE, listOf()),
                     Pair(AAMVA_NAMESPACE, listOf())
                 )

--- a/identity-doctypes/src/commonMain/kotlin/com/android/identity/documenttype/knowntypes/EUPersonalID.kt
+++ b/identity-doctypes/src/commonMain/kotlin/com/android/identity/documenttype/knowntypes/EUPersonalID.kt
@@ -29,6 +29,7 @@ import com.android.identity.documenttype.DocumentType
 object EUPersonalID {
     const val EUPID_DOCTYPE = "eu.europa.ec.eudi.pid.1"
     const val EUPID_NAMESPACE = "eu.europa.ec.eudi.pid.1"
+    const val EUPID_VCT = "urn:eu.europa.ec.eudi:pid:1"
 
     /**
      * Build the EU Personal ID Document Type.
@@ -36,7 +37,8 @@ object EUPersonalID {
     fun getDocumentType(): DocumentType {
         return DocumentType.Builder("EU Personal ID")
             .addMdocDocumentType(EUPID_DOCTYPE)
-            .addMdocAttribute(
+            .addVcDocumentType("EuPersonalID")
+            .addAttribute(
                 DocumentAttributeType.String,
                 "family_name",
                 "Family Name",
@@ -45,7 +47,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.FAMILY_NAME.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "given_name",
                 "Given Names",
@@ -54,7 +56,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.GIVEN_NAME.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.Date,
                 "birth_date",
                 "Date of Birth",
@@ -63,7 +65,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.birthDate.toDataItemFullDate()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.Number,
                 "age_in_years",
                 "Age in Years",
@@ -72,7 +74,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.AGE_IN_YEARS.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.Number,
                 "age_birth_year",
                 "Year of Birth",
@@ -81,7 +83,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.AGE_BIRTH_YEAR.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.Boolean,
                 "age_over_18",
                 "Older Than 18",
@@ -90,7 +92,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.AGE_OVER_18.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.Boolean,
                 "age_over_21",
                 "Older Than 21",
@@ -99,7 +101,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.AGE_OVER_21.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "family_name_birth",
                 "Family Name at Birth",
@@ -108,7 +110,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.FAMILY_NAME_BIRTH.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "given_name_birth",
                 "First Name at Birth",
@@ -117,7 +119,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.GIVEN_NAME_BIRTH.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "birth_place",
                 "Place of Birth",
@@ -126,7 +128,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.BIRTH_PLACE.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
                 "birth_country",
                 "Country of Birth",
@@ -135,7 +137,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.BIRTH_COUNTRY.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "birth_state",
                 "State of Birth",
@@ -144,7 +146,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.BIRTH_STATE.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "birth_city",
                 "City of Birth",
@@ -153,7 +155,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.BIRTH_CITY.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "resident_address",
                 "Resident Address",
@@ -162,7 +164,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.RESIDENT_ADDRESS.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
                 "resident_country",
                 "Resident Country",
@@ -171,7 +173,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.RESIDENT_COUNTRY.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "resident_state",
                 "Resident State",
@@ -180,7 +182,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.RESIDENT_STATE.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "resident_city",
                 "Resident City",
@@ -189,7 +191,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.RESIDENT_CITY.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "resident_postal_code",
                 "Resident Postal Code",
@@ -198,7 +200,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.RESIDENT_POSTAL_CODE.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "resident_street",
                 "Resident Street",
@@ -207,7 +209,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.RESIDENT_STREET.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "resident_house_number",
                 "Resident House Number",
@@ -216,7 +218,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.RESIDENT_HOUSE_NUMBER.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.IntegerOptions(Options.SEX_ISO_IEC_5218),
                 "gender",
                 "Gender",
@@ -225,7 +227,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.SEX_ISO218.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
                 "nationality",
                 "Nationality",
@@ -234,7 +236,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.NATIONALITY.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.Date,
                 "issuance_date",
                 "Date of Issue",
@@ -243,7 +245,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.issueDate.toDataItemFullDate()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.Date,
                 "expiry_date",
                 "Date of Expiry",
@@ -252,7 +254,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.expiryDate.toDataItemFullDate()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "issuing_authority",
                 "Issuing Authority",
@@ -263,7 +265,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.ISSUING_AUTHORITY_EU_PID.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "document_number",
                 "Document Number",
@@ -272,7 +274,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.DOCUMENT_NUMBER.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "administrative_number",
                 "Administrative Number",
@@ -281,7 +283,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.ADMINISTRATIVE_NUMBER.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.String,
                 "issuing_jurisdiction",
                 "Issuing Jurisdiction",
@@ -292,7 +294,7 @@ object EUPersonalID {
                 EUPID_NAMESPACE,
                 SampleData.ISSUING_JURISDICTION.toDataItem()
             )
-            .addMdocAttribute(
+            .addAttribute(
                 DocumentAttributeType.StringOptions(Options.COUNTRY_ISO_3166_1_ALPHA_2),
                 "issuing_country",
                 "Issuing Country",
@@ -303,14 +305,17 @@ object EUPersonalID {
                 SampleData.ISSUING_COUNTRY.toDataItem()
             )
             .addSampleRequest(
+                id = "age_over_18",
                 displayName = "Age Over 18",
                 mdocDataElements = mapOf(
                     Pair(EUPID_NAMESPACE, listOf(
                         "age_over_18",
                     ))
                 ),
+                vcClaims = listOf("age_over_18")
             )
             .addSampleRequest(
+                id = "mandatory",
                 displayName = "Mandatory Data Elements",
                 mdocDataElements = mapOf(
                     Pair(EUPID_NAMESPACE, listOf(
@@ -323,14 +328,26 @@ object EUPersonalID {
                         "issuing_authority",
                         "issuing_country"
                     ))
+                ),
+                vcClaims = listOf(
+                    "family_name",
+                    "given_name",
+                    "birth_date",
+                    "age_over_18",
+                    "issuance_date",
+                    "expiry_date",
+                    "issuing_authority",
+                    "issuing_country"
                 )
             )
             .addSampleRequest(
+                id = "full",
                 displayName = "All Data Elements",
                 mdocDataElements = mapOf(
                     Pair(EUPID_NAMESPACE, listOf(
                     ))
-                )
+                ),
+                vcClaims = listOf()
             )
             .build()
     }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/IssuingAuthorityState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/hardcoded/IssuingAuthorityState.kt
@@ -530,7 +530,7 @@ class IssuingAuthorityState(
         val sdJwtVcGenerator = SdJwtVcGenerator(
             random = Random.Default,
             payload = identityAttributes,
-            docType = "PersonalIdentificationDocument",
+            docType = EUPersonalID.EUPID_VCT,
             issuer = Issuer("https://example-issuer.com", Algorithm.ES256, "key-1")
         )
 

--- a/identity/src/commonMain/kotlin/com/android/identity/documenttype/DocumentType.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/documenttype/DocumentType.kt
@@ -189,15 +189,18 @@ class DocumentType private constructor(
         /**
          * Adds a sample request to the document.
          *
-         * TODO: Add support for VC claims as well.
-         *
-         * @param displayName a short name explaining the request
+         * @param id an identifier for the request.
+         * @param displayName a short name explaining the request.
          * @param mdocDataElements the mdoc data elements in the request, per namespace. If
          * the list of a namespace is empty, all defined data elements will be included.
+         * @param vcClaims the VC claims in the request. If the list is empty, all defined
+         * claims will be included.
          */
         fun addSampleRequest(
+            id: String,
             displayName: String,
-            mdocDataElements: Map<String, List<String>>?
+            mdocDataElements: Map<String, List<String>>? = null,
+            vcClaims: List<String>? = null
         ) = apply {
             val mdocRequest = if (mdocDataElements == null) {
                 null
@@ -218,7 +221,21 @@ class DocumentType private constructor(
                 }
                 MdocRequest(mdocBuilder!!.docType, nsRequests)
             }
-            sampleRequests.add(DocumentWellKnownRequest(displayName, mdocRequest))
+            val vcRequest = if (vcClaims == null) {
+                null
+            } else {
+                val claims = if (vcClaims.isEmpty()) {
+                    vcBuilder!!.claims.values.toList()
+                } else {
+                    val list = mutableListOf<DocumentAttribute>()
+                    for (claimName in vcClaims) {
+                        list.add(vcBuilder!!.claims[claimName]!!)
+                    }
+                    list
+                }
+                VcRequest(claims)
+            }
+            sampleRequests.add(DocumentWellKnownRequest(id, displayName, mdocRequest, vcRequest))
         }
 
         /**

--- a/identity/src/commonMain/kotlin/com/android/identity/documenttype/DocumentWellKnownRequest.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/documenttype/DocumentWellKnownRequest.kt
@@ -4,10 +4,15 @@ package com.android.identity.documenttype
 /**
  * Class representing a well-known document request.
  *
+ * @param id an identifier for the well-known document request (unique only for the document type)
  * @param displayName a short string with the name of the request, short enough to be used
  * for a button. For example "Age Over 21 and Portrait" or "Full mDL".
+ * @param mdocRequest the request for a mdoc, if defined.
+ * @param vcRequest the request for a VC, if defined.
  */
 data class DocumentWellKnownRequest(
+    val id: String,
     val displayName: String,
     val mdocRequest: MdocRequest?,
+    val vcRequest: VcRequest?
 )

--- a/identity/src/commonMain/kotlin/com/android/identity/documenttype/VcRequest.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/documenttype/VcRequest.kt
@@ -1,0 +1,10 @@
+package com.android.identity.documenttype
+
+/**
+ * A class representing a request for claims.
+ *
+ * @param claimsToRequest the claims to request.
+ */
+data class VcRequest(
+    val claimsToRequest: List<DocumentAttribute>
+)

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -25,6 +25,7 @@ dependencies {
     implementation(project(":identity-csa"))
     implementation(project(":identity-mdoc"))
     implementation(project(":identity-sdjwt"))
+    implementation(project(":identity-doctypes"))
 
     implementation(libs.javax.servlet.api)
     implementation(libs.kotlinx.datetime)

--- a/server/src/main/webapp/verifier.html
+++ b/server/src/main/webapp/verifier.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta http-equiv="origin-trial" content="AqrF+vKVQZS3y5OJ3K2wkWZ4yEVxroNpC0oQR3kFeRmnvjBw+T9NPftQV9reLYszk8kNYyF1Zw+u3UZ9PMuxFQIAAACBeyJvcmlnaW4iOiJodHRwczovL2RpZ2l0YWwtY3JlZGVudGlhbHMuZGV2OjQ0MyIsImZlYXR1cmUiOiJXZWJJZGVudGl0eURpZ2l0YWxDcmVkZW50aWFscyIsImV4cGlyeSI6MTc0NDc2MTU5OSwiaXNTdWJkb21haW4iOnRydWV9">
     <title>OWF Identity Credential Online Verifier</title>
     <link rel="icon" type="image/x-icon" href="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/fingerprint/default/24px.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
@@ -44,7 +45,7 @@
                         Request PID (Age Over 18)
                     </button>
                     <button type="button" class="btn btn-primary btn-lg" onclick="requestDocument('pid_mdoc_mandatory')">
-                        Request PID (Mandatory Elements)
+                        Request PID (Mandatory)
                     </button>
                     <button type="button" class="btn btn-primary btn-lg" onclick="requestDocument('pid_mdoc_full')">
                         Request PID (Full)
@@ -53,8 +54,11 @@
             </div>
             <div class="tab-pane fade" id="pills-pid_sdjwt" role="tabpanel" aria-labelledby="pills-pid_sdjwt-tab" tabindex="0">
                 <div class="d-grid gap-2 mx-auto">
+                    <button type="button" class="btn btn-primary btn-lg" onclick="requestDocument('pid_sdjwt_age_over_18')">
+                        Request PID (Age Over 18)
+                    </button>
                     <button type="button" class="btn btn-primary btn-lg" onclick="requestDocument('pid_sdjwt_mandatory')">
-                        Request PID (Mandatory Claims)
+                        Request PID (Mandatory)
                     </button>
                     <button type="button" class="btn btn-primary btn-lg" onclick="requestDocument('pid_sdjwt_full')">
                         Request PID (Full)
@@ -85,9 +89,12 @@
             <div class="dropdown">
                 <button class="btn btn-secondary dropdown-toggle btn-lg" type="button"
                         data-bs-toggle="dropdown" aria-expanded="false" id="protocolDropdown">
-                    OpenID4VP (openid4vp:// URI scheme)
+                    W3C Digital Credentials API (Preview)
                 </button>
                 <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" value="w3c_dc_preview" href="#">
+                        W3C Digital Credentials API (Preview)
+                    </a></li>
                     <li><a class="dropdown-item" value="openid4vp_plain" href="#">
                         OpenID4VP (openid4vp:// URI scheme)
                     </a></li>
@@ -106,6 +113,27 @@
         This identity verifier is part of the <a href="https://github.com/openwallet-foundation-labs/identity-credential">OWF Identity Credential</a> project
         and is considered experimental software. Use at your own risk. <a href="verifier/readerRootCert">Reader Root Certificate</a>.
     </footer>
+</div>
+
+<!-- DC Result Modal -->
+<div class="modal fade" id="dcResultModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered modal-dialog-scrollable">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="exampleModalLabel">User Data</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <ol class="list-group">
+
+                </ol>
+
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
+            </div>
+        </div>
+    </div>
 </div>
 
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/js/bootstrap.bundle.min.js" integrity="sha384-HwwvtgBNo3bZJJLYd8oVXjrBZt8cqVSpeBNS5n7C8IVInixGAoxmnlMuBnhbgrkm" crossorigin="anonymous"></script>

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedEuPidIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedEuPidIssuingAuthority.kt
@@ -261,8 +261,7 @@ class SelfSignedEuPidIssuingAuthority(
                 staticData = staticData
             ),
             sdJwtVcDocumentConfiguration = SdJwtVcDocumentConfiguration(
-                // TODO: the vct is TBD, just use this for now
-                vct = "PersonalIdentificationDocument"
+                vct = EUPersonalID.EUPID_VCT
             ),
         )
     }
@@ -289,8 +288,7 @@ class SelfSignedEuPidIssuingAuthority(
                 staticData = builder.build()
             ),
             sdJwtVcDocumentConfiguration = SdJwtVcDocumentConfiguration(
-                // TODO: the vct is TBD, just use this for now
-                vct = "PersonalIdentificationDocument"
+                vct = EUPersonalID.EUPID_VCT
             ),
         )
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedIssuingAuthority.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SelfSignedIssuingAuthority.kt
@@ -27,6 +27,7 @@ import com.android.identity.crypto.X509CertChain
 import com.android.identity.crypto.EcPrivateKey
 import com.android.identity.crypto.EcPublicKey
 import com.android.identity.crypto.javaX509Certificate
+import com.android.identity.documenttype.knowntypes.EUPersonalID
 import com.android.identity.issuance.DocumentConfiguration
 import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.simple.SimpleIssuingAuthority
@@ -134,7 +135,7 @@ abstract class SelfSignedIssuingAuthority(
         val sdJwtVcGenerator = SdJwtVcGenerator(
             random = Random(42),
             payload = identityAttributes,
-            docType = "PersonalIdentificationDocument",
+            docType = EUPersonalID.EUPID_VCT,
             issuer = Issuer("https://example-issuer.com", Algorithm.ES256, "key-1")
         )
 


### PR DESCRIPTION
Also add support for W3C VC claims in sample requests in the DocumentType API and use this to avoid repetition in VerifierServlet.

Test: Manually tested.
Test: ./gradlew check
Test: ./gradlew connectedCheck
