### PR TITLE
Properly handle strings/objects being returned from navigator.identity.get().

### DIFF
--- a/server/src/main/webapp/verifier.js
+++ b/server/src/main/webapp/verifier.js
@@ -159,11 +159,17 @@ async function dcRequestCredential(sessionId, dcRequestProtocol, dcRequest) {
 }
 
 async function dcProcessResponse(sessionId, credentialResponse) {
+    var dataStr
+    if (typeof(credentialResponse.data) == 'string') {
+	dataStr = credentialResponse.data
+    } else {
+	dataStr = JSON.stringify(credentialResponse.data)
+    }
     const response = await callServer(
         'dcGetData',
         {
             sessionId: sessionId,
-            credentialResponse: credentialResponse.data
+            credentialResponse: dataStr
         }
     )
     var modalBody = document.getElementById('dcResultModal').querySelector('.list-group')


### PR DESCRIPTION
The latest spec of the W3C DC API returns an object, not a string. Add workaround to cope with some implementations - such as Chrome - not yet doing this.

Test: Manually tested.
