### PR TITLE
Send a single image as evidence, rather than the whole video.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceResponseSelfieVideo.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceResponseSelfieVideo.kt
@@ -1,6 +1,6 @@
 package com.android.identity.issuance.evidence
 
-data class EvidenceResponseSelfieVideo(val video: ByteArray)
+data class EvidenceResponseSelfieVideo(val selfieImage: ByteArray)
     : EvidenceResponse() {
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
@@ -8,10 +8,10 @@ data class EvidenceResponseSelfieVideo(val video: ByteArray)
 
         other as EvidenceResponseSelfieVideo
 
-        return video.contentEquals(other.video)
+        return selfieImage.contentEquals(other.selfieImage)
     }
 
     override fun hashCode(): Int {
-        return video.contentHashCode()
+        return selfieImage.contentHashCode()
     }
 }


### PR DESCRIPTION
When recording a selfie, if the video was too long, the app would run out of memory when trying to send the video to the issuer. Now this sends a single front-facing image instead.

Tested by:
- Manual testing, recording selfies as evidence, including a long video.
- ./gradlew connectedCheck
- ./gradlew check

- [X] Tests pass