### PR TITLE
Added TOS screen and request for notification permissions to Funke proofing workflow.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/proofing/defaultGraph.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/proofing/defaultGraph.kt
@@ -219,7 +219,7 @@ fun defaultGraph(
                 of when this happens. This requires granting a permission.
                 
                 If you previously denied this permission, attempting to grant it again might not do
-                anything and you may need to manually go into Settings and manually enable
+                anything and you may need to go into Settings and manually enable
                 notifications for this application.
             """.trimIndent(),
             grantPermissionButtonText = "Grant Permission",

--- a/server/src/main/resources/resources/funke/tos.html
+++ b/server/src/main/resources/resources/funke/tos.html
@@ -1,0 +1,5 @@
+<h2>Provisioning a Personal Identification Data (PID) credential</h2>
+<p>In the following screens, information will be collected for provisioning of a PID for
+    a fictional person used for testing only.</p>
+<p>The PID is generated and signed on the government server. The created PID will be bound to
+    this device.</p>

--- a/wallet/src/main/java/com/android/identity/issuance/remote/LocalDevelopmentEnvironment.kt
+++ b/wallet/src/main/java/com/android/identity/issuance/remote/LocalDevelopmentEnvironment.kt
@@ -169,6 +169,8 @@ class LocalDevelopmentEnvironment(
                     context.resources.getString(R.string.utopia_local_issuing_authority_tos)
                 "utopia_local_pid/tos.html" ->
                     context.resources.getString(R.string.utopia_local_issuing_authority_pid_tos)
+                "funke/tos.html" ->
+                    context.resources.getString(R.string.funke_issuing_authority_tos)
                 else -> null
             }
         }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -433,6 +433,14 @@
     <string name="utopia_eu_pid_issuing_authority_pending_document_title">Utopia PID (pending)</string>
     <string name="utopia_eu_pid_issuing_authority_document_title">%1$s\'s PID</string>
 
+    <!-- Funke issuing authority TOS -->
+    <string name="funke_issuing_authority_tos"><![CDATA[
+        <h2>Provisioning a Personal Identification Data (PID) credential</h2>
+        <p>In the following screens, information will be collected for provisioning of a PID for
+        a fictional person used for testing only.</p>
+        <p>The PID is generated and signed on the government server. The created PID will be bound to
+        this device.</p>
+    ]]></string>
     <!-- Consent Prompt -->
     <string name="consent_prompt_button_cancel">Cancel</string>
     <string name="consent_prompt_button_confirm">Share</string>


### PR DESCRIPTION
Tested manually both in "dev:" server and localhost wallet server.