### PR TITLE
Clean up the SD-JWT inputDescriptor.

### DIFF
--- a/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
@@ -1179,11 +1179,9 @@ private fun sdjwtCalcPresentationDefinition(
     val fields = JSONArray()
     for (claim in request.vcRequest!!.claimsToRequest) {
         var array = JSONArray()
-        // TODO: should not include namespace here
-        array.add("\$['${EUPersonalID.EUPID_NAMESPACE}']['${claim.identifier}']")
+        array.add("\$.${claim.identifier}")
         val field = JSONObject()
         field.put("path", array)
-        field.put("intent_to_retain", false)
         fields.add(field)
     }
     val constraints = JSONObject()

--- a/wallet/src/main/java/com/android/identity_credential/wallet/presentation/OpenID4VPPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/presentation/OpenID4VPPresentationActivity.kt
@@ -530,7 +530,9 @@ class OpenID4VPPresentationActivity : FragmentActivity() {
         val requestState: String? = authorizationRequest.state
         val response = httpClient.post(authorizationRequest.responseUri) {
             body = FormData(Parameters.build {
-                append("response", jwtResponse.serialize())
+                val serializedJwtResposne = jwtResponse.serialize()
+                Logger.i(TAG, "Sending serialized JWT response: $serializedJwtResposne")
+                append("response", serializedJwtResposne)
                 requestState?.let {
                     append("state", it)
                 }


### PR DESCRIPTION
Namespaces were re-added to the descriptor in a recent CL. This strips them out again.
This also adds a little more debugging output.

Tested by:
- Manually testing the sd-jwt verification flows.
- ./gradlew check
- ./gradlew connectedCheck

- [X] Tests pass
- [ ] Appropriate changes to README are included in PR