### PR TITLE
Presentation during issuance.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceRequestOpenid4Vp.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceRequestOpenid4Vp.kt
@@ -1,0 +1,6 @@
+package com.android.identity.issuance.evidence
+
+class EvidenceRequestOpenid4Vp(
+    val originUri: String,
+    val request: String
+): EvidenceRequest()

--- a/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceResponseOpenid4Vp.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/evidence/EvidenceResponseOpenid4Vp.kt
@@ -1,0 +1,5 @@
+package com.android.identity.issuance.evidence
+
+class EvidenceResponseOpenid4Vp(
+    val response: String
+) : EvidenceResponse()

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/ProofingInfo.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/ProofingInfo.kt
@@ -4,7 +4,9 @@ import com.android.identity.cbor.annotation.CborSerializable
 
 @CborSerializable
 data class ProofingInfo(
-    val authorizeUrl: String,
+    val requestUri: String?,
     val pkceCodeVerifier: String,
-    val landingUrl: String
+    val landingUrl: String,
+    val authSession: String?,
+    val openid4VpPresentation: String?,
 )

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/openid4VciIssuerMetadata.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/openid4VciIssuerMetadata.kt
@@ -123,9 +123,12 @@ internal data class Openid4VciIssuerMetadata(
                 SUPPORTED_SIGNATURE_ALGORITHMS
             ) ?: return null
             val authorizationEndpoint = jsonObject["authorization_endpoint"]!!.jsonPrimitive.content
