### PR TITLE
Add a notification if Bluetooth is disabled.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/SettingsModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/SettingsModel.kt
@@ -28,6 +28,7 @@ class SettingsModel(
     // Non visible in the Settings screen
     val focusedCardId = MutableLiveData("")
     val hideMissingProximityPermissionsWarning = MutableLiveData(false)
+    val hideMissingBluetoothPermissionsWarning = MutableLiveData(false)
 
     val screenLockIsSetup = MutableLiveData(false)
 


### PR DESCRIPTION
Previously, we added a dialog if the user tries to show a QR code, telling the user that Bluetooth needs to be enabled. This adds a snackbar notification before that, on the main screen when we're displaying a document.

Tested by:
- Manual testing
- ./gradlew check
- ./gradlew connectedCheck

Fixes #698

- [X] Tests pass
