### PR TITLE
Add "mediation: 'required'" to navigator.identity.get() calls.

### DIFF
--- a/server/src/main/webapp/verifier.js
+++ b/server/src/main/webapp/verifier.js
@@ -99,6 +99,7 @@ async function dcRequestCredential(sessionId, dcRequestProtocol, dcRequest) {
                     request: dcRequest
                 }]
             },
+            mediation: 'required',
           })
         dcProcessResponse(sessionId, credentialResponse)
     } catch (err) {


### PR DESCRIPTION
This is required as per

 https://wicg.github.io/digital-credentials/#the-digitalcredential-interface

Chrome adds this by default but this is not true for all browsers.

Test: Manually tested.