### PR TITLE
Update Verifier and Presentation to Pass Conformance Tests

### DIFF
--- a/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
@@ -980,7 +980,12 @@ class VerifierServlet : HttpServlet() {
             encryptedJWT.decrypt(decrypter)
 
             val vpToken = encryptedJWT.jwtClaimsSet.getClaim("vp_token") as String
-            session.deviceResponse = vpToken.fromBase64Url()
+            if (session.requestType.format == DocumentFormat.MDOC) {
+                session.deviceResponse = vpToken.fromBase64Url()
+            } else {
+                session.deviceResponse = vpToken.toByteArray()
+            }
+
             session.sessionTranscript = createSessionTranscriptOpenID4VP(
                 clientId = clientId,
                 responseUri = session.responseUri!!,
@@ -1522,7 +1527,10 @@ private fun calcClientMetadata(session: Session, format: DocumentFormat): JSONOb
     val keys = JSONArray()
     keys.add(key)
 
-    client_metadata.put("jwks", keys)
+    val keys_map = JSONObject()
+    keys_map.put("keys", keys)
+
+    client_metadata.put("jwks", keys_map)
 
     return client_metadata
 }


### PR DESCRIPTION
Modified OpenID4VPPresentationActivity to format vpToken differently in both mdl and sd-jwt cases, and expect jwks already in a "keys" map. Updated VerifierServlet to parse vpToken after changes, and put jwks in "keys".

Tested wallet against conformance tests at https://demo.certification.openid.net/ for both sd-jwt and mdl credential types. Used response_mode=direct_post.jwt.

Manually tested verifier locally against changes in wallet to ensure verifier successfully receives + displays response from wallet.