### PR TITLE
Improved message for in-person presentation if no documents match the request

### DIFF
--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/response/DeviceResponseGenerator.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/response/DeviceResponseGenerator.kt
@@ -154,6 +154,11 @@ class DeviceResponseGenerator(private val mStatusCode: Long) {
     }
 
     /**
+     * Checks if any documents have been added to the device response.
+     */
+    fun isEmpty(): Boolean = mDocumentsBuilder.isEmpty()
+
+    /**
      * Builds the `DeviceResponse` CBOR.
      *
      * @return the bytes of `DeviceResponse` CBOR.

--- a/identity/src/commonMain/kotlin/com/android/identity/cbor/ArrayBuilder.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/cbor/ArrayBuilder.kt
@@ -161,4 +161,9 @@ data class ArrayBuilder<T>(private val parent: T, private val array: CborArray) 
     fun add(value: Float) = apply {
         add(value.toDataItem())
     }
+
+    /**
+     * Checks if the array is empty.
+     */
+    fun isEmpty(): Boolean = array.items.isEmpty()
 }

--- a/identity/src/commonTest/kotlin/com/android/identity/cbor/ArrayBuilderTests.kt
+++ b/identity/src/commonTest/kotlin/com/android/identity/cbor/ArrayBuilderTests.kt
@@ -1,0 +1,28 @@
+package com.android.identity.cbor
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ArrayBuilderTests {
+    @Test
+    fun testEmptyArray() {
+        val builder = CborArray.builder()
+        assertTrue { builder.isEmpty() }
+
+        val array = builder.end().build()
+        assertEquals(CborArray(mutableListOf()), array)
+    }
+
+    @Test
+    fun testNonEmptyArray() {
+        val builder = CborArray.builder()
+        builder.add(1)
+        builder.add(2)
+        assertFalse { builder.isEmpty() }
+
+        val array = builder.end().build()
+        assertEquals(CborArray(mutableListOf(1.toDataItem(), 2.toDataItem())), array)
+    }
+}


### PR DESCRIPTION
Previously, this just printed an error message. Now it indicates that there are no documents that match the request.

Tested by:
- Manual testing with various doc types, using AppVerifier as the RP.
- ./gradlew check

- [X] Tests pass