### PR TITLE
Use fewest possible bytes for CBOR length encodings.

### DIFF
--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/response/DeviceResponseParser.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/response/DeviceResponseParser.kt
@@ -202,6 +202,9 @@ class DeviceResponseParser(
                                 "No digestID MSO entry for ID $digestId in namespace $nameSpace"
                             )
                         val digestMatch = expectedDigest contentEquals digest
+                        if (!digestMatch) {
+                            Logger.w(TAG, "hash mismatch for data element $nameSpace $elementName")
+                        }
                         builder.addIssuerEntry(
                             nameSpace, elementName,
                             Cbor.encode(elementValue),

--- a/identity/src/commonMain/kotlin/com/android/identity/cbor/Cbor.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/cbor/Cbor.kt
@@ -28,14 +28,14 @@ object Cbor {
         builder.apply {
             if (length < 24U) {
                 append(majorTypeShifted.or(length.toByte()))
-            } else if (length < (1U shl 8)) {
+            } else if (length < (1UL shl 8)) {
                 append(majorTypeShifted.or(24))
                 append(length.toByte())
-            } else if (length < (1U shl 16)) {
+            } else if (length < (1UL shl 16)) {
                 append(majorTypeShifted.or(25))
                 append((length shr 8).and(0xffU).toByte())
                 append((length shr 0).and(0xffU).toByte())
-            } else if (length < (1U shl 32)) {
+            } else if (length < (1UL shl 32)) {
                 append(majorTypeShifted.or(26))
                 append((length shr 24).and(0xffU).toByte())
                 append((length shr 16).and(0xffU).toByte())


### PR DESCRIPTION
Turns out the code for encoding a Bstr, Tstr, and other types doesn't use the fewest possible bytes when encoding. This is allowed behavior but the resulting CBOR is not compliant with the rules for Preferred Serialization according to RFC 8949 4.2.1. Core Deterministic Encoding Requirements.

This behavior triggers a bug in `DeviceResponseParser` because it's written to assume that the encoding `IssuerSignedItemBytes` follows the rules in ISO/IEC 18013-5:2021 which requires this as per clause "8.1 Encoding of data structures and data elements."

Concretely, it means that any `DeviceResponse` CBOR with bstr data elements greater than 64 KiB will be reported as failing to validate by `DeviceResponseParser` when in fact this is not the case. Normally mdoc data elements are smaller than this, typically the portrait and signature/usual-mark is only a dozen kB or so. This was only discovered because someone at the mDL test event used a portrait image of 90 kB.

Fix this bug and add new unit tests which ensures the fewest possible bytes are always used for length encodings.

Also make `DeviceResponseParser` log a warning when a data element mismatch is detected.

Test: New unit test and all unit tests pass.