+            val authorizationChallengeEndpoint =
+                jsonObject["authorization_challenge_endpoint"]?.jsonPrimitive?.content
             return Openid4VciAuthorizationMetadata(
                 pushedAuthorizationRequestEndpoint = jsonObject["pushed_authorization_request_endpoint"]!!.jsonPrimitive.content,
                 authorizationEndpoint = authorizationEndpoint,
+                authorizationChallengeEndpoint = authorizationChallengeEndpoint,
                 tokenEndpoint = jsonObject["token_endpoint"]!!.jsonPrimitive.content,
                 responseType = responseType,
                 codeChallengeMethod = codeChallengeMethod,
@@ -178,6 +181,7 @@ internal data class Openid4VciIssuerMetadata(
 internal data class Openid4VciAuthorizationMetadata(
     val pushedAuthorizationRequestEndpoint: String,
     val authorizationEndpoint: String,
+    val authorizationChallengeEndpoint: String?,
     val tokenEndpoint: String,
     val responseType: String,
     val codeChallengeMethod: String,

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/AuthorizeChallengeServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/AuthorizeChallengeServlet.kt
@@ -1,0 +1,65 @@
+package com.android.identity.server.openid4vci
+
+import com.android.identity.flow.handler.InvalidRequestException
+import com.android.identity.flow.server.Storage
+import com.android.identity.util.toBase64Url
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.net.URLEncoder
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+class AuthorizeChallengeServlet : BaseServlet() {
+    override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
+        val authSession = req.getParameter("auth_session")
+        val id = if (authSession == null) {
+            // Initial call, authSession was not yet established
+            runBlocking {
+                createSession(environment, req)
+            }
+        } else {
+            codeToId(OpaqueIdType.AUTH_SESSION, authSession)
+        }
+        val presentation = req.getParameter("presentation_during_issuance_session")
+        val storage = environment.getInterface(Storage::class)!!
+        val state = runBlocking {
+            IssuanceState.fromCbor(storage.get("IssuanceState", "", id)!!.toByteArray())
+        }
+        if (authSession != null) {
+            authorizeWithDpop(
+                state.dpopKey,
+                req,
+                state.dpopNonce?.toByteArray()?.toBase64Url(),
+                null
+            )
+        }
+        if (presentation == null) {
+            val expirationSeconds = 600
+            val code = idToCode(OpaqueIdType.PAR_CODE, id, expirationSeconds.seconds)
+            val openid4VpCode = idToCode(OpaqueIdType.OPENID4VP_CODE, id, 5.minutes)
+            val requestUri = URLEncoder.encode(
+                AuthorizeServlet.OPENID4VP_REQUEST_URI_PREFIX + openid4VpCode,
+                "UTF-8"
+            )
+            resp.status = 400
+            resp.writer.write(buildJsonObject {
+                put("error", "insufficient_authorization")
+                put("presentation", "$baseUrl/authorize?request_uri=$requestUri")
+                put("auth_session", idToCode(OpaqueIdType.AUTH_SESSION, id, 5.minutes))
+                put("request_uri", "urn:ietf:params:oauth:request_uri:$code")
+                put("expires_in", expirationSeconds)
+
+            }.toString())
+        } else {
+            if (codeToId(OpaqueIdType.OPENID4VP_PRESENTATION, presentation) != id) {
+                throw IllegalStateException("Bad presentation code")
+            }
+            resp.writer.write(buildJsonObject {
+                put("authorization_code", idToCode(OpaqueIdType.REDIRECT, id, 2.minutes))
+            }.toString())
+        }
+    }
+}

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/BaseServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/BaseServlet.kt
@@ -7,6 +7,7 @@ import com.android.identity.flow.handler.AesGcmCipher
 import com.android.identity.flow.handler.FlowNotifications
 import com.android.identity.flow.handler.InvalidRequestException
 import com.android.identity.flow.handler.SimpleCipher
+import com.android.identity.flow.server.Configuration
 import com.android.identity.flow.server.FlowEnvironment
 import com.android.identity.flow.server.Storage
 import com.android.identity.server.BaseHttpServlet
@@ -48,6 +49,10 @@ abstract class BaseServlet: BaseHttpServlet() {
         cipher = AesGcmCipher(encryptionKey)
         return null
     }
+
+    protected val baseUrl: String
+        get() = environment.getInterface(Configuration::class)!!
+                    .getValue("base_url") + "/openid4vci"
 
     /**
      * Creates an opaque session id ("code") that can be safely given to the client. On the server

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/Openid4VpResponseServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/Openid4VpResponseServlet.kt
@@ -1,0 +1,134 @@
+package com.android.identity.server.openid4vci
+
+import com.android.identity.cbor.Cbor
+import com.android.identity.cbor.CborArray
+import com.android.identity.cbor.Simple
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+import com.android.identity.crypto.javaPrivateKey
+import com.android.identity.crypto.javaPublicKey
+import com.android.identity.document.NameSpacedData
+import com.android.identity.flow.server.Storage
+import com.android.identity.mdoc.response.DeviceResponseParser
+import com.android.identity.util.fromBase64Url
+import com.nimbusds.jose.crypto.ECDHDecrypter
+import com.nimbusds.jose.jwk.Curve
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jwt.EncryptedJWT
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import kotlinx.coroutines.runBlocking
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
+import kotlin.time.Duration.Companion.minutes
+
+class Openid4VpResponseServlet: BaseServlet() {
+    override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
+        val stateCode = req.getParameter("state")!!
+        val id = codeToId(OpaqueIdType.OPENID4VP_STATE, stateCode)
+        val storage = environment.getInterface(Storage::class)!!
+        val state = runBlocking {
+            IssuanceState.fromCbor(storage.get("IssuanceState", "", id)!!.toByteArray())
+        }
+
+        val encryptedJWT = EncryptedJWT.parse(req.getParameter("response")!!)
+
+        val encPub = state.pidReadingKey!!.publicKey.javaPublicKey as ECPublicKey
+        val encPriv = state.pidReadingKey!!.javaPrivateKey as ECPrivateKey
+
+        val encKey = ECKey(
+            Curve.P_256,
+            encPub,
+            encPriv,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null,
+            null
+        )
+
+        val decrypter = ECDHDecrypter(encKey)
+        encryptedJWT.decrypt(decrypter)
+
+        val vpToken = encryptedJWT.jwtClaimsSet.getClaim("vp_token") as String
+        val deviceResponse = vpToken.fromBase64Url()
+        val responseUri = "$baseUrl/openid4vp-response"
+
+        val sessionTranscript = createSessionTranscriptOpenID4VP(
+            clientId = state.clientId,
+            responseUri = responseUri,
+            authorizationRequestNonce = encryptedJWT.header.agreementPartyVInfo.toString(),
+            mdocGeneratedNonce = encryptedJWT.header.agreementPartyUInfo.toString()
+        )
+
+        val parser = DeviceResponseParser(deviceResponse, sessionTranscript)
+        val parsedResponse = parser.parse()
+
+        val data = NameSpacedData.Builder()
+        for (document in parsedResponse.documents) {
+            for (namespaceName in document.issuerNamespaces) {
+                for (dataElementName in document.getIssuerEntryNames(namespaceName)) {
+                    val value = document.getIssuerEntryData(namespaceName, dataElementName)
+                    data.putEntry(namespaceName, dataElementName, value)
+                }
+            }
+        }
+
+        state.credentialData = data.build()
+        runBlocking {
+            storage.update("IssuanceState", "", id, ByteString(state.toCbor()))
+        }
+
+        val presentation = idToCode(OpaqueIdType.OPENID4VP_PRESENTATION, id, 5.minutes)
+        resp.writer.write(buildJsonObject {
+            put("presentation_during_issuance_session", presentation)
+        }.toString())
+    }
+}
+
+// defined in ISO 18013-7 Annex B
+private fun createSessionTranscriptOpenID4VP(
+    clientId: String,
+    responseUri: String,
+    authorizationRequestNonce: String,
+    mdocGeneratedNonce: String
+): ByteArray {
+    val clientIdToHash = Cbor.encode(
+        CborArray.builder()
+        .add(clientId)
+        .add(mdocGeneratedNonce)
+        .end()
+        .build())
+    val clientIdHash = Crypto.digest(Algorithm.SHA256, clientIdToHash)
+
+    val responseUriToHash = Cbor.encode(
+        CborArray.builder()
+        .add(responseUri)
+        .add(mdocGeneratedNonce)
+        .end()
+        .build())
+    val responseUriHash = Crypto.digest(Algorithm.SHA256, responseUriToHash)
+
+    val oid4vpHandover = CborArray.builder()
+        .add(clientIdHash)
+        .add(responseUriHash)
+        .add(authorizationRequestNonce)
+        .end()
+        .build()
+
+    return Cbor.encode(
+        CborArray.builder()
+            .add(Simple.NULL)
+            .add(Simple.NULL)
+            .add(oid4vpHandover)
+            .end()
+            .build()
+    )
+}

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/ParServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/ParServlet.kt
@@ -36,61 +36,8 @@ class ParServlet : BaseServlet() {
     }
 
     override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
-        // Read all parameters
-        if (req.getParameter("client_assertion_type") != ASSERTION_TYPE) {
-            throw InvalidRequestException("invalid parameter 'client_assertion_type'")
-        }
-        val scope = req.getParameter("scope") ?: ""
-        if (!CredentialFactory.supportedScopes.contains(scope)) {
-            throw InvalidRequestException("invalid parameter 'scope'")
-        }
-        if (req.getParameter("response_type") != "code") {
-            throw InvalidRequestException("invalid parameter 'response_type'")
-        }
-        if (req.getParameter("code_challenge_method") != "S256") {
-            throw InvalidRequestException("invalid parameter 'code_challenge_method'")
-        }
-        val redirectUri = req.getParameter("redirect_uri")
-            ?: throw InvalidRequestException("missing parameter 'redirect_uri'")
-        val clientId = req.getParameter("client_id")
-            ?: throw InvalidRequestException("missing parameter 'client_id'")
-        val codeChallenge = try {
-            ByteString(req.getParameter("code_challenge").fromBase64Url())
-        } catch (err: Exception) {
-            throw InvalidRequestException("invalid parameter 'code_challenge'")
-        }
-        val clientAssertion = req.getParameter("client_assertion")
-
-        // Check that client assertion is signed by the trusted client.
-        val sequence = clientAssertion.split("~")
-        val clientCertificate = runBlocking {
-            environment.cache(
-                ClientCertificate::class,
-                clientId
-            ) { configuration, resources ->
-                // So in real life this should be parameterized by clientId, as different clients will
-                // have different public keys.
-                val certificateName = configuration.getValue("attestation.certificate")
-                    ?: "attestation/certificate.pem"
-                val certificate = X509Cert.fromPem(resources.getStringResource(certificateName)!!)
-                ClientCertificate(certificate)
-            }
-        }
-        checkJwtSignature(clientCertificate.certificate.ecPublicKey, sequence[0])
-
-        // Extract session key (used in DPoP authorization for subsequent requests).
-        val parts = sequence[0].split(".")
-        if (parts.size != 3) {
-            throw InvalidRequestException("invalid JWT assertion")
-        }
-        val assertionBody = Json.parseToJsonElement(String(parts[1].fromBase64Url(), Charsets.UTF_8))
-        val dpopKey = JsonWebKey((assertionBody as JsonObject)["cnf"] as JsonObject).asEcPublicKey
-
-        // Create a session
-        val storage = environment.getInterface(Storage::class)!!
-        val state = IssuanceState(clientId, scope, dpopKey, redirectUri, codeChallenge)
         val id = runBlocking {
-            storage.insert("IssuanceState", "", ByteString(state.toCbor()))
+            createSession(environment, req)
         }
 
         // Format the result (session identifying information).
@@ -106,6 +53,4 @@ class ParServlet : BaseServlet() {
                 )
             ).toByteArray())
     }
-
-    private data class ClientCertificate(val certificate: X509Cert)
 }

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/WellKnownOauthAuthorizationServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/WellKnownOauthAuthorizationServlet.kt
@@ -9,11 +9,13 @@ import kotlinx.serialization.json.buildJsonObject
 
 class WellKnownOauthAuthorizationServlet : BaseServlet() {
     override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
-        val configuration = environment.getInterface(Configuration::class)!!
-        val baseUrl = configuration.getValue("base_url") + "/openid4vci"
+        val baseUrl = this.baseUrl
         resp.writer.write(buildJsonObject {
             put("issuer", JsonPrimitive(baseUrl))
             put("authorization_endpoint", JsonPrimitive("$baseUrl/authorize"))
+            // OAuth for First-Party Apps (FiPA)
+            put("authorization_challenge_endpoint",
+                JsonPrimitive("$baseUrl/authorize-challenge"))
             put("token_endpoint", JsonPrimitive("$baseUrl/token"))
             put("pushed_authorization_request_endpoint", JsonPrimitive("$baseUrl/par"))
             put("require_pushed_authorization_requests", JsonPrimitive(true))

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/WellKnownOpenidCredentialIssuerServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/WellKnownOpenidCredentialIssuerServlet.kt
@@ -14,7 +14,7 @@ class WellKnownOpenidCredentialIssuerServlet : BaseServlet() {
     }
     override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
         val configuration = environment.getInterface(Configuration::class)!!
-        val baseUrl = configuration.getValue("base_url") + "/openid4vci"
+        val baseUrl = this.baseUrl
         resp.writer.write(buildJsonObject {
             put("credential_issuer", JsonPrimitive(baseUrl))
             put("credential_endpoint", JsonPrimitive("$baseUrl/credential"))

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/createSession.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/createSession.kt
@@ -1,0 +1,71 @@
+package com.android.identity.server.openid4vci
+
+import com.android.identity.crypto.X509Cert
+import com.android.identity.flow.handler.InvalidRequestException
+import com.android.identity.flow.server.FlowEnvironment
+import com.android.identity.flow.server.Storage
+import com.android.identity.issuance.common.cache
+import com.android.identity.sdjwt.util.JsonWebKey
+import com.android.identity.util.fromBase64Url
+import jakarta.servlet.http.HttpServletRequest
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+
+suspend fun createSession(environment: FlowEnvironment, req: HttpServletRequest): String {
+    // Read all parameters
+    if (req.getParameter("client_assertion_type") != ParServlet.ASSERTION_TYPE) {
+        throw InvalidRequestException("invalid parameter 'client_assertion_type'")
+    }
+    val scope = req.getParameter("scope") ?: ""
+    if (!CredentialFactory.supportedScopes.contains(scope)) {
+        throw InvalidRequestException("invalid parameter 'scope'")
+    }
+    if (req.getParameter("response_type") != "code") {
+        throw InvalidRequestException("invalid parameter 'response_type'")
+    }
+    if (req.getParameter("code_challenge_method") != "S256") {
+        throw InvalidRequestException("invalid parameter 'code_challenge_method'")
+    }
+    val redirectUri = req.getParameter("redirect_uri")
+        ?: throw InvalidRequestException("missing parameter 'redirect_uri'")
+    val clientId = req.getParameter("client_id")
+        ?: throw InvalidRequestException("missing parameter 'client_id'")
+    val codeChallenge = try {
+        ByteString(req.getParameter("code_challenge").fromBase64Url())
+    } catch (err: Exception) {
+        throw InvalidRequestException("invalid parameter 'code_challenge'")
+    }
+    val clientAssertion = req.getParameter("client_assertion")
+
+    // Check that client assertion is signed by the trusted client.
+    val sequence = clientAssertion.split("~")
+    val clientCertificate =
+        environment.cache(
+            ClientCertificate::class,
+            clientId
+        ) { configuration, resources ->
+            // So in real life this should be parameterized by clientId, as different clients will
+            // have different public keys.
+            val certificateName = configuration.getValue("attestation.certificate")
+                ?: "attestation/certificate.pem"
+            val certificate = X509Cert.fromPem(resources.getStringResource(certificateName)!!)
+            ClientCertificate(certificate)
+        }
+    checkJwtSignature(clientCertificate.certificate.ecPublicKey, sequence[0])
+
+    // Extract session key (used in DPoP authorization for subsequent requests).
+    val parts = sequence[0].split(".")
+    if (parts.size != 3) {
+        throw InvalidRequestException("invalid JWT assertion")
+    }
+    val assertionBody = Json.parseToJsonElement(String(parts[1].fromBase64Url(), Charsets.UTF_8))
+    val dpopKey = JsonWebKey((assertionBody as JsonObject)["cnf"] as JsonObject).asEcPublicKey
+
+    // Create a session
+    val storage = environment.getInterface(Storage::class)!!
+    val state = IssuanceState(clientId, scope, dpopKey, redirectUri, codeChallenge)
+    return storage.insert("IssuanceState", "", ByteString(state.toCbor()))
+}
+
+private data class ClientCertificate(val certificate: X509Cert)

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/messages.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/messages.kt
@@ -1,6 +1,5 @@
 package com.android.identity.server.openid4vci
 
-import com.android.identity.cbor.DataItem
 import com.android.identity.cbor.annotation.CborSerializable
 import com.android.identity.crypto.EcPrivateKey
 import com.android.identity.crypto.EcPublicKey
@@ -39,6 +38,7 @@ data class IssuanceState(
     var dpopNonce: ByteString? = null,
     var cNonce: ByteString? = null,
     var pidReadingKey: EcPrivateKey? = null,
+    var pidNonce: String? = null,
     var credentialData: NameSpacedData? = null
 ) {
     companion object
@@ -54,5 +54,9 @@ enum class OpaqueIdType {
     REDIRECT,
     ACCESS_TOKEN,
     REFRESH_TOKEN,
-    PID_READING
+    PID_READING,
+    AUTH_SESSION,  // for use in /authorize_challenge
+    OPENID4VP_CODE,  // send to /authorize when we want openid4vp request
+    OPENID4VP_STATE,  // for state field in openid4vp
+    OPENID4VP_PRESENTATION  // for use in presentation_during_issuance_session
 }

--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/openid4vp.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/openid4vp.kt
@@ -1,0 +1,233 @@
+package com.android.identity.server.openid4vci
+
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
+import com.android.identity.crypto.EcCurve
+import com.android.identity.crypto.EcPrivateKey
+import com.android.identity.crypto.EcPublicKey
+import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
+import com.android.identity.crypto.X509Cert
+import com.android.identity.crypto.X509CertChain
+import com.android.identity.crypto.X509CertificateCreateOption
+import com.android.identity.crypto.X509CertificateExtension
+import com.android.identity.crypto.create
+import com.android.identity.crypto.javaX509Certificate
+import com.android.identity.documenttype.DocumentWellKnownRequest
+import com.android.identity.documenttype.knowntypes.EUPersonalID
+import com.android.identity.sdjwt.util.JsonWebKey
+import com.android.identity.util.toBase64Url
+import kotlinx.datetime.Clock
+import kotlinx.datetime.DateTimePeriod
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.plus
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.bouncycastle.asn1.ASN1ObjectIdentifier
+import org.bouncycastle.asn1.x509.ExtendedKeyUsage
+import org.bouncycastle.asn1.x509.Extension
+import org.bouncycastle.asn1.x509.KeyPurposeId
+import org.bouncycastle.asn1.x509.KeyUsage
+import java.security.interfaces.ECPrivateKey
+import java.security.interfaces.ECPublicKey
+import kotlin.random.Random
+
+data class Openid4VpSession(
+    val jwt: String,
+    val privateKey: EcPrivateKey,
+    val nonce: String
+)
+
+fun initiateOpenid4Vp(
+    clientId: String,
+    responseUri: String,
+    state: String
+): Openid4VpSession {
+    val (singleUseReaderKeyPriv, singleUseReaderKeyCertChain) = createSingleUseReaderKey()
+
+    val request = EUPersonalID.getDocumentType().sampleRequests.first { it.id == "full" }
+    val nonce = Random.nextBytes(15).toBase64Url()
+    val publicKey = singleUseReaderKeyPriv.publicKey
+
+    val header = buildJsonObject {
+        put("typ", JsonPrimitive("oauth-authz-req+jwt"))
+        put("alg", JsonPrimitive(publicKey.curve.defaultSigningAlgorithm.jwseAlgorithmIdentifier))
+        put("jwk", publicKey.toJson(null))
+        put("x5c", buildJsonArray {
+            for (cert in singleUseReaderKeyCertChain.certificates) {
+                add(cert.encodedCertificate.toBase64Url())
+            }
+        })
+    }.toString().toByteArray().toBase64Url()
+
+    val body = buildJsonObject {
+        put("client_id", clientId)
+        put("response_uri", responseUri)
+        put("response_type", "vp_token")
+        put("response_mode", "direct_post.jwt")
+        put("nonce", nonce)
+        put("state", state)
+        put("presentation_definition", mdocCalcPresentationDefinition(request))
+        put("client_metadata", calcClientMetadata(singleUseReaderKeyPriv.publicKey))
+    }.toString().toByteArray().toBase64Url()
+
+    val message = "$header.$body"
+    val signature = Crypto.sign(singleUseReaderKeyPriv, Algorithm.ES256, message.toByteArray())
+        .toCoseEncoded().toBase64Url()
+
+    return Openid4VpSession("$message.$signature", singleUseReaderKeyPriv, nonce)
+}
+
+private fun EcPublicKey.toJson(keyId: String?): JsonObject {
+    return JsonWebKey(this).toRawJwk {
+        if (keyId != null) {
+            put("kid", JsonPrimitive(keyId))
+        }
+        put("alg", JsonPrimitive(curve.defaultSigningAlgorithm.jwseAlgorithmIdentifier))
+        put("use", JsonPrimitive("sig"))
+    }
+}
+
+private fun mdocCalcPresentationDefinition(
+    request: DocumentWellKnownRequest
+): JsonObject {
+    return buildJsonObject {
+        // Fill in a unique ID.
+        put("id", Random.Default.nextBytes(15).toBase64Url())
+        put("input_descriptors", buildJsonArray {
+            add(buildJsonObject {
+                put("id", request.mdocRequest!!.docType)
+                put("format", buildJsonObject {
+                    put("mso_mdoc", buildJsonObject {
+                        put("alg", buildJsonArray {
+                            add("ES256")
+                        })
+                    })
+                })
+                put("constraints", buildJsonObject {
+                    put("limit_disclosure", "required")
+                    put("fields", buildJsonArray {
+                        for (ns in request.mdocRequest!!.namespacesToRequest) {
+                            for ((de, intentToRetain) in ns.dataElementsToRequest) {
+                                add(buildJsonObject {
+                                    put("path", buildJsonArray {
+                                        add("\$['${ns.namespace}']['${de.attribute.identifier}']")
+                                    })
+                                    put("intent_to_retain", intentToRetain)
+                                })
+                            }
+                        }
+                    })
+                })
+            })
+        })
+    }
+}
+
+private fun createSingleUseReaderKey(): Pair<EcPrivateKey, X509CertChain> {
+    val now = Clock.System.now()
+    val validFrom = now.plus(DateTimePeriod(minutes = -10), TimeZone.currentSystemDefault())
+    val validUntil = now.plus(DateTimePeriod(minutes = 10), TimeZone.currentSystemDefault())
+    val readerKey = Crypto.createEcPrivateKey(EcCurve.P256)
+
+    val extensions = mutableListOf<X509CertificateExtension>()
+    extensions.add(
+        X509CertificateExtension(
+            Extension.keyUsage.toString(),
+            true,
+            KeyUsage(KeyUsage.digitalSignature).encoded
+        )
+    )
+    extensions.add(
+        X509CertificateExtension(
+            Extension.extendedKeyUsage.toString(),
+            true,
+            ExtendedKeyUsage(
+                KeyPurposeId.getInstance(ASN1ObjectIdentifier("1.0.18013.5.1.2"))
+            ).encoded
+        )
+    )
+    val readerKeySubject = "CN=OWF IC Online Verifier Single-Use Reader Key"
+
+    // TODO: for now, instead of using the per-site Reader Root generated at first run, use the
+    //  well-know OWF IC Reader root checked into Git.
+    val owfIcReaderCert = X509Cert.fromPem("""
+-----BEGIN CERTIFICATE-----
+MIICCTCCAY+gAwIBAgIQZc/0rhdjZ9n3XoZYzpt2GjAKBggqhkjOPQQDAzA+MS8wLQYDVQQDDCZP
+V0YgSWRlbnRpdHkgQ3JlZGVudGlhbCBURVNUIFJlYWRlciBDQTELMAkGA1UEBhMCWlowHhcNMjQw
+OTE3MTY1NjA5WhcNMjkwOTE3MTY1NjA5WjA+MS8wLQYDVQQDDCZPV0YgSWRlbnRpdHkgQ3JlZGVu
+dGlhbCBURVNUIFJlYWRlciBDQTELMAkGA1UEBhMCWlowdjAQBgcqhkjOPQIBBgUrgQQAIgNiAATM
+1ZVDQ7E4A+ujJl0J7Op8qvy/BSgg/UCTw+WrwYI32/jV9pk8Qu5BSTbUDZE2PQheqy4s3j8y1gMu
++Q5pemhYn/c4OMYXZY8uD+t4Wo9UFoSDkFbvlumZ/cuO5TTAI76jUjBQMB0GA1UdDgQWBBTgtILK
+HJ50qO/Nc33zshz2aX4+4TAfBgNVHSMEGDAWgBTgtILKHJ50qO/Nc33zshz2aX4+4TAOBgNVHQ8B
+Af8EBAMCAQYwCgYIKoZIzj0EAwMDaAAwZQIxALmOcU+Ggax3wHbD8tcd8umuDxzimf9PSICjvlh5
+kwR0/1SZZF7bqMAOQXsrwNYFLgIwLVirmU4WvRlUktR2Ty5kxgDG0iy+g00ur9JXCF+wAUQjKHbg
+VvIQ6NRr06GwpPJR
+-----END CERTIFICATE-----
+        """.trimIndent())
+
+    val owfIcReaderRoot = EcPrivateKey.fromPem("""
+-----BEGIN PRIVATE KEY-----
+MFcCAQAwEAYHKoZIzj0CAQYFK4EEACIEQDA+AgEBBDDxgrZBXnoO54/hZM2DAGrByoWRatjH9hGs
+lrW+vvdmRHBgS+ss56uWyYor6W7ah9ygBwYFK4EEACI=
+-----END PRIVATE KEY-----
+        """.trimIndent(),
+        owfIcReaderCert.ecPublicKey)
+    val owfIcReaderRootSignatureAlgorithm = Algorithm.ES384
+    val owfIcReaderRootIssuer = owfIcReaderCert.javaX509Certificate.issuerX500Principal.name
+
+    val readerKeyCertificate = X509Cert.create(
+        readerKey.publicKey,
+        owfIcReaderRoot,
+        owfIcReaderCert,
+        owfIcReaderRootSignatureAlgorithm,
+        "1",
+        readerKeySubject,
+        owfIcReaderRootIssuer,
+        validFrom,
+        validUntil,
+        setOf(
+            X509CertificateCreateOption.INCLUDE_SUBJECT_KEY_IDENTIFIER,
+            X509CertificateCreateOption.INCLUDE_AUTHORITY_KEY_IDENTIFIER_FROM_SIGNING_KEY_CERTIFICATE
+        ),
+        extensions
+    )
+    return Pair(
+        readerKey,
+        X509CertChain(listOf(readerKeyCertificate) + owfIcReaderCert)
+    )
+}
+
+private fun calcClientMetadata(publicKey: EcPublicKey): JsonObject {
+    val encPub = publicKey as EcPublicKeyDoubleCoordinate
+    val formats = buildJsonObject {
+        put("mso_mdoc", buildJsonObject {
+            put("alg", buildJsonArray {
+                add("ES256")
+            })
+        })
+    }
+    return buildJsonObject {
+        put("authorization_encrypted_response_alg", "ECDH-ES")
+        put("authorization_encrypted_response_enc", "A128CBC-HS256")
+        put("response_mode", "direct_post.jwt")
+        put("vp_formats", formats)
+        put("vp_formats_supported", formats)
+        put("jwks", buildJsonObject {
+            put("keys", buildJsonArray {
+                add(buildJsonObject {
+                    put("kty", "EC")
+                    put("use", "enc")
+                    put("crv", "P-256")
+                    put("alg", "ECDH-ES")
+                    put("x", encPub.x.toBase64Url())
+                    put("y", encPub.y.toBase64Url())
+                })
+            })
+        })
+    }
+}
+

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -296,6 +296,30 @@
     </servlet-mapping>
 
     <servlet>
+        <display-name>AuthorizeChallengeServlet</display-name>
+        <servlet-name>AuthorizeChallengeServlet</servlet-name>
+        <servlet-class>com.android.identity.server.openid4vci.AuthorizeChallengeServlet</servlet-class>
+        <load-on-startup>10</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>AuthorizeChallengeServlet</servlet-name>
+        <url-pattern>/openid4vci/authorize-challenge</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <display-name>Openid4VpResponseServlet</display-name>
+        <servlet-name>Openid4VpResponseServlet</servlet-name>
+        <servlet-class>com.android.identity.server.openid4vci.Openid4VpResponseServlet</servlet-class>
+        <load-on-startup>10</load-on-startup>
+    </servlet>
+
+    <servlet-mapping>
+        <servlet-name>Openid4VpResponseServlet</servlet-name>
+        <url-pattern>/openid4vci/openid4vp-response</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
         <display-name>FinishAuthorizationServlet</display-name>
         <servlet-name>FinishAuthorizationServlet</servlet-name>
         <servlet-class>com.android.identity.server.openid4vci.FinishAuthorizationServlet</servlet-class>

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -171,7 +171,7 @@ fun WalletNavigation(
          */
         composable(WalletDestination.ProvisionDocument.route) {
             ProvisionDocumentScreen(
-                context = application.applicationContext,
+                application = application,
                 secureAreaRepository = application.secureAreaRepository,
                 provisioningViewModel = provisioningViewModel,
                 onNavigate = onNavigate,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
@@ -1,7 +1,9 @@
 package com.android.identity_credential.wallet.ui.destination.provisioncredential
 
+import android.app.Activity
 import android.content.Context
-import android.widget.Toast
+import android.content.ContextWrapper
+import android.util.Base64
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -13,11 +15,23 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import androidx.fragment.app.FragmentActivity
+import com.android.identity.android.mdoc.util.CredmanUtil
+import com.android.identity.appsupport.ui.consent.ConsentDocument
+import com.android.identity.appsupport.ui.consent.ConsentField
+import com.android.identity.appsupport.ui.consent.ConsentRelyingParty
+import com.android.identity.appsupport.ui.consent.MdocConsentField
+import com.android.identity.credential.Credential
+import com.android.identity.crypto.Algorithm
+import com.android.identity.crypto.Crypto
 import com.android.identity.document.DocumentStore
+import com.android.identity.issuance.DocumentExtensions.documentConfiguration
 import com.android.identity.issuance.IssuingAuthorityException
 import com.android.identity.issuance.evidence.EvidenceRequestCreatePassphrase
 import com.android.identity.issuance.evidence.EvidenceRequestGermanEid
@@ -25,27 +39,53 @@ import com.android.identity.issuance.evidence.EvidenceRequestIcaoNfcTunnel
 import com.android.identity.issuance.evidence.EvidenceRequestIcaoPassiveAuthentication
 import com.android.identity.issuance.evidence.EvidenceRequestMessage
 import com.android.identity.issuance.evidence.EvidenceRequestNotificationPermission
+import com.android.identity.issuance.evidence.EvidenceRequestOpenid4Vp
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionMultipleChoice
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionString
 import com.android.identity.issuance.evidence.EvidenceRequestSelfieVideo
 import com.android.identity.issuance.evidence.EvidenceRequestSetupCloudSecureArea
 import com.android.identity.issuance.evidence.EvidenceRequestWeb
 import com.android.identity.issuance.evidence.EvidenceResponseCreatePassphrase
+import com.android.identity.issuance.evidence.EvidenceResponseOpenid4Vp
 import com.android.identity.issuance.evidence.EvidenceResponseQuestionMultipleChoice
 import com.android.identity.issuance.evidence.EvidenceResponseQuestionString
 import com.android.identity.issuance.evidence.EvidenceResponseSetupCloudSecureArea
 import com.android.identity.issuance.remote.WalletServerProvider
+import com.android.identity.mdoc.credential.MdocCredential
+import com.android.identity.mdoc.response.DeviceResponseGenerator
 import com.android.identity.securearea.SecureAreaRepository
+import com.android.identity.trustmanagement.TrustPoint
+import com.android.identity.util.Constants
+import com.android.identity.util.fromBase64Url
+import com.android.identity.util.toBase64Url
 import com.android.identity_credential.wallet.PermissionTracker
 import com.android.identity_credential.wallet.ProvisioningViewModel
 import com.android.identity_credential.wallet.R
+import com.android.identity_credential.wallet.WalletApplication
 import com.android.identity_credential.wallet.navigation.WalletDestination
+import com.android.identity_credential.wallet.presentation.showMdocPresentmentFlow
 import com.android.identity_credential.wallet.ui.ScreenWithAppBar
+import com.nimbusds.jose.EncryptionMethod
+import com.nimbusds.jose.JWEAlgorithm
+import com.nimbusds.jose.JWEHeader
+import com.nimbusds.jose.crypto.ECDHEncrypter
+import com.nimbusds.jose.jwk.ECKey
+import com.nimbusds.jose.jwk.JWKSet
+import com.nimbusds.jose.util.Base64URL
+import com.nimbusds.jwt.EncryptedJWT
+import com.nimbusds.jwt.JWT
+import com.nimbusds.jwt.JWTClaimsSet
+import com.nimbusds.jwt.PlainJWT
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.json.JSONObject
+import java.util.StringTokenizer
+import kotlin.random.Random
 
 
 @Composable
 fun ProvisionDocumentScreen(
-    context: Context,
+    application: WalletApplication,
     secureAreaRepository: SecureAreaRepository,
     provisioningViewModel: ProvisioningViewModel,
     onNavigate: (String) -> Unit,
@@ -53,6 +93,8 @@ fun ProvisionDocumentScreen(
     walletServerProvider: WalletServerProvider,
     documentStore: DocumentStore
 ) {
+    val context = application.applicationContext
+
     ScreenWithAppBar(title = stringResource(R.string.provisioning_title), navigationIcon = {
         if (provisioningViewModel.state.value != ProvisioningViewModel.State.PROOFING_COMPLETE) {
             IconButton(
@@ -104,8 +146,7 @@ fun ProvisionDocumentScreen(
                             onAccept = { inputString ->
                                 provisioningViewModel.provideEvidence(
                                     evidence = EvidenceResponseQuestionString(inputString),
-                                    walletServerProvider = walletServerProvider,
-                                    documentStore = documentStore
+                                    walletServerProvider = walletServerProvider
                                 )
                             }
                         )
@@ -118,8 +159,7 @@ fun ProvisionDocumentScreen(
                             onAccept = { inputString ->
                                 provisioningViewModel.provideEvidence(
                                     evidence = EvidenceResponseCreatePassphrase(inputString),
-                                    walletServerProvider = walletServerProvider,
-                                    documentStore = documentStore
+                                    walletServerProvider = walletServerProvider
                                 )
                             }
                         )
@@ -134,8 +174,7 @@ fun ProvisionDocumentScreen(
                                 provisioningViewModel.provideEvidence(
                                     evidence = EvidenceResponseSetupCloudSecureArea(
                                         evidenceRequest.cloudSecureAreaIdentifier),
-                                    walletServerProvider = walletServerProvider,
-                                    documentStore = documentStore
+                                    walletServerProvider = walletServerProvider
                                 )
                             },
                             onError = { error ->
@@ -172,8 +211,7 @@ fun ProvisionDocumentScreen(
                             onAccept = { selectedOption ->
                                 provisioningViewModel.provideEvidence(
                                     evidence = EvidenceResponseQuestionMultipleChoice(selectedOption),
-                                    walletServerProvider = walletServerProvider,
-                                    documentStore = documentStore
+                                    walletServerProvider = walletServerProvider
                                 )
                             }
                         )
@@ -223,6 +261,15 @@ fun ProvisionDocumentScreen(
                             provisioningViewModel = provisioningViewModel,
                             walletServerProvider = walletServerProvider,
                             documentStore = documentStore
+                        )
+                    }
+
+                    is EvidenceRequestOpenid4Vp -> {
+                        EvidenceRequestOpenid4Vp(
+                            evidenceRequest = evidenceRequest,
+                            provisioningViewModel = provisioningViewModel,
+                            walletServerProvider = walletServerProvider,
+                            application = application
                         )
                     }
                 }
@@ -295,5 +342,160 @@ fun ProvisionDocumentScreen(
                 }
             }
         }
+    }
+}
+
+fun getFragmentActivity(cx: Context): FragmentActivity {
+    var context = cx
+    while (context is ContextWrapper) {
+        if (context is Activity) {
+            if (context is FragmentActivity) {
+                return context
+            }
+            break
+        }
+        context = context.baseContext
+    }
+
+    throw IllegalStateException("Not a FragmentActivity")
+}
+
+suspend fun openid4VpPresentation(
+    credential: Credential,
+    walletApp: WalletApplication,
+    fragmentActivity: FragmentActivity,
+    originUri: String,
+    request: String
+): String {
+    val parts = request.split('.')
+    val openid4vpRequest = JSONObject(String(parts[1].fromBase64Url()))
+    val nonceBase64 = openid4vpRequest.getString("nonce")
+    val nonce = Base64.decode(nonceBase64, Base64.NO_WRAP or Base64.URL_SAFE)
+    val clientID = openid4vpRequest.getString("client_id")
+
+    val presentationDefinition = openid4vpRequest.getJSONObject("presentation_definition")
+    val inputDescriptors = presentationDefinition.getJSONArray("input_descriptors")
+    if (inputDescriptors.length() != 1) {
+        throw IllegalArgumentException("Only support a single input input_descriptor")
+    }
+    val inputDescriptor = inputDescriptors.getJSONObject(0)!!
+    val docType = inputDescriptor.getString("id")
+
+    val constraints = inputDescriptor.getJSONObject("constraints")
+    val fields = constraints.getJSONArray("fields")
+
+    val requestedData = mutableMapOf<String, MutableList<Pair<String, Boolean>>>()
+
+    for (n in 0 until fields.length()) {
+        val field = fields.getJSONObject(n)
+        // Only support a single path entry for now
+        val path = field.getJSONArray("path").getString(0)!!
+        // JSONPath is horrible, hacky way to parse it for demonstration purposes
+        val st = StringTokenizer(path, "'", false).asSequence().toList()
+        val namespace = st[1] as String
+        val name = st[3] as String
+        val intentToRetain = field.getBoolean("intent_to_retain")
+        requestedData.getOrPut(namespace) { mutableListOf() }
+            .add(Pair(name, intentToRetain))
+    }
+
+    val consentFields = MdocConsentField.generateConsentFields(
+        docType,
+        requestedData,
+        walletApp.documentTypeRepository,
+        credential as MdocCredential
+    )
+
+    // Generate the Session Transcript
+    val encodedSessionTranscript = CredmanUtil.generateBrowserSessionTranscript(
+        nonce,
+        originUri,
+        Crypto.digest(Algorithm.SHA256, clientID.toByteArray())
+    )
+    val deviceResponse = showPresentmentFlowAndGetDeviceResponse(
+        fragmentActivity,
+        credential,
+        consentFields,
+        null,
+        originUri,
+        encodedSessionTranscript
+    )
+
+    val clientMetadata = openid4vpRequest.getJSONObject("client_metadata")
+    val encryptionAlg = clientMetadata.getString("authorization_encrypted_response_alg")
+    val encryptionEnc = clientMetadata.getString("authorization_encrypted_response_enc")
+
+    // Create the openid4vp response
+    val responseBody = buildJsonObject {
+        if (openid4vpRequest.has("state")) {
+            put("state", openid4vpRequest.getString("state"))
+        }
+        put("vp_token", deviceResponse.toBase64Url())
+
+        // TODO: do we need this?
+        //put("presentation_submission", Json.encodeToJsonElement(presentationSubmission))
+    }.toString()
+
+    val jwt = maybeEncryptJwtResponse(JWTClaimsSet.parse(responseBody),
+        encryptionAlg, encryptionEnc, nonce, clientMetadata.getJSONObject("jwks").toString())
+
+    return jwt.serialize()
+}
+
+private fun maybeEncryptJwtResponse(
+    claimSet: JWTClaimsSet,
+    encryptedResponseAlg: String?,
+    encryptedResponseEnc: String?,
+    requestNonce: ByteArray,
+    jwks: String
+): JWT {
+    return if (encryptedResponseAlg == null || encryptedResponseEnc == null) {
+        PlainJWT(claimSet)
+    } else {
+        val generatedNonce = Random.nextBytes(15)
+        val apv = Base64URL.encode(requestNonce)
+        val apu = Base64URL.encode(generatedNonce)
+        val responseEncryptionAlg = JWEAlgorithm.parse(encryptedResponseAlg)
+        val responseEncryptionMethod = EncryptionMethod.parse(encryptedResponseEnc)
+        val jweHeader = JWEHeader.Builder(responseEncryptionAlg, responseEncryptionMethod)
+            .apply {
+                apv.let(::agreementPartyVInfo)
+                apu.let(::agreementPartyUInfo)
+            }
+            .build()
+        val keySet = JWKSet.parse(jwks)
+        val jweEncrypter: ECDHEncrypter? = keySet.keys.mapNotNull { key ->
+            runCatching { ECDHEncrypter(key as ECKey) }.getOrNull()
+                ?.let { encrypter -> key to encrypter }
+        }
+            .toMap().firstNotNullOfOrNull { it.value }
+        EncryptedJWT(jweHeader, claimSet).apply { encrypt(jweEncrypter) }
+    }
+}
+
+private suspend fun showPresentmentFlowAndGetDeviceResponse(
+    fragmentActivity: FragmentActivity,
+    mdocCredential: MdocCredential,
+    consentFields: List<ConsentField>,
+    trustPoint: TrustPoint?,
+    websiteOrigin: String?,
+    encodedSessionTranscript: ByteArray,
+): ByteArray {
+    val documentCborBytes = showMdocPresentmentFlow(
+        activity = fragmentActivity,
+        consentFields = consentFields,
+        document = ConsentDocument(
+            name = mdocCredential.document.documentConfiguration.displayName,
+            description = mdocCredential.document.documentConfiguration.typeDisplayName,
+            cardArt = mdocCredential.document.documentConfiguration.cardArt,
+        ),
+        relyingParty = ConsentRelyingParty(trustPoint, websiteOrigin),
+        credential = mdocCredential,
+        encodedSessionTranscript = encodedSessionTranscript,
+    )
+    // Create ISO DeviceResponse
+    DeviceResponseGenerator(Constants.DEVICE_RESPONSE_STATUS_OK).run {
+        addDocument(documentCborBytes)
+        return generate()
     }
 }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -357,6 +357,14 @@
     <!-- External browser -->
     <string name="browser_continue">Launching browser, continue there…</string>
 
+    <!-- Presentation while issuing evidence -->
+    <string name="presentation_evidence_message">
+        The Issuing Authority requires you to authenticate yourself.
+        You can do this by presenting the eID you have in your wallet.
+    </string>
+    <string name="presentation_evidence_ok">Present eID</string>
+    <string name="presentation_evidence_cancel">Cancel</string>
+
     <!-- Accessibility -->
     <string name="accessibility_go_back_icon">Go back</string>
     <string name="accessibility_menu_icon">Menu</string>


### PR DESCRIPTION
Implemented draft spec for presentation during issuance that adds an option for the issuing authority to request openid4vp credential presentation as evidence. This significantly improves user experience as there is no need to switch to the browser and then back to the wallet.

In our implementation we send EvidenceRequests for both openid4vp presentation and web-based evidence collection. Wallet determines if there is actually a valid credential that can be used and only offers user to do presentation during issuance if an appropriate credential is found.

Manually tested the scenarios of having and not having an appropriate PID in the wallet as well as accepting or not accepting in-wallet PID presentation.

Only narrow path for OpenId4VP presentation is implemented: PID in mdoc format. OpenId4VP code should be factored out in a separate library that can be used in the wallet, verifier and OpenId4VCI issuer.