### PR TITLE
Misc fixes for Austroads Test Event.

### DIFF
--- a/identity-doctypes/src/commonMain/kotlin/com/android/identity/documenttype/knowntypes/PhotoID.kt
+++ b/identity-doctypes/src/commonMain/kotlin/com/android/identity/documenttype/knowntypes/PhotoID.kt
@@ -671,7 +671,7 @@ object PhotoID {
             .addMdocAttribute(
                 DocumentAttributeType.Blob,
                 "dg_content_info",
-                "",
+                "eMRTD Content Info",
                 "Binary data of the DTCContentInfo",
                 false,
                 DTC_NAMESPACE,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ReaderModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ReaderModel.kt
@@ -261,7 +261,9 @@ class ReaderModel(
                 )
                 if (trustResult.isTrusted) {
                     val trustPoint = trustResult.trustPoints[0]
-                    infoTexts.add(res.getString(R.string.reader_model_info_in_trust_list, trustPoint.displayName))
+                    val displayName = trustPoint.displayName
+                        ?: trustPoint.certificate.subjectX500Principal.name
+                    infoTexts.add(res.getString(R.string.reader_model_info_in_trust_list, displayName))
                 } else {
                     val dsCert = readerAuthChain[0]
                     val displayName = dsCert.issuerX500Principal.name

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -235,11 +235,6 @@ class WalletApplication : Application() {
 
         // init TrustManager for issuers (used in reader)
         //
-        issuerTrustManager.addTrustPoint(
-            displayName = "OWF Identity Credential TEST IACA",
-            certificateResourceId = R.raw.iaca_certificate,
-            displayIconResourceId = R.drawable.owf_identity_credential_reader_display_icon
-        )
         val signedVical = SignedVical.parse(
             resources.openRawResource(R.raw.austroad_test_event_vical_20241002).readBytes()
         )
@@ -253,6 +248,11 @@ class WalletApplication : Application() {
                 )
             )
         }
+        issuerTrustManager.addTrustPoint(
+            displayName = "OWF Identity Credential TEST IACA",
+            certificateResourceId = R.raw.iaca_certificate,
+            displayIconResourceId = R.drawable.owf_identity_credential_reader_display_icon
+        )
 
 
         documentModel = DocumentModel(


### PR DESCRIPTION
Handle not having `displayName` in a Trust Point for the reader. This can happen when importing trust points from a VICAL where there's no display name. Just use the subject X500 principal name instead.

Register the OWF Test IACA _after_ the VICAL so our display name and icon is actually used.

Add missing description for PhotoID data element.

Test: Manually tested.

Fixes #<issue_number_goes_here>

> It's a good idea to open an issue first for discussion.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR