### PR TITLE
Using PID authentication as openid4vci proofing.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuingAuthorityState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuingAuthorityState.kt
@@ -13,6 +13,7 @@ import com.android.identity.documenttype.knowntypes.EUPersonalID
 import com.android.identity.flow.annotation.FlowJoin
 import com.android.identity.flow.annotation.FlowMethod
 import com.android.identity.flow.annotation.FlowState
+import com.android.identity.flow.server.Configuration
 import com.android.identity.flow.server.FlowEnvironment
 import com.android.identity.flow.server.Resources
 import com.android.identity.flow.server.Storage
@@ -468,8 +469,9 @@ class FunkeIssuingAuthorityState(
         } else {
             landingUrl = applicationSupport?.createLandingUrl() ?:
                 ApplicationSupportState(clientId).createLandingUrl(env)
-            // TODO: use real server's base URL
-            parRedirectUrl = "http://localhost:8080/server/$landingUrl"
+            val configuration = env.getInterface(Configuration::class)!!
+            val baseUrl = configuration.getValue("base_url")
+            parRedirectUrl = "$baseUrl/$landingUrl"
         }
 
         val clientKeyInfo = FunkeUtil.communicationKey(env, clientId)

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/AuthorizeServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/AuthorizeServlet.kt
@@ -1,10 +1,34 @@
 package com.android.identity.server.openid4vci
 
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborArray
+import com.android.identity.cbor.CborMap
+import com.android.identity.cbor.DataItem
+import com.android.identity.cbor.DiagnosticOption
+import com.android.identity.cbor.Simple
+import com.android.identity.cbor.Tstr
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+import com.android.identity.crypto.EcCurve
+import com.android.identity.crypto.EcPublicKey
+import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
+import com.android.identity.document.NameSpacedData
+import com.android.identity.flow.server.Configuration
+import com.android.identity.flow.server.Resources
 import com.android.identity.flow.server.Storage
+import com.android.identity.mdoc.response.DeviceResponseParser
+import com.android.identity.util.fromBase64Url
+import com.android.identity.util.fromHex
+import com.android.identity.util.toBase64Url
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import kotlinx.coroutines.runBlocking
 import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import java.net.URI
+import java.net.URL
 import kotlin.time.Duration.Companion.minutes
 
 /**
@@ -16,56 +40,147 @@ import kotlin.time.Duration.Companion.minutes
  * redirect_uri supplied to [ParServlet] on the previous step.
  */
 class AuthorizeServlet : BaseServlet() {
-
-    /**
-     * Create a simple web page for the user to enter their name.
-     *
-     * TODO: flesh this out, use web API for PID-based authentication.
-     */
-    override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
-        val requestUri = req.getParameter("request_uri")
-        val code = requestUri.substring(requestUri.lastIndexOf(":") + 1)
-        val id = codeToId(OpaqueIdType.PAR_CODE, code)
-        val stateStr = idToCode(OpaqueIdType.AUTHORIZATION_STATE, id, 20.minutes)
-        resp.contentType = "text/html"
-        resp.writer.print("""
-            <!DOCTYPE html>
-            <html>
-            <head>
-            <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-            </head>
-            <body>
-                <h1>Enter your name</h1>
-                <form action="authorize" method="post">
-                  <label for="f">First name:</label>
-                  <input type="text" id="f" name="f"><br/>
-                  <label for="l">Last name:</label>
-                  <input type="text" id="l" name="l"><br/>
-                  <input type="hidden" name="state" value="$stateStr"/>
-                  <input type="submit" value="Submit">
-                </form>
-                </form>
-            </body>
-            </html>
-        """.trimIndent())
+    companion object {
+        const val RESOURCE_BASE = "openid4vci"
     }
 
     /**
-     * Handle first/last name form submission and redirect to [FinishAuthorizationServlet].
+     * Create a simple web page for the user to authorize the credential issuance.
+     */
+    override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
+        val resources = environment.getInterface(Resources::class)!!
+        val requestUri = req.getParameter("request_uri")
+        val code = requestUri.substring(requestUri.lastIndexOf(":") + 1)
+        val id = codeToId(OpaqueIdType.PAR_CODE, code)
+        val authorizationCode = idToCode(OpaqueIdType.AUTHORIZATION_STATE, id, 20.minutes)
+        val pidReadingCode = idToCode(OpaqueIdType.PID_READING, id, 20.minutes)
+        val authorizeHtml = resources.getStringResource("$RESOURCE_BASE/authorize.html")!!
+        resp.contentType = "text/html"
+        resp.writer.print(
+            authorizeHtml
+                .replace("\$authorizationCode", authorizationCode)
+                .replace("\$pidReadingCode", pidReadingCode))
+    }
+
+    /**
+     * Handle user's authorization and redirect to [FinishAuthorizationServlet].
      */
     override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
