### PR TITLE
Fix handling of a deleted doc, so the error message to the user is clearer

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/presentation/OpenID4VPPresentationActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/presentation/OpenID4VPPresentationActivity.kt
@@ -320,6 +320,9 @@ class OpenID4VPPresentationActivity : FragmentActivity() {
         // prefer the credential which is on-screen if possible
         val credentialIdFromPager: String? = settingsModel.focusedCardId.value
         if (credentialIdFromPager != null
+            // Sometimes the focused card ID references an old deleted card, in which case
+            // lookupDocument will return null, so we still need to check for that:
+            && walletApp.documentStore.lookupDocument(credentialIdFromPager) != null
             && canDocumentSatisfyRequest(credentialIdFromPager, credentialFormat, docType)
         ) {
             return documentStore.lookupDocument(credentialIdFromPager)


### PR DESCRIPTION
Added a null check so the code ends up displaying a message to the user, "No available documents can fulfill the request," rather than the generic, "An error has occurred."

This hits when running OpenID4VP verification from the verifier server to an empty wallet.

Tested by:
- Manual testing
- ./gradlew check
- ./gradlew connectedCheck

Fixes #763

- [X] Tests pass