### PR TITLE
Implemented key attestation in openid4vci + misc. fixes.

### DIFF
--- a/identity-flow/src/main/java/com/android/identity/flow/handler/FlowExceptionMap.kt
+++ b/identity-flow/src/main/java/com/android/identity/flow/handler/FlowExceptionMap.kt
@@ -18,6 +18,12 @@ class FlowExceptionMap private constructor(
         private val byClass = mutableMapOf<KClass<out Throwable>, Item<*>>()
         private val byId = mutableMapOf<String, Item<*>>()
 
+        init {
+            // This exception is the part of the framework and is always supported.
+            // TODO: consider adding some Kotlin exceptions (they'd need cbor serialization).
+            InvalidRequestException.register(this)
+        }
+
         fun <ExceptionT : Throwable> addException(
             exceptionId: String,
             serializer: (ExceptionT) -> DataItem,

--- a/identity-flow/src/main/java/com/android/identity/flow/handler/InvalidRequestException.kt
+++ b/identity-flow/src/main/java/com/android/identity/flow/handler/InvalidRequestException.kt
@@ -1,0 +1,10 @@
+package com.android.identity.flow.handler
+
+import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.flow.annotation.FlowException
+
+@FlowException
+@CborSerializable
+class InvalidRequestException(message: String?) : RuntimeException(message) {
+    companion object
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/ApplicationSupport.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/ApplicationSupport.kt
@@ -12,11 +12,8 @@ import com.android.identity.securearea.KeyAttestation
 @FlowInterface
 interface ApplicationSupport : FlowNotifiable<LandingUrlNotification> {
     /**
-     * Creates a "landing" URL suitable for web redirects. When a landing URL is navigated to,
-     * [LandingUrlNotification] is sent to the client.
-     *
-     * NB: this method returns the relative URL, server base URL should be prepended to it before
-     * use.
+     * Creates a "landing" absolute URL suitable for web redirects. When a landing URL is
+     * navigated to, [LandingUrlNotification] is sent to the client.
      */
     @FlowMethod
     suspend fun createLandingUrl(): String
@@ -25,10 +22,10 @@ interface ApplicationSupport : FlowNotifiable<LandingUrlNotification> {
      * Returns the query portion of the URL which was actually used when navigating to a landing
      * URL, or null if navigation did not occur yet.
      *
-     * [relativeUrl] relative URL of the landing page as returned by [createLandingUrl].
+     * [landingUrl] URL of the landing page as returned by [createLandingUrl].
      */
     @FlowMethod
-    suspend fun getLandingUrlStatus(relativeUrl: String): String?
+    suspend fun getLandingUrlStatus(landingUrl: String): String?
 
     /**
      * Creates OAuth JWT client assertion based on the mobile-platform-specific [KeyAttestation].
@@ -37,5 +34,15 @@ interface ApplicationSupport : FlowNotifiable<LandingUrlNotification> {
     suspend fun createJwtClientAssertion(
         clientAttestation: KeyAttestation,
         targetIssuanceUrl: String
+    ): String
+
+    /**
+     * Creates OAuth JWT key attestation based on the given list of mobile-platform-specific
+     * [KeyAttestation]s.
+     */
+    @FlowMethod
+    suspend fun createJwtKeyAttestation(
+        keyAttestations: List<KeyAttestation>,
+        nonce: String
     ): String
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/AbstractRequestCredentials.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/AbstractRequestCredentials.kt
@@ -1,0 +1,19 @@
+package com.android.identity.issuance.funke
+
+import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.flow.annotation.FlowState
+import com.android.identity.issuance.CredentialConfiguration
+import com.android.identity.issuance.CredentialFormat
+import com.android.identity.issuance.RequestCredentialsFlow
+
+@FlowState(
+    flowInterface = RequestCredentialsFlow::class
+)
+abstract class AbstractRequestCredentials(
+    val documentId: String,
+    val credentialConfiguration: CredentialConfiguration,
+    val nonce: String,
+    var format: CredentialFormat? = null,
+) {
+    companion object
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuerDocument.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeIssuerDocument.kt
@@ -5,20 +5,15 @@ import com.android.identity.issuance.CredentialData
 import com.android.identity.issuance.DocumentCondition
 import com.android.identity.issuance.DocumentConfiguration
 import com.android.identity.issuance.RegistrationResponse
-import com.android.identity.issuance.evidence.EvidenceRequestSetupCloudSecureArea
-import com.android.identity.issuance.evidence.EvidenceResponseGermanEid
-import com.android.identity.securearea.SecureArea
-import kotlinx.datetime.Instant
 
 @CborSerializable
 data class FunkeIssuerDocument(
     val registrationResponse: RegistrationResponse,
-    var state: DocumentCondition,
-    var access: FunkeAccess?,
-    var documentConfiguration: DocumentConfiguration?,
-    var secureAreaIdentifier: String?,
-    val credentialRequests: MutableList<FunkeCredentialRequest>,
-    val credentials: MutableList<CredentialData>
+    var state: DocumentCondition = DocumentCondition.PROOFING_REQUIRED,
+    var access: FunkeAccess? = null,
+    var documentConfiguration: DocumentConfiguration? = null,
+    var secureAreaIdentifier: String? = null,
+    val credentials: MutableList<CredentialData> = mutableListOf()
 ) {
     companion object
 }

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
@@ -26,9 +26,16 @@ internal object FunkeUtil {
     const val TAG = "FunkeUtil"
 
     const val EU_PID_MDOC_DOCTYPE = "eu.europa.ec.eudi.pid.1"
-    const val SD_JWT_VCT = "urn:eu.europa.ec.eudi:pid:1"
+
+    // Was changed recently, it seems
+    // TODO: read this from openid4vci server metadata (which we are yet to read).
+    const val SD_JWT_VCT = "https://example.bmi.bund.de/credential/pid/1.0"
 
     const val USE_AUSWEIS_SDK = true
+
+    // Determines if key attestation or of proof of possession should be used.
+    // TODO: decide this based on the openid4vci server metadata (which we are yet to read).
+    const val USE_KEY_ATTESTATION = false
 
     private val keyCreationMutex = Mutex()
 

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/KeyAttestationCredentialRequest.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/KeyAttestationCredentialRequest.kt
@@ -1,15 +1,14 @@
 package com.android.identity.issuance.funke
 
 import com.android.identity.cbor.annotation.CborSerializable
-import com.android.identity.crypto.EcPublicKey
 import com.android.identity.issuance.CredentialFormat
 import com.android.identity.issuance.CredentialRequest
-import kotlinx.io.bytestring.ByteString
 
 @CborSerializable
-data class FunkeCredentialRequest(
-    val request: CredentialRequest,
+data class KeyAttestationCredentialRequest(
+    val request: MutableList<CredentialRequest>,
     val format: CredentialFormat,
-    val proofOfPossessionJwtHeaderAndBody: String,
-    var proofOfPossessionJwtSignature: String? = null
-)
+    val jwtKeyAttestation: String
+) {
+    companion object
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/ProofOfPossessionCredentialRequest.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/ProofOfPossessionCredentialRequest.kt
@@ -1,0 +1,13 @@
+package com.android.identity.issuance.funke
+
+import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.issuance.CredentialFormat
+import com.android.identity.issuance.CredentialRequest
+
+@CborSerializable
+data class ProofOfPossessionCredentialRequest(
+    val request: CredentialRequest,
+    val format: CredentialFormat,
+    val proofOfPossessionJwtHeaderAndBody: String,
+    var proofOfPossessionJwtSignature: String? = null
+)

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/RequestCredentialsUsingKeyAttestation.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/RequestCredentialsUsingKeyAttestation.kt
@@ -1,0 +1,52 @@
+package com.android.identity.issuance.funke
+
+import com.android.identity.cbor.annotation.CborSerializable
+import com.android.identity.flow.annotation.FlowMethod
+import com.android.identity.flow.annotation.FlowState
+import com.android.identity.flow.server.FlowEnvironment
+import com.android.identity.issuance.CredentialConfiguration
+import com.android.identity.issuance.CredentialFormat
+import com.android.identity.issuance.CredentialRequest
+import com.android.identity.issuance.KeyPossessionChallenge
+import com.android.identity.issuance.KeyPossessionProof
+import com.android.identity.issuance.RequestCredentialsFlow
+
+@FlowState(
+    flowInterface = RequestCredentialsFlow::class
+)
+@CborSerializable
+class RequestCredentialsUsingKeyAttestation(
+    documentId: String,
+    credentialConfiguration: CredentialConfiguration,
+    nonce: String,
+    format: CredentialFormat? = null,
+    var credentialRequests: List<CredentialRequest>? = null
+) : AbstractRequestCredentials(documentId, credentialConfiguration, nonce, format) {
+    companion object
+
+    @FlowMethod
+    fun getCredentialConfiguration(
+        env: FlowEnvironment,
+        format: CredentialFormat
+    ): CredentialConfiguration {
+        this.format = format
+        return credentialConfiguration
+    }
+
+    @FlowMethod
+    fun sendCredentials(
+        env: FlowEnvironment,
+        newCredentialRequests: List<CredentialRequest>
+    ): List<KeyPossessionChallenge> {
+        if (credentialRequests != null) {
+            throw IllegalStateException("Credential requests were already sent")
+        }
+        credentialRequests = newCredentialRequests
+        return listOf()
+    }
+
+    @FlowMethod
+    fun sendPossessionProofs(env: FlowEnvironment, keyPossessionProofs: List<KeyPossessionProof>) {
+        throw UnsupportedOperationException("Should not be called")
+    }
+}

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/RequestCredentialsUsingProofOfPossession.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/RequestCredentialsUsingProofOfPossession.kt
@@ -20,15 +20,15 @@ import kotlinx.serialization.json.JsonPrimitive
     flowInterface = RequestCredentialsFlow::class
 )
 @CborSerializable
-class FunkeRequestCredentialsState(
+class RequestCredentialsUsingProofOfPossession(
     val issuanceClientId: String,
-    val documentId: String = "",
-    val credentialConfiguration: CredentialConfiguration,
-    val nonce: String,
-    var format: CredentialFormat? = null,
-    var credentialRequests: List<FunkeCredentialRequest>? = null,
-    val credentialIssuerUri:String,
-) {
+    documentId: String,
+    credentialConfiguration: CredentialConfiguration,
+    nonce: String,
+    val credentialIssuerUri: String,
+    format: CredentialFormat? = null,
+    var credentialRequests: List<ProofOfPossessionCredentialRequest>? = null,
+) : AbstractRequestCredentials(documentId, credentialConfiguration, nonce, format) {
     companion object
 
     @FlowMethod
@@ -60,7 +60,7 @@ class FunkeRequestCredentialsState(
                 "iat" to JsonPrimitive(Clock.System.now().epochSeconds),
                 "nonce" to JsonPrimitive(nonce)
             )).toString().toByteArray().toBase64Url()
-            FunkeCredentialRequest(request, format!!, "$header.$body")
+            ProofOfPossessionCredentialRequest(request, format!!, "$header.$body")
         }
         credentialRequests = requests
         return requests.map {

--- a/identity-issuance/src/main/java/com/android/identity/issuance/wallet/WalletServerState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/wallet/WalletServerState.kt
@@ -21,7 +21,8 @@ import com.android.identity.issuance.common.AbstractIssuingAuthorityState
 import com.android.identity.issuance.funke.FunkeIssuingAuthorityState
 import com.android.identity.issuance.funke.FunkeProofingState
 import com.android.identity.issuance.funke.FunkeRegistrationState
-import com.android.identity.issuance.funke.FunkeRequestCredentialsState
+import com.android.identity.issuance.funke.RequestCredentialsUsingKeyAttestation
+import com.android.identity.issuance.funke.RequestCredentialsUsingProofOfPossession
 import com.android.identity.issuance.funke.register
 import com.android.identity.issuance.hardcoded.IssuingAuthorityState
 import com.android.identity.issuance.hardcoded.ProofingState
@@ -85,7 +86,8 @@ class WalletServerState(
             FunkeIssuingAuthorityState.register(dispatcher)
             FunkeProofingState.register(dispatcher)
             FunkeRegistrationState.register(dispatcher)
-            FunkeRequestCredentialsState.register(dispatcher)
+            RequestCredentialsUsingProofOfPossession.register(dispatcher)
+            RequestCredentialsUsingKeyAttestation.register(dispatcher)
         }
     }
 

--- a/processor/src/main/kotlin/com/android/identity/processor/CborSymbolProcessor.kt
+++ b/processor/src/main/kotlin/com/android/identity/processor/CborSymbolProcessor.kt
@@ -510,7 +510,10 @@ class CborSymbolProcessor(
                         return@forEach
                     }
                     val name = varName(fieldName)
-                    constructorParameters.add(name)
+                    // Always use field names (and require constructor to use them as parameter
+                    // names!), because the order of parameters in the constructor sometimes have
+                    // to differ from the order of the fields (esp. when using inheritance).
+                    constructorParameters.add("$fieldName = $name")
                     if (findAnnotation(property, ANNOTATION_MERGE) != null) {
                         if (type.declaration.qualifiedName!!.asString() == "kotlin.collections.Map") {
                             line("val $name = mutableMapOf<${typeArguments(this, type)}>()")
@@ -533,19 +536,13 @@ class CborSymbolProcessor(
                         }
                     }
                 }
-                line {
-                    append("return $baseName(")
-                    var first = true
+                line("return $baseName(")
+                withIndent {
                     constructorParameters.forEach { parameter ->
-                        if (first) {
-                            first = false
-                        } else {
-                            append(", ")
-                        }
-                        append(parameter)
+                        line("$parameter,")
                     }
-                    append(")")
                 }
+                line(")")
             }
 
             if (hadMergedMap) {

--- a/server-env/src/main/java/com/android/identity/server/BaseFlowHttpServlet.kt
+++ b/server-env/src/main/java/com/android/identity/server/BaseFlowHttpServlet.kt
@@ -90,24 +90,27 @@ abstract class BaseFlowHttpServlet : BaseHttpServlet() {
                 )
             }
             Logger.i(TAG, "$prefix: POST response status 200 (${bytes.size} bytes)")
-            resp.contentType = "application/cbor"
             resp.outputStream.write(bytes.toByteArray())
         } catch (e: UnsupportedOperationException) {
-            Logger.i(TAG, "$prefix: POST response status 404")
+            Logger.e(TAG, "$prefix: POST response status 404", e)
             resp.sendError(404, e.message)
         } catch (e: SimpleCipher.DataTamperedException) {
-            Logger.i(TAG, "$prefix: POST response status 405")
+            Logger.e(TAG, "$prefix: POST response status 405", e)
             resp.sendError(405, "State tampered")
         } catch (e: IllegalStateException) {
-            Logger.i(TAG, "$prefix: POST response status 405")
+            Logger.e(TAG, "$prefix: POST response status 405", e)
             resp.sendError(405, "IllegalStateException")
         } catch (e: Throwable) {
-            Logger.i(TAG, "$prefix: POST response status 500: ${e::class.simpleName}: ${e.message}")
             // NotificationTimeoutError happens frequently, don't need a stack trace for this...
-            if (e !is HttpTransport.TimeoutException) {
-                e.printStackTrace()
+            if (e is HttpTransport.TimeoutException) {
+                Logger.e(TAG, "$prefix: POST response status 500 (TimeoutException)")
+            } else {
+                Logger.e(TAG, "$prefix: POST response status 500", e)
             }
             resp.sendError(500, e.message)
         }
     }
+
+    override val outputFormat: String
+        get() = "application/cbor"
 }

--- a/server-env/src/main/java/com/android/identity/server/BaseHttpServlet.kt
+++ b/server-env/src/main/java/com/android/identity/server/BaseHttpServlet.kt
@@ -1,10 +1,15 @@
 package com.android.identity.server
 
 import com.android.identity.flow.handler.FlowNotifications
+import com.android.identity.flow.handler.InvalidRequestException
 import com.android.identity.flow.server.FlowEnvironment
+import com.android.identity.util.Logger
 import jakarta.servlet.ServletConfig
 import jakarta.servlet.http.HttpServlet
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.security.Security
 import kotlin.reflect.KClass
@@ -15,6 +20,8 @@ open class BaseHttpServlet : HttpServlet() {
     companion object {
         private val environmentMap = mutableMapOf<KClass<*>, ServerEnvironment>()
 
+        const val TAG = "BaseHttpServlet"
+        
         @Synchronized
         private fun initializeEnvironment(
             clazz: KClass<*>,
@@ -67,4 +74,47 @@ open class BaseHttpServlet : HttpServlet() {
     open fun initializeEnvironment(env: FlowEnvironment): FlowNotifications? {
         return null
     }
+
+    override fun service(req: HttpServletRequest, resp: HttpServletResponse) {
+        try {
+            resp.contentType = outputFormat
+            super.service(req, resp)
+        } catch (err: InvalidRequestException) {
+            Logger.e(TAG, "Error in ${req.requestURL}", err)
+            when (outputFormat) {
+                "application/json" -> {
+                    val json = buildJsonObject {
+                        put("error", JsonPrimitive("invalid_request"))
+                        put("error_description", JsonPrimitive(err.message ?: "not provided"))
+                    }
+                    resp.status = 400
+                    resp.writer.write(json.toString())
+                }
+                "text/html" -> {
+                    resp.status = 400
+                    val text = (err.message ?: "")
+                        .replace("&", "&amp")
+                        .replace("<", "&lt")
+                        .replace(">", "&gt")
+                    resp.writer.write(
+                        """
+                            <!DOCTYPE html>                          
+                            <html>
+                            <body>
+                            <h1>Invalid Request</h1>
+                            <p>$text</p>
+                            </body>
+                            </html>
+                        """.trimIndent())
+                }
+                else -> {
+                    Logger.e(TAG, "Unsupported error format: $outputFormat")
+                    resp.status = 400
+                }
+            }
+        }
+    }
+
+    protected open val outputFormat: String
+        get() = "application/json"
 }

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/CredentialRequestServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/CredentialRequestServlet.kt
@@ -5,6 +5,7 @@ import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
 import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
 import com.android.identity.documenttype.knowntypes.EUPersonalID
+import com.android.identity.flow.handler.InvalidRequestException
 import com.android.identity.flow.server.Storage
 import com.android.identity.util.toBase64Url
 import jakarta.servlet.http.HttpServletRequest
@@ -31,10 +32,7 @@ class CredentialRequestServlet : BaseServlet() {
         val requestData = req.inputStream.readNBytes(requestLength)
         val params = Json.parseToJsonElement(String(requestData)) as JsonObject
         val code = params["code"]?.jsonPrimitive?.content
-        if (code == null) {
-            errorResponse(resp, "invalid_request", "missing parameter 'code'")
-            return
-        }
+            ?: throw InvalidRequestException("missing parameter 'code'")
         val id = codeToId(OpaqueIdType.PID_READING, code)
         val storage = environment.getInterface(Storage::class)!!
         runBlocking {

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/FinishAuthorizationServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/FinishAuthorizationServlet.kt
@@ -1,5 +1,6 @@
 package com.android.identity.server.openid4vci
 
+import com.android.identity.flow.handler.InvalidRequestException
 import com.android.identity.flow.server.Storage
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -11,20 +12,18 @@ import kotlin.time.Duration.Companion.minutes
  * Wallet Server).
  */
 class FinishAuthorizationServlet : BaseServlet() {
+    override val outputFormat: String
+        get() = "text/html"
+
     override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
         val issuerState = req.getParameter("issuer_state")
-        if (issuerState == null) {
-            println("Error")
-            errorResponse(resp, "invalid_request", "missing parameter 'issuer_state'")
-            return
-        }
+            ?: throw InvalidRequestException("missing parameter 'issuer_state'")
         val id = codeToId(OpaqueIdType.ISSUER_STATE, issuerState)
         val storage = environment.getInterface(Storage::class)!!
         runBlocking {
             val state = IssuanceState.fromCbor(storage.get("IssuanceState", "", id)!!.toByteArray())
             val redirectUri = state.redirectUri ?: ""
             if (!redirectUri.startsWith("http://") && !redirectUri.startsWith("https://")) {
-                resp.contentType = "text/html"
                 resp.writer.write(
                     """
                             <!DOCTYPE html>

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/messages.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/messages.kt
@@ -12,12 +12,6 @@ import kotlinx.serialization.Serializable
 //------------ JSON-formatted replies from various OpenID4VCI servlets
 
 @Serializable
-data class ErrorMessage(
-    val error: String,
-    @SerialName("error_description") val description: String
-)
-
-@Serializable
 data class ParResponse(
     @SerialName("request_uri") val requestUri: String,
     @SerialName("expires_in") val expiresIn: Int

--- a/server/src/main/java/com/android/identity/wallet/server/LandingServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/LandingServlet.kt
@@ -1,6 +1,7 @@
 package com.android.identity.wallet.server
 
 import com.android.identity.flow.handler.FlowNotifications
+import com.android.identity.flow.server.Configuration
 import com.android.identity.flow.server.FlowEnvironment
 import com.android.identity.flow.server.Resources
 import com.android.identity.flow.server.Storage
@@ -53,8 +54,11 @@ class LandingServlet: BaseHttpServlet() {
                 val record = LandingRecord.fromCbor(recordData.toByteArray())
                 record.resolved = req.queryString ?: ""
                 storage.update("Landing", "", id, ByteString(record.toCbor()))
+                val configuration = environment.getInterface(Configuration::class)!!
+                val baseUrl = configuration.getValue("base_url")
+                val landingUrl = "$baseUrl/${ApplicationSupportState.URL_PREFIX}$id"
                 ApplicationSupportState(record.clientId).emit(environment,
-                    LandingUrlNotification("landing/$id"))
+                    LandingUrlNotification(landingUrl))
                 resp.contentType = "text/html"
                 val resources = environment.getInterface(Resources::class)!!
                 resp.outputStream.write(


### PR DESCRIPTION
Implemented:
 - key attestation in our openid4vci server and client
 - refresh token in our openid4vci server (it is already supported on the client).
 
Some additional fixes:
 - allow arbitrary order in constructor parameters for classes marked with CborSerializable
 - InvalidRequestException to declutter the most basic error processing
 - changed support for "landing URLs" to always work with absolute URLs (tends to be more robust)
 - adjusted sd-jwt-vc vci value for the most recent BDR issuance server version

Tested manually using both default Funke issuance server and our own openid4vci server (adjusting parameters that are currently hardcoded).