### PR TITLE
Fix Android Studio's "Duplicate content roots detected" warning.

### DIFF
--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -75,7 +75,6 @@ android {
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
-    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         applicationId = "com.android.identity.testapp"


### PR DESCRIPTION
This resources directory is included in both the testapp main and commonMain modules (by KMM). Android Studio's response to detecting the same directory in multiple modules is to remove it from one of them: the main module, in this case. This change ends up with the same result: we no longer add this directory to the main module (it's only in commonMain).

Tests still pass, so as far as I can tell this hasn't broken anything. But I haven't been able to test iOS or any other platform than Android.

Tested by:
- ./gradlew check
- ./gradlew connectedCheck

- [X] Tests pass