### PR TITLE
wallet: add new "Proximity Sharing Settings" screen.

### DIFF
--- a/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
+++ b/identity-android/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
@@ -194,6 +194,8 @@ class DataTransportBlePeripheralServerMode(
                 reportError(error)
             }
         }
+        gattClient!!.clearCache = options.bleClearCache
+        gattClient!!.connect(device)
     }
 
     override fun setEDeviceKeyBytes(encodedEDeviceKeyBytes: ByteArray) {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/QrEngagementViewModel.kt
@@ -9,14 +9,10 @@ import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.android.identity.android.mdoc.engagement.QrEngagementHelper
 import com.android.identity.android.mdoc.transport.DataTransport
-import com.android.identity.android.mdoc.transport.DataTransportOptions
 import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
 import com.android.identity.crypto.EcPrivateKey
-import com.android.identity.mdoc.connectionmethod.ConnectionMethod
-import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
 import com.android.identity.util.Logger
-import com.android.identity.util.UUID
 import kotlinx.coroutines.launch
 
 class QrEngagementViewModel(val context: Application) : AndroidViewModel(context)  {
@@ -75,17 +71,9 @@ class QrEngagementViewModel(val context: Application) : AndroidViewModel(context
                     }
                 }
 
-                val options = DataTransportOptions.Builder().build()
-                val connectionMethods = mutableListOf<ConnectionMethod>()
-                val bleUuid = UUID.randomUUID()
-                connectionMethods.add(
-                    ConnectionMethodBle(
-                        false,
-                        true,
-                        null,
-                        bleUuid
-                    )
-                )
+                val walletApplication = context as WalletApplication
+                val (connectionMethods, options) = walletApplication.settingsModel
+                    .createConnectionMethodsAndOptions()
                 qrEngagementHelper = QrEngagementHelper.Builder(
                     context,
                     eDeviceKey!!.publicKey,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ReaderModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ReaderModel.kt
@@ -31,6 +31,7 @@ import kotlinx.datetime.Clock
 class ReaderModel(
     val context: Context,
     val documentTypeRepository: DocumentTypeRepository,
+    val settingsModel: SettingsModel
 ) {
     companion object {
         private const val TAG = "ReaderModel"
@@ -136,15 +137,8 @@ class ReaderModel(
         trustManagerToUse = trustManager
         phase.value = Phase.WAITING_FOR_ENGAGEMENT
 
-        val connectionMethods = mutableListOf<ConnectionMethod>()
-        val bleUuid = UUID.randomUUID()
-        connectionMethods.add(
-            ConnectionMethodBle(
-                false,
-                true,
-                null,
-                bleUuid)
-        )
+        val (connectionMethods, dataTransportOptions) =
+            settingsModel.createConnectionMethodsAndOptions()
 
         val listener = object : VerificationHelper.Listener {
             override fun onReaderEngagementReady(readerEngagement: ByteArray) {
@@ -197,7 +191,7 @@ class ReaderModel(
         }
 
         verificationHelper = VerificationHelper.Builder(context, listener, context.mainExecutor)
-            .setDataTransportOptions(DataTransportOptions.Builder().build())
+            .setDataTransportOptions(dataTransportOptions)
             .setNegotiatedHandoverConnectionMethods(connectionMethods)
             .build()
         activityForNfcReaderMode = activity

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -264,7 +264,11 @@ class WalletApplication : Application() {
             this
         )
 
-        readerModel = ReaderModel(applicationContext, documentTypeRepository)
+        readerModel = ReaderModel(
+            applicationContext,
+            documentTypeRepository,
+            settingsModel
+        )
 
         val notificationChannel = NotificationChannel(
             NOTIFICATION_CHANNEL_ID,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
@@ -20,6 +20,7 @@ sealed class WalletDestination(val routeEnum: Route) {
     object Main : WalletDestination(Route.MAIN)
     object About : WalletDestination(Route.ABOUT)
     object Settings : WalletDestination(Route.SETTINGS)
+    object SettingsProximitySharing : WalletDestination(Route.SETTINGS_PROXIMITY_SHARING)
     object AddToWallet : WalletDestination(Route.ADD_TO_WALLET)
     object ProvisionDocument : WalletDestination(Route.PROVISION_DOCUMENT)
 
@@ -180,6 +181,7 @@ enum class Route(val routeName: String, val argumentsStr: String = "") {
     MAIN("main"),
     ABOUT("about"),
     SETTINGS("settings"),
+    SETTINGS_PROXIMITY_SHARING("settings_proximity_sharing"),
     ADD_TO_WALLET("add_to_wallet"),
     DOCUMENT_INFO("document_info",
         "documentId={documentId}&section={section}&auth_required={auth_required}"),

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -22,6 +22,7 @@ import com.android.identity_credential.wallet.ui.destination.main.MainScreen
 import com.android.identity_credential.wallet.ui.destination.provisioncredential.ProvisionDocumentScreen
 import com.android.identity_credential.wallet.ui.destination.qrengagement.QrEngagementScreen
 import com.android.identity_credential.wallet.ui.destination.reader.ReaderScreen
+import com.android.identity_credential.wallet.ui.destination.settings.SettingsProximitySharingScreen
 import com.android.identity_credential.wallet.ui.destination.settings.SettingsScreen
 
 /**
@@ -97,6 +98,17 @@ fun WalletNavigation(
          */
         composable(WalletDestination.Settings.route) {
             SettingsScreen(
+                settingsModel = application.settingsModel,
+                documentStore = application.documentStore,
+                onNavigate = onNavigate
+            )
+        }
+
+        /**
+         * Settings Proximity Sharing Screen
+         */
+        composable(WalletDestination.SettingsProximitySharing.route) {
+            SettingsProximitySharingScreen(
                 settingsModel = application.settingsModel,
                 documentStore = application.documentStore,
                 onNavigate = onNavigate

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/CommonUI.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/CommonUI.kt
@@ -176,26 +176,35 @@ fun ColumnWithPortrait(
 fun SettingToggle(
     modifier: Modifier = Modifier,
     title: String,
-    subtitleOn: String,
-    subtitleOff: String,
-    isChecked: Boolean,
+    subtitleOn: String? = null,
+    subtitleOff: String? = null,
+    isChecked: Boolean = false,
     onCheckedChange: (Boolean) -> Unit,
     enabled: Boolean = true
 ) {
     Row(modifier = modifier, verticalAlignment = Alignment.CenterVertically) {
         Column(modifier = Modifier.weight(1f)) {
-            Text(
-                text = title,
-                fontWeight = FontWeight.Bold,
-                style = MaterialTheme.typography.titleMedium,
-                color = MaterialTheme.colorScheme.onSurface
-            )
-            val subtitle = if (isChecked) subtitleOn else subtitleOff
-            Text(
-                text = subtitle,
-                style = MaterialTheme.typography.bodySmall,
-                color = MaterialTheme.colorScheme.onSurfaceVariant
-            )
+            if (subtitleOn != null && subtitleOff != null) {
+                Text(
+                    text = title,
+                    fontWeight = FontWeight.Bold,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+                val subtitle = if (isChecked) subtitleOn else subtitleOff
+                Text(
+                    text = subtitle,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant
+                )
+            } else {
+                Text(
+                    text = title,
+                    fontWeight = FontWeight.Normal,
+                    style = MaterialTheme.typography.titleMedium,
+                    color = MaterialTheme.colorScheme.onSurface
+                )
+            }
         }
         Switch(
             checked = isChecked,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsProximitySharingScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsProximitySharingScreen.kt
@@ -1,0 +1,93 @@
+package com.android.identity_credential.wallet.ui.destination.settings
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.android.identity.document.DocumentStore
+import com.android.identity.util.Logger
+import com.android.identity_credential.wallet.R
+import com.android.identity_credential.wallet.SettingsModel
+import com.android.identity_credential.wallet.navigation.WalletDestination
+import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
+import com.android.identity_credential.wallet.ui.SettingSectionSubtitle
+import com.android.identity_credential.wallet.ui.SettingToggle
+
+private const val TAG = "SettingsProximitySharingScreen"
+
+@Composable
+fun SettingsProximitySharingScreen(
+    settingsModel: SettingsModel,
+    documentStore: DocumentStore,
+    onNavigate: (String) -> Unit
+) {
+    ScreenWithAppBarAndBackButton(
+        title = stringResource(R.string.settings_proximity_sharing_screen_title),
+        onBackButtonClick = { onNavigate(WalletDestination.PopBackStack.route) },
+        scrollable = false
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(16.dp)
+        ) {
+            SettingSectionSubtitle(title = stringResource(R.string.settings_proximity_sharing_screen_device_engagement_settings_title))
+            Text(
+                text = stringResource(R.string.settings_proximity_sharing_screen_device_engagement_settings_explanation),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontStyle = FontStyle.Italic,
+            )
+            SettingToggle(
+                title = stringResource(R.string.settings_proximity_sharing_screen_nfc_static_handover_title),
+                isChecked = settingsModel.nfcStaticHandoverEnabled.observeAsState(false).value,
+                onCheckedChange = { settingsModel.nfcStaticHandoverEnabled.value = it }
+            )
+            SettingToggle(
+                title = stringResource(R.string.settings_proximity_sharing_screen_nfc_negotiated_handover_title),
+                isChecked = !settingsModel.nfcStaticHandoverEnabled.observeAsState(false).value,
+                onCheckedChange = { settingsModel.nfcStaticHandoverEnabled.value = !it }
+            )
+
+            SettingSectionSubtitle(title = stringResource(R.string.settings_proximity_sharing_screen_device_retrieval_title))
+            Text(
+                text = stringResource(R.string.settings_proximity_sharing_screen_device_retrieval_explanation),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontStyle = FontStyle.Italic,
+            )
+            SettingToggle(
+                title = stringResource(R.string.settings_proximity_sharing_screen_device_retrieval_ble_mdoc_central_client_mode_title),
+                isChecked = settingsModel.bleCentralClientMode.observeAsState(false).value,
+                onCheckedChange = { settingsModel.bleCentralClientMode.value = it }
+            )
+            SettingToggle(
+                title = stringResource(R.string.settings_proximity_sharing_screen_device_retrieval_ble_mdoc_peripheral_server_mode_title),
+                isChecked = settingsModel.blePeripheralServerMode.observeAsState(false).value,
+                onCheckedChange = { settingsModel.blePeripheralServerMode.value = it }
+            )
+
+            SettingSectionSubtitle(title = stringResource(R.string.settings_proximity_sharing_screen_options_title))
+            Text(
+                text = stringResource(R.string.settings_proximity_sharing_screen_options_explanation),
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                fontStyle = FontStyle.Italic,
+            )
+            SettingToggle(
+                title = stringResource(R.string.settings_proximity_sharing_screen_options_ble_l2cap_enabled_title),
+                isChecked = settingsModel.bleL2CAP.observeAsState(false).value,
+                onCheckedChange = { settingsModel.bleL2CAP.value = it }
+            )
+       }
+    }
+}

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
@@ -208,6 +208,13 @@ fun SettingsScreen(
                     onClicked = { showSetWalletServerUrlDialog = true }
                 )
             }
+            if (settingsModel.developerModeEnabled.value == true) {
+                SettingString(
+                    title = stringResource(R.string.settings_screen_proximity_sharing_button_title),
+                    subtitle = stringResource(R.string.settings_screen_proximity_sharing_button_subtitle),
+                    onClicked = { onNavigate(WalletDestination.SettingsProximitySharing.route) }
+                )
+            }
             if (WalletApplicationConfiguration.CLOUD_SECURE_AREA_SETTING_AVAILABLE ||
                 WalletApplicationConfiguration.WALLET_SERVER_SETTING_AVAILABLE) {
                 SettingSectionSubtitle(title = stringResource(R.string.settings_screen_built_in_issuer_settings))

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -145,6 +145,23 @@
     <string name="settings_screen_built_in_issuer_settings">Built-in Issuer Settings</string>
     <string name="settings_screen_cloud_secure_area_title">Cloud Secure Area</string>
     <string name="settings_screen_min_server_title">Minimal Wallet Server</string>
+    <string name="settings_screen_proximity_sharing_button_title">Proximity Sharing Settings</string>
+    <string name="settings_screen_proximity_sharing_button_subtitle">Settings related to in-person presentment</string>
+
+    <string name="settings_proximity_sharing_screen_title">Proximity Sharing Settings</string>
+    <string name="settings_proximity_sharing_screen_device_engagement_settings_title">Device Engagement</string>
+    <string name="settings_proximity_sharing_screen_device_engagement_settings_explanation">Configure whether to use static or negotiated handover when engaging with a mdoc reader over NFC.</string>
+    <string name="settings_proximity_sharing_screen_nfc_static_handover_title">NFC Static Handover</string>
+    <string name="settings_proximity_sharing_screen_nfc_negotiated_handover_title">NFC Negotiated Handover</string>
+
+    <string name="settings_proximity_sharing_screen_device_retrieval_title">Device Retrieval</string>
+    <string name="settings_proximity_sharing_screen_device_retrieval_explanation">When using QR or NFC static handover, these are the device retrieval methods offered to the mdoc reader. When acting as a mdoc reader and using NFC negotiated handover, these are the device retrieval methods offered to the mdoc.</string>
+    <string name="settings_proximity_sharing_screen_device_retrieval_ble_mdoc_central_client_mode_title">BLE mdoc central client mode</string>
+    <string name="settings_proximity_sharing_screen_device_retrieval_ble_mdoc_peripheral_server_mode_title">BLE mdoc peripheral server mode</string>
+
+    <string name="settings_proximity_sharing_screen_options_title">Options</string>
+    <string name="settings_proximity_sharing_screen_options_explanation">Configure options which affect device retrieval.</string>
+    <string name="settings_proximity_sharing_screen_options_ble_l2cap_enabled_title">BLE L2CAP support</string>
 
     <!-- Set Wallet Server URL dialog -->
     <string name="settings_screen_set_wallet_server_url_dialog_title">Wallet Server</string>


### PR DESCRIPTION
This is a new screen only available if Developer Mode is enabled and it allows configuration of which parts of the ISO/IEC 18013-5:2021 protocol to use. This is useful for interoperability testing with other wallets and readers.

Also fix a bug in our implementation of _BLE mdoc peripheral server_ mode. The problem is that we forgot to start the GATT client, looks like this bug was introduced a long time ago but was never discovered since _BLE mdoc central client_ is the default mode for the vast majority of wallets and readers. The fact that we now have settings to change the default will help avoid mistakes like this in the future.

Test: Manually tested.
