### PR TITLE
Show a friendlier error message if no documents match the request.

### DIFF
--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -474,5 +474,6 @@
     <string name="qr_alert_dialog_bt_disabled_title">Bluetooth disabled</string>
     <string name="qr_alert_dialog_bt_disabled_text">Bluetooth must be enabled to share a QR connection code</string>
     <string name="qr_alert_dialog_bt_enable_button">Enable</string>
+    <string name="presentation_result_no_matching_document_message">No available documents can fulfill the request.</string>
 
 </resources>


### PR DESCRIPTION
Previously, the message just said there was an error. Now, it indicates that there are no documents available that match the request.

Tested by:
- Manual testing
- ./gradlew check

- [X] Tests pass