-        val code = req.getParameter("state")
+        val code = req.getParameter("authorizationCode")
+        val pidData = req.getParameter("pidData")
+        val extraInfo = req.getParameter("extraInfo")
         val id = codeToId(OpaqueIdType.AUTHORIZATION_STATE, code)
         val storage = environment.getInterface(Storage::class)!!
+        val configuration = environment.getInterface(Configuration::class)!!
+
+        val tokenData = Json.parseToJsonElement(pidData).jsonObject["token"]!!
+            .jsonPrimitive.content.fromBase64Url()
+
+        val (cipherText, encapsulatedPublicKey) = parseCredentialDocument(tokenData)
+
         runBlocking {
+            val baseUri = URI(configuration.getValue("base_url")!!)
+            val origin = baseUri.scheme + "://" + baseUri.authority
             val state = IssuanceState.fromCbor(storage.get("IssuanceState", "", id)!!.toByteArray())
-            state.credentialData = CredentialData(
-                firstName = req.getParameter("f"),
-                lastName = req.getParameter("l")
+            val encodedKey = (state.pidReadingKey!!.publicKey as EcPublicKeyDoubleCoordinate).asUncompressedPointEncoding
+            val sessionTranscript = generateBrowserSessionTranscript(
+                Crypto.digest(Algorithm.SHA256, id.toByteArray()),
+                origin,
+                Crypto.digest(Algorithm.SHA256, encodedKey)
             )
+            val deviceResponseRaw = Crypto.hpkeDecrypt(
+                Algorithm.HPKE_BASE_P256_SHA256_AES128GCM,
+                state.pidReadingKey!!,
+                cipherText,
+                sessionTranscript,
+                encapsulatedPublicKey)
+            val parser = DeviceResponseParser(deviceResponseRaw, sessionTranscript)
+            val deviceResponse = parser.parse()
+            val data = NameSpacedData.Builder()
+            for (document in deviceResponse.documents) {
+                for (namespaceName in document.issuerNamespaces) {
+                    for (dataElementName in document.getIssuerEntryNames(namespaceName)) {
+                        val value = document.getIssuerEntryData(namespaceName, dataElementName)
+                        data.putEntry(namespaceName, dataElementName, value)
+                    }
+                }
+            }
+
+            data.putEntry("com.android.identity.server.openid4vci", "extraInfo", Cbor.encode(Tstr(extraInfo)))
+            state.credentialData = data.build()
             storage.update("IssuanceState", "", id, ByteString(state.toCbor()))
         }
         val issuerState = idToCode(OpaqueIdType.ISSUER_STATE, id, 5.minutes)
         resp.sendRedirect("finish_authorization?issuer_state=$issuerState")
     }
+}
+
+// Copied from VerifierServlet.kt as is
+// TODO: this code should be removed here and in VerifierServlet.kt and the functionality
+// factored into a reusable library.
+
+private const val BROWSER_HANDOVER_V1 = "BrowserHandoverv1"
+private const val ANDROID_CREDENTIAL_DOCUMENT_VERSION = "ANDROID-HPKE-v1"
+
+private fun parseCredentialDocument(encodedCredentialDocument: ByteArray
+): Pair<ByteArray, EcPublicKey> {
+    val map = Cbor.decode(encodedCredentialDocument)
+    val version = map["version"].asTstr
+    if (!version.equals(ANDROID_CREDENTIAL_DOCUMENT_VERSION)) {
+        throw IllegalArgumentException("Unexpected version $version")
+    }
+    val encryptionParameters = map["encryptionParameters"]
+    val pkEm = encryptionParameters["pkEm"].asBstr
+    val encapsulatedPublicKey =
+        EcPublicKeyDoubleCoordinate.fromUncompressedPointEncoding(EcCurve.P256, pkEm)
+    val cipherText = map["cipherText"].asBstr
+    return Pair(cipherText, encapsulatedPublicKey)
+}
+
+//    SessionTranscript = [
+//      null, // DeviceEngagementBytes not available
+//      null, // EReaderKeyBytes not available
+//      AndroidHandover // defined below
+//    ]
+//
+//    From https://github.com/WICG/mobile-document-request-api
+//
+//    BrowserHandover = [
+//      "BrowserHandoverv1",
+//      nonce,
+//      OriginInfoBytes, // origin of the request as defined in ISO/IEC 18013-7
+//      RequesterIdentity, // ? (omitting)
+//      pkRHash
+//    ]
+private fun generateBrowserSessionTranscript(
+    nonce: ByteArray,
+    origin: String,
+    requesterIdHash: ByteArray
+): ByteArray {
+    // TODO: Instead of hand-rolling this, we should use OriginInfoDomain which
+    //   uses `domain` instead of `baseUrl` which is what the latest version of 18013-7
+    //   calls for.
+    val originInfoBytes = Cbor.encode(
+        CborMap.builder()
+            .put("cat", 1)
+            .put("type", 1)
+            .putMap("details")
+            .put("baseUrl", origin)
+            .end()
+            .end()
+            .build()
+    )
+    return Cbor.encode(
+        CborArray.builder()
+            .add(Simple.NULL) // DeviceEngagementBytes
+            .add(Simple.NULL) // EReaderKeyBytes
+            .addArray() // BrowserHandover
+            .add(BROWSER_HANDOVER_V1)
+            .add(nonce)
+            .add(originInfoBytes)
+            .add(requesterIdHash)
+            .end()
+            .end()
+            .build()
+    )
 }

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/CredentialRequestServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/CredentialRequestServlet.kt
@@ -1,0 +1,82 @@
+package com.android.identity.server.openid4vci
+
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+import com.android.identity.crypto.EcCurve
+import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
+import com.android.identity.documenttype.knowntypes.EUPersonalID
+import com.android.identity.flow.server.Storage
+import com.android.identity.util.toBase64Url
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Generates request for Digital Credential for the browser-based authorization workflow.
+ */
+class CredentialRequestServlet : BaseServlet() {
+    companion object {
+        const val EU_PID_DOCTYPE = EUPersonalID.EUPID_DOCTYPE
+    }
+
+    override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
+        val requestLength = req.contentLength
+        val requestData = req.inputStream.readNBytes(requestLength)
+        val params = Json.parseToJsonElement(String(requestData)) as JsonObject
+        val code = params["code"]?.jsonPrimitive?.content
+        if (code == null) {
+            errorResponse(resp, "invalid_request", "missing parameter 'code'")
+            return
+        }
+        val id = codeToId(OpaqueIdType.PID_READING, code)
+        val storage = environment.getInterface(Storage::class)!!
+        runBlocking {
+            val state = IssuanceState.fromCbor(storage.get("IssuanceState", "", id)!!.toByteArray())
+            val nonce = Crypto.digest(Algorithm.SHA256, id.toByteArray()).toBase64Url()
+            state.pidReadingKey = Crypto.createEcPrivateKey(EcCurve.P256)
+            storage.update("IssuanceState", "", id, ByteString(state.toCbor()))
+            val pidPublicKey = (state.pidReadingKey!!.publicKey as EcPublicKeyDoubleCoordinate)
+                .asUncompressedPointEncoding.toBase64Url()
+            val fullPid = EUPersonalID.getDocumentType().sampleRequests.first { it.id == "full" }
+            // Request for "preview" protocol
+            val previewRequest = buildJsonObject {
+                put("selector", buildJsonObject {
+                    put("doctype", JsonPrimitive(EU_PID_DOCTYPE))
+                    put("format", buildJsonArray {
+                        add(JsonPrimitive("mdoc"))
+                    })
+                    put("fields", buildJsonArray {
+                        for (namespace in fullPid.mdocRequest!!.namespacesToRequest) {
+                            for (dataElement in namespace.dataElementsToRequest) {
+                                add(buildJsonObject {
+                                    put("intentToRetain", JsonPrimitive(false))
+                                    put("namespace", JsonPrimitive(namespace.namespace))
+                                    put("name", JsonPrimitive(dataElement.attribute.identifier))
+                                })
+                            }
+                        }
+                    })
+                })
+                put("nonce", JsonPrimitive(nonce))
+                put("readerPublicKey", JsonPrimitive(pidPublicKey))
+            }
+            val credentialRequest = buildJsonObject {
+                put("providers", buildJsonArray {
+                    add(buildJsonObject {
+                        put("protocol", JsonPrimitive("preview"))
+                        put("request", previewRequest)
+                    })
+                })
+            }
+            resp.contentType = "application/json"
+            resp.writer.write(credentialRequest.toString())
+        }
+    }
+}

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/CredentialServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/CredentialServlet.kt
@@ -126,9 +126,11 @@ class CredentialServlet : BaseServlet() {
         state: IssuanceState,
         authenticationKey: EcPublicKey
     ): String {
+
+        val data = state.credentialData!!
         val identityAttributes = buildJsonObject {
-            put("given_name", JsonPrimitive(state.credentialData!!.firstName))
-            put("family_name", JsonPrimitive(state.credentialData!!.lastName))
+            put("given_name", JsonPrimitive(data.getDataElementString(EUPersonalID.EUPID_NAMESPACE, "given_name")))
+            put("family_name", JsonPrimitive(data.getDataElementString(EUPersonalID.EUPID_NAMESPACE, "family_name")))
         }
 
         val sdJwtVcGenerator = SdJwtVcGenerator(
@@ -183,14 +185,9 @@ class CredentialServlet : BaseServlet() {
         )
         msoGenerator.setValidityInfo(timeSigned, validFrom, validUntil, null)
 
-        val credentialData = NameSpacedData.Builder()
-            .putEntryString(EUPersonalID.EUPID_NAMESPACE, "family_name", state.credentialData!!.lastName!!)
-            .putEntryString(EUPersonalID.EUPID_NAMESPACE, "given_name", state.credentialData!!.firstName!!)
-            .build()
-
         val randomProvider = Random.Default
         val issuerNameSpaces = MdocUtil.generateIssuerNameSpaces(
-            credentialData,
+            state.credentialData!!,
             randomProvider,
             16,
             null

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/ParServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/ParServlet.kt
@@ -105,7 +105,7 @@ class ParServlet : BaseServlet() {
         }
 
         // Format the result (session identifying information).
-        val expirationSeconds = 60
+        val expirationSeconds = 600
         val code = idToCode(OpaqueIdType.PAR_CODE, id, expirationSeconds.seconds)
         resp.status = 201  // Created
         resp.outputStream.write(

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/messages.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/messages.kt
@@ -1,7 +1,10 @@
 package com.android.identity.server.openid4vci
 
+import com.android.identity.cbor.DataItem
 import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.crypto.EcPrivateKey
 import com.android.identity.crypto.EcPublicKey
+import com.android.identity.document.NameSpacedData
 import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
@@ -40,15 +43,8 @@ data class IssuanceState(
     var codeChallenge: ByteString?,
     var dpopNonce: ByteString? = null,
     var cNonce: ByteString? = null,
-    var credentialData: CredentialData? = null
-) {
-    companion object
-}
-
-@CborSerializable
-data class CredentialData(
-    var firstName: String? = null,
-    var lastName: String? = null,
+    var pidReadingKey: EcPrivateKey? = null,
+    var credentialData: NameSpacedData? = null
 ) {
     companion object
 }
@@ -62,5 +58,6 @@ enum class OpaqueIdType {
     ISSUER_STATE,
     REDIRECT,
     ACCESS_TOKEN,
-    REFRESH_TOKEN
+    REFRESH_TOKEN,
+    PID_READING
 }

--- a/server/src/main/resources/resources/common_configuration.json
+++ b/server/src/main/resources/resources/common_configuration.json
@@ -1,2 +1,3 @@
 {
+  "base_url": "http://localhost:8080/server"
 }

--- a/server/src/main/resources/resources/openid4vci/authorize.html
+++ b/server/src/main/resources/resources/openid4vci/authorize.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>Authorize</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+</head>
+<body>
+<h1>Verify your identity using PID</h1>
+<h2>(mDoc format only currently)</h2>
+<form action="authorize" method="post" id="form">
+    <input type="hidden" name="authorizationCode" value="$authorizationCode"/>
+    <input type="hidden" name="pidData" id="pidData" value=""/>
+    <button id="verify" data-code="$pidReadingCode">Verify PID</button><br/>
+    <label for="extraInfo">Extra info (optional):</label>
+    <input type="text" id="extraInfo" name="extraInfo">
+</form>
+<script src="authorize.js"></script>
+</body>
+</html>

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -331,4 +331,16 @@
         <url-pattern>/openid4vci/credential</url-pattern>
     </servlet-mapping>
 
+    <servlet>
+        <display-name>CredentialRequestServlet</display-name>
+        <servlet-name>CredentialRequestServlet</servlet-name>
+        <servlet-class>com.android.identity.server.openid4vci.CredentialRequestServlet</servlet-class>
+        <load-on-startup>10</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>CredentialRequestServlet</servlet-name>
+        <url-pattern>/openid4vci/credential_request</url-pattern>
+    </servlet-mapping>
+
 </web-app>

--- a/server/src/main/webapp/openid4vci/authorize.js
+++ b/server/src/main/webapp/openid4vci/authorize.js
@@ -1,0 +1,30 @@
+init(
+   document.getElementById("verify"),
+   document.getElementById("pidData"),
+   document.getElementById("form")
+)
+
+async function init(button, pidData, form) {
+    button.disabled = true;
+    if (!navigator.identity) {
+        alert("This browser does not support digital credential reading");
+        return;
+    }
+    let code = button.dataset.code;
+    let response = await fetch('credential_request', {
+            method: 'POST',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json',
+            },
+            body: JSON.stringify({code: code})
+        })
+    let credentialRequest = await response.json();
+    button.disabled = false;
+    button.addEventListener('click', async (evt) => {
+        evt.preventDefault();  // avoid form submission from click
+        const credentialResponse = await navigator.identity.get({digital: credentialRequest});
+        pidData.value = credentialResponse.data;
+        form.submit();
+    });
+}


### PR DESCRIPTION
Only mdoc PIDs are supported at this point.

Tested manually with a PID generated by our hardcoded issuer.