### PR TITLE
Improve activity viewer and log requester information

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
@@ -57,6 +57,7 @@ import com.android.identity.securearea.software.SoftwareKeyUnlockData
 import com.android.identity.securearea.software.SoftwareSecureArea
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.credman.CredmanRegistry
+import com.android.identity_credential.wallet.logging.EventLogger
 import com.android.identity_credential.wallet.logging.MdocPresentationEvent
 import com.android.identity_credential.wallet.presentation.UserCanceledPromptException
 import com.android.identity_credential.wallet.ui.destination.document.formatDate
@@ -186,8 +187,6 @@ class DocumentModel(
                 is MdocPresentationEvent -> {
                     val parser = DeviceRequestParser(event.deviceRequestCbor, event.deviceResponseCbor)
                     val deviceRequest = parser.parse()
-
-                    // Extract the requested fields as before
                     val targetNamespaces = setOf("eu.europa.ec.eudi.pid.1", "org.iso.18013.5.1")
                     val requestedFields = deviceRequest.docRequests.flatMap { docRequest ->
                         targetNamespaces.flatMap { namespace ->
@@ -202,13 +201,14 @@ class DocumentModel(
                     // Format timestamp and other UI-friendly data
                     EventInfo(
                         timestamp = formatDate(event.timestamp),
+                        requesterInfo = event.requesterInfo,
                         requestedFields = requestedFields,
-                        // TODO: thumbnail to be populated instead of requestedFields
                     )
                 }
                 else -> {
                     EventInfo(
                         timestamp = formatDate(event.timestamp),
+                        requesterInfo = EventLogger.RequesterInfo(EventLogger.Requester.Anonymous(), EventLogger.ShareType.UNKNOWN),
                         requestedFields = "Unknown event type"
                     )
                 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/EventInfo.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/EventInfo.kt
@@ -1,8 +1,9 @@
 package com.android.identity_credential.wallet
 
-import android.graphics.Bitmap
+import com.android.identity_credential.wallet.logging.EventLogger
 
 data class EventInfo(
     val timestamp: String,
+    val requesterInfo: EventLogger.RequesterInfo?,
     val requestedFields: String,
 )

--- a/wallet/src/main/java/com/android/identity_credential/wallet/logging/EventLogger.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/logging/EventLogger.kt
@@ -1,8 +1,8 @@
 package com.android.identity_credential.wallet.logging
 
+import com.android.identity.cbor.annotation.CborSerializable
 import com.android.identity.storage.StorageEngine
 import com.android.identity.util.Logger
-import com.android.identity.util.UUID
 import kotlinx.datetime.Clock
 
 /**
@@ -34,11 +34,45 @@ class EventLogger(private val storageEngine: StorageEngine) {
         return eventLoggingEnabled
     }
 
+    @CborSerializable
+    sealed class Requester {
+        class Anonymous : Requester() {
+            override fun toString() = "Anonymous requester"
+        }
+
+        class Unknown : Requester() {
+            override fun toString() = "Unknown requester"
+        }
+
+        class Named(val name: String) : Requester() {
+            override fun toString() = name
+        }
+    }
+
+    enum class ShareType(val displayName: String) {
+        SHARED_IN_PERSON("Shared in-person"),
+        SHARED_WITH_APPLICATION("Shared with application"),
+        SHARED_WITH_WEBSITE("Shared with website"),
+        UNKNOWN("Unknown");
+
+        override fun toString(): String {
+            return displayName
+        }
+    }
+
+    @CborSerializable
+    data class RequesterInfo(
+        val requester: Requester,
+        val shareType: ShareType
+    )
+
     fun addMDocPresentationEntry(
         documentId: String,
         sessionTranscript: ByteArray,
         deviceRequestCbor: ByteArray,
-        deviceResponseCbor: ByteArray
+        deviceResponseCbor: ByteArray,
+        requesterType: Requester,
+        shareType: ShareType
     ) {
         if (!eventLoggingEnabled) {
             Logger.i(TAG, "Logging is disabled")
@@ -46,6 +80,10 @@ class EventLogger(private val storageEngine: StorageEngine) {
         }
 
         val uniqueId = Clock.System.now()
+        val requesterInfo = RequesterInfo(
+            requester = requesterType,
+            shareType = shareType
+        )
         val serializedEntry: ByteArray
 
         val event = MdocPresentationEvent(
@@ -54,8 +92,9 @@ class EventLogger(private val storageEngine: StorageEngine) {
             sessionTranscript = sessionTranscript,
             deviceRequestCbor = deviceRequestCbor,
             deviceResponseCbor = deviceResponseCbor,
+            requesterInfo = requesterInfo
         )
-        serializedEntry = event.toCbor()//Cbor.encode(event.toDataItem())
+        serializedEntry = event.toCbor()
 
         val key = STORAGE_KEY_PREFIX + uniqueId
         storageEngine.put(key, serializedEntry)
@@ -67,10 +106,14 @@ class EventLogger(private val storageEngine: StorageEngine) {
             if (key.startsWith(STORAGE_KEY_PREFIX)) {
                 val value = storageEngine[key]
                 if (value != null) {
-                    when (val event = Event.fromCbor(value)) {
-                        is MdocPresentationEvent -> if (event.documentId == documentId) entries.add(event)
-                        is DocumentUpdateCheckEvent -> if (event.documentId == documentId) entries.add(event)
-                        // No need for an else branch here, as other Event subclasses don't have documentId
+                    try {
+                        val event = Event.fromCbor(value)
+                        when {
+                            event is MdocPresentationEvent && event.documentId == documentId -> entries.add(event)
+                            event is DocumentUpdateCheckEvent && event.documentId == documentId -> entries.add(event)
+                        }
+                    } catch(e: IllegalStateException) {
+                        Logger.w(TAG, "Failed to deserialize event for key: $key", e)
                     }
                 }
             }
@@ -92,4 +135,3 @@ class EventLogger(private val storageEngine: StorageEngine) {
         Logger.i(TAG, "Deleted all entries for documentId: $documentId")
     }
 }
-

--- a/wallet/src/main/java/com/android/identity_credential/wallet/logging/MdocPresentationEvent.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/logging/MdocPresentationEvent.kt
@@ -9,4 +9,7 @@ data class MdocPresentationEvent (
     var sessionTranscript: ByteArray,
     var deviceRequestCbor: ByteArray,
     var deviceResponseCbor: ByteArray,
+    val requesterInfo: EventLogger.RequesterInfo = EventLogger.RequesterInfo(
+        requester = EventLogger.Requester.Anonymous(),
+        shareType = EventLogger.ShareType.UNKNOWN)
 ) : Event(timestamp)

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletDestination.kt
@@ -31,6 +31,24 @@ sealed class WalletDestination(val routeEnum: Route) {
 
     object Reader : WalletDestination(Route.READER)
 
+    object EventDetails : WalletDestination(Route.EVENT_DETAILS) {
+        enum class Argument(val argument: NamedNavArgument) {
+            REQUESTED_FIELDS(
+                navArgument("requestedFields") {
+                    type = NavType.StringType
+                    nullable = false
+                }
+            );
+
+            fun extractFromBackStackEntry(backStackEntry: NavBackStackEntry): String? {
+                return backStackEntry.arguments?.getString(argument.name)
+            }
+        }
+
+        override fun getArguments(): List<NamedNavArgument> =
+            Argument.values().map { it.argument }
+    }
+
     // Screens with arguments
     object DocumentInfo : WalletDestination(Route.DOCUMENT_INFO) {
         /**
@@ -189,10 +207,11 @@ enum class Route(val routeName: String, val argumentsStr: String = "") {
     ADD_TO_WALLET("add_to_wallet"),
     DOCUMENT_INFO("document_info",
         "documentId={documentId}&section={section}&auth_required={auth_required}"),
-    ACTIVITY_LOG("activity_log","documentId={documentId}"),
+    ACTIVITIES("activities","documentId={documentId}"),
     PROVISION_DOCUMENT("provision_document"),
     QR_ENGAGEMENT("qr_engagement"),
     READER("reader_select_request"),
+    EVENT_DETAILS("event_details"),
 
     // a Route for popping the back stack showing a different Screen
     POP_BACK_STACK("pop_back_stack"),

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -4,8 +4,10 @@ import android.content.SharedPreferences
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.PermissionTracker
 import com.android.identity_credential.wallet.ProvisioningViewModel
@@ -17,6 +19,7 @@ import com.android.identity_credential.wallet.ui.destination.addtowallet.AddToWa
 import com.android.identity_credential.wallet.ui.destination.document.CredentialInfoScreen
 import com.android.identity_credential.wallet.ui.destination.document.DocumentDetailsScreen
 import com.android.identity_credential.wallet.ui.destination.document.DocumentInfoScreen
+import com.android.identity_credential.wallet.ui.destination.document.EventDetailsScreen
 import com.android.identity_credential.wallet.ui.destination.document.EventLogScreen
 import com.android.identity_credential.wallet.ui.destination.main.MainScreen
 import com.android.identity_credential.wallet.ui.destination.provisioncredential.ProvisionDocumentScreen
@@ -130,6 +133,26 @@ fun WalletNavigation(
         }
 
         composable(
+            route = "${WalletDestination.EventDetails.route}/{documentId}/{timestamp}",
+            arguments = listOf(
+                navArgument("documentId") { type = NavType.StringType },
+                navArgument("timestamp") { type = NavType.StringType }
+            )
+        ) { backStackEntry ->
+            // Extract arguments from the back stack entry
+            val documentId = backStackEntry.arguments?.getString("documentId") ?: ""
+            val timestamp = backStackEntry.arguments?.getString("timestamp") ?: ""
+
+            EventDetailsScreen(
+                documentModel = documentModel,
+                navController = navController,
+                documentId = documentId,
+                timestamp = timestamp
+            )
+        }
+
+
+        composable(
             route = WalletDestination.DocumentInfo.routeWithArgs,
             arguments = WalletDestination.DocumentInfo.getArguments()
         ) { backStackEntry ->
@@ -156,7 +179,7 @@ fun WalletNavigation(
                     EventLogScreen(
                         documentId = cardId,
                         documentModel = documentModel,
-                        onNavigate = onNavigate,
+                        navController = navController,
                     )
                 }
                 "credentials" -> {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/EventLogScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/EventLogScreen.kt
@@ -1,16 +1,18 @@
 package com.android.identity_credential.wallet.ui.destination.document
 
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
-import androidx.compose.material3.Button
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,73 +23,202 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.runtime.remember
+import androidx.navigation.NavHostController
 import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.EventInfo
 import com.android.identity_credential.wallet.R
+import com.android.identity_credential.wallet.logging.EventLogger
 import com.android.identity_credential.wallet.navigation.WalletDestination
 import com.android.identity_credential.wallet.ui.KeyValuePairText
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
 
 private const val TAG = "EventLogScreen"
 
+/**
+ * Formats a timestamp string into a human-readable format.
+ *
+ * This function takes a timestamp string (expected to be in the format "yyyy-MM-dd HH:mm:ss")
+ * and converts it into a more readable format like "Wed Oct 02 5:20 PM".
+ *
+ * @param timestampString The timestamp string to format.
+ * @return The formatted timestamp string.
+ */
+fun formatTimestamp(timestampString: String): String {
+    // TODO: Consider using KMM version: https://github.com/Kotlin/kotlinx-datetime.
+    // Convert the input timestamp to ISO-8601 format
+    val isoTimestamp = timestampString.replace(" ", "T") + "Z"
+
+    // Parse the ISO formatted timestamp as an Instant
+    val instant = Instant.parse(isoTimestamp)
+
+    // Convert the instant to LocalDateTime in the system's default timezone
+    val localDateTime = instant.toLocalDateTime(TimeZone.currentSystemDefault())
+
+    // Manually format the LocalDateTime to the desired output format
+    val dayOfWeek = localDateTime.dayOfWeek.name.take(3).lowercase().replaceFirstChar { it.uppercase() } // e.g., "Wed"
+    val month = localDateTime.month.name.take(3).lowercase().replaceFirstChar { it.uppercase() }         // e.g., "Oct"
+    val day = localDateTime.dayOfMonth                                // e.g., "02"
+    val hour = if (localDateTime.hour > 12) localDateTime.hour - 12 else localDateTime.hour
+    val minute = localDateTime.minute.toString().padStart(2, '0')     // e.g., "20"
+    val amPm = if (localDateTime.hour >= 12) "PM" else "AM"
+
+    return "$dayOfWeek $month $day $hour:$minute $amPm"
+}
+
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
-fun EventLogScreen(documentId: String, documentModel: DocumentModel, onNavigate: (String) -> Unit) {
+fun EventLogScreen(
+    documentId: String,
+    documentModel: DocumentModel,
+    navController: NavHostController
+) {
     val eventInfos = remember {
         mutableStateListOf<EventInfo>().apply {
             addAll(documentModel.getEventInfos(documentId))
         }
     }
 
-    Box(
-        modifier = Modifier.fillMaxHeight()
+    ScreenWithAppBarAndBackButton(
+        title = stringResource(R.string.document_info_screen_menu_activities_log),
+        onBackButtonClick = { navController.popBackStack() }
     ) {
-        ScreenWithAppBarAndBackButton(
-            title = stringResource(R.string.document_info_screen_menu_activities_log),
-            onBackButtonClick = { onNavigate(WalletDestination.PopBackStack.route) }
-        ) {
-            if (eventInfos.isEmpty()) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.Center,
-                ) {
-                    Text(
-                        modifier = Modifier.padding(8.dp),
-                        text = stringResource(R.string.document_info_screen_menu_activities_log_screen_empty),
-                        style = MaterialTheme.typography.titleLarge,
-                        textAlign = TextAlign.Center
-                    )
-                }
-            } else {
-                Column(modifier = Modifier.weight(1f)) {
+        if (eventInfos.isEmpty()) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center,
+            ) {
+                Text(
+                    modifier = Modifier.padding(8.dp),
+                    text = stringResource(R.string.document_info_screen_menu_activities_log_screen_empty),
+                    style = MaterialTheme.typography.titleLarge,
+                    textAlign = TextAlign.Center
+                )
+            }
+        } else {
+            Column(
+                verticalArrangement = Arrangement.Top,
+                modifier = Modifier.weight(1f)
+            ) {
                 LazyColumn {
-                        items(eventInfos) { eventInfo ->
-                            Row(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(4.dp),
-                                verticalAlignment = Alignment.CenterVertically
-                            ) {
-                                KeyValuePairText(eventInfo.timestamp, eventInfo.requestedFields)
+                    items(eventInfos) { eventInfo ->
+                        Row(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(4.dp)
+                                .clickable {
+                                    // Pass documentId and timestamp as arguments
+                                    navController.navigate("${WalletDestination.EventDetails.route}/$documentId/${eventInfo.timestamp}")
+                                },
+                            verticalAlignment = Alignment.CenterVertically
+                        ) {
+                            val requesterInfo = eventInfo.requesterInfo ?: EventLogger.RequesterInfo(
+                                requester = EventLogger.Requester.Anonymous(),
+                                shareType = EventLogger.ShareType.UNKNOWN
+                            )
+
+                            val shareTypeText = when (requesterInfo.shareType) {
+                                EventLogger.ShareType.SHARED_IN_PERSON -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_shared_in_person)
+                                EventLogger.ShareType.SHARED_WITH_APPLICATION -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_shared_with_application)
+                                EventLogger.ShareType.SHARED_WITH_WEBSITE -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_shared_with_website)
+                                EventLogger.ShareType.UNKNOWN -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_unknown_share)
                             }
+
+                            KeyValuePairText(
+                                requesterInfo.requester.toString(), "${formatTimestamp(eventInfo.timestamp)} . $shareTypeText"
+                            )
                         }
                     }
                 }
             }
         }
-        if (eventInfos.isNotEmpty()) {
-            Row(
-                horizontalArrangement = Arrangement.End,
-                modifier = Modifier
-                    .align(Alignment.BottomEnd)
-                    .fillMaxWidth()
-                    .padding(16.dp)
-            ) {
-                Button(onClick = {
-                    documentModel.deleteEventInfos(documentId)
-                    eventInfos.clear()
-                }) {
-                    Text("Delete All")
+    }
+}
+
+@Composable
+fun EventDetailsScreen(
+    documentModel: DocumentModel,
+    navController: NavHostController,
+    documentId: String,
+    timestamp: String
+) {
+    // Retrieve the event based on documentId and timestamp
+    val eventInfos = remember { documentModel.getEventInfos(documentId) }
+    val eventInfo = eventInfos.find { it.timestamp == timestamp }
+
+    ScreenWithAppBarAndBackButton(
+        title = "",
+        onBackButtonClick = { navController.popBackStack() }
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .weight(1f)
+        ) {
+            if (eventInfo == null) {
+                Text(text = "Event not found")
+            } else {
+                Text(
+                    text = documentModel.getDocumentInfo(documentId)?.name ?: "Unknown",
+                    modifier = Modifier.fillMaxWidth(),
+                    textAlign = TextAlign.Center
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                val requesterInfo = eventInfo.requesterInfo ?: EventLogger.RequesterInfo(
+                    requester = EventLogger.Requester.Anonymous(),
+                    shareType = EventLogger.ShareType.UNKNOWN
+                )
+
+                val shareTypeText = when (requesterInfo.shareType) {
+                    EventLogger.ShareType.SHARED_IN_PERSON -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_shared_in_person)
+                    EventLogger.ShareType.SHARED_WITH_APPLICATION -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_shared_with_application)
+                    EventLogger.ShareType.SHARED_WITH_WEBSITE -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_shared_with_website)
+                    EventLogger.ShareType.UNKNOWN -> stringResource(id = R.string.document_info_screen_menu_activities_log_screen_unknown_share)
+                }
+
+                KeyValuePairText(
+                    stringResource(id = R.string.document_info_screen_menu_activities_log_screen_share_type),
+                    shareTypeText
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+                KeyValuePairText(
+                    stringResource(id = R.string.document_info_screen_menu_activities_log_screen_requester),
+                    requesterInfo.requester.toString()
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+
+                val fieldsList = eventInfo.requestedFields.replace("_", " ")
+                    .split(",")
+
+                KeyValuePairText(
+                    stringResource(id = R.string.document_info_screen_menu_activities_log_screen_data_shared),
+                    ""
+                )
+                Card(
+                    modifier = Modifier
+                        .padding(16.dp)
+                        .fillMaxWidth(),
+                    shape = RoundedCornerShape(16.dp),
+                ) {
+                    Column(modifier = Modifier.padding(16.dp)) {
+                        fieldsList.chunked(2).forEach { pair ->
+                            Row(modifier = Modifier.fillMaxWidth()) {
+                                Text(
+                                    text = pair.getOrNull(0) ?: "",
+                                    modifier = Modifier.weight(1f),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                                Text(
+                                    text = pair.getOrNull(1) ?: "",
+                                    modifier = Modifier.weight(1f),
+                                    color = MaterialTheme.colorScheme.onSurface
+                                )
+                            }
+                        }
+                    }
                 }
             }
         }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -134,9 +134,23 @@
     <string name="settings_screen_log_to_file_title">Logging</string>
     <string name="settings_screen_log_to_file_subtitle_on">Diagnostic messages are being logged</string>
     <string name="settings_screen_log_to_file_subtitle_off">Diagnostic messages are not being logged</string>
-    <string name="settings_screen_activities_logging_title">Show Activity</string>
+    <string name="settings_screen_activities_logging_title">Log Activity</string>
     <string name="settings_screen_activities_logging_subtitle_on">Activities are being logged</string>
     <string name="settings_screen_activities_logging_subtitle_off">Activities are not being logged</string>
+    <string name="settings_screen_activities_logging_shared_in_person">Shared in person</string>
+    <string name="settings_screen_activities_logging_shared_to_website">Shared to website</string>
+    <string name="settings_screen_activities_logging_shared_to_application">Shared to application</string>
+    <string name="settings_screen_activities_logging_unknown_requester">Unknown requester</string>
+    <string name="settings_screen_activities_logging_unverified_requester">Unverified requester</string>
+    <string name="settings_screen_activities_logging_disclaimer">
+        The activity log is kept on this device and is encrypted at rest. It is never shared with the application
+        vendor, device manufacturer, or anyone else.
+    </string>
+    <string name="settings_screen_activities_logging_delete_all_entries">Delete all entries</string>
+    <string name="settings_screen_activities_logging_confirm_deletion">Confirm Deletion</string>
+    <string name="settings_screen_activities_logging_confirm_deletion_detailed">
+        Are you sure you want to delete all activity entries for this document?
+    </string>
     <string name="settings_screen_log_to_file_clear_button">Clear log</string>
     <string name="settings_screen_log_to_file_share_button">Share log</string>
     <string name="settings_screen_log_to_file_chooser_title">Share Log</string>
@@ -222,8 +236,15 @@
     <string name="document_info_screen_menu_item_show_data">Show Data</string>
     <string name="document_info_screen_menu_item_show_credentials">Show Credentials</string>
     <string name="document_info_screen_menu_item_request_update">Request Update</string>
-    <string name="document_info_screen_menu_activities_log">Activities Log</string>
+    <string name="document_info_screen_menu_activities_log">Show Usage</string>
     <string name="document_info_screen_menu_activities_log_screen_empty">No activities logged yet</string>
+    <string name="document_info_screen_menu_activities_log_screen_shared_in_person">"Shared in-person"</string>
+    <string name="document_info_screen_menu_activities_log_screen_shared_with_website">"Shared with website"</string>
+    <string name="document_info_screen_menu_activities_log_screen_shared_with_application">"Shared with application"</string>
+    <string name="document_info_screen_menu_activities_log_screen_unknown_share">"Unknown share type"</string>
+    <string name="document_info_screen_menu_activities_log_screen_share_type">"Share Type"</string>
+    <string name="document_info_screen_menu_activities_log_screen_requester">"Requester"</string>
+    <string name="document_info_screen_menu_activities_log_screen_data_shared">"Data shared"</string>
     <string name="document_info_screen_request_update_title">Request Update</string>
     <string name="document_info_screen_request_update_message">
         This is a Developer Mode feature to request a document update from the Issuing Authority.

--- a/wallet/src/test/java/com/android/identity_credential/wallet/logging/EventLoggerTest.kt
+++ b/wallet/src/test/java/com/android/identity_credential/wallet/logging/EventLoggerTest.kt
@@ -1,20 +1,28 @@
 package com.android.identity_credential.wallet.logging
 
 import com.android.identity.storage.EphemeralStorageEngine
-import org.junit.Assert.*
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.Parameterized
 import kotlin.test.assertTrue
 
-class EventLoggerTest {
+
+@RunWith(Parameterized::class)
+class EventLoggerTest(
+    private val requesterType: EventLogger.Requester,
+    private val shareType: EventLogger.ShareType
+) {
 
     private lateinit var mockStorage: EphemeralStorageEngine
-    private lateinit var activityLogger: EventLogger // Create an instance
+    private lateinit var activityLogger: EventLogger
 
     @Before
     fun setUp() {
         mockStorage = EphemeralStorageEngine()
-        activityLogger = EventLogger(mockStorage) // Initialize the instance
+        activityLogger = EventLogger(mockStorage)
     }
 
     @Test
@@ -30,28 +38,45 @@ class EventLoggerTest {
     }
 
     @Test
-    fun testDeleteEntries() {
-        // Start logging events
+    fun testAddAndDeleteEntries() {
         activityLogger.startLoggingEvents()
 
-        // Add an MdocPresentationEntry to the logger
         activityLogger.addMDocPresentationEntry(
             documentId = "doc123",
             sessionTranscript = "sessionTranscript".toByteArray(),
             deviceRequestCbor = "request data".toByteArray(),
-            deviceResponseCbor = "response data".toByteArray()
+            deviceResponseCbor = "response data".toByteArray(),
+            requesterType = requesterType,
+            shareType = shareType,
         )
 
-        // Retrieve the entries for the given documentId
         val entries = activityLogger.getEntries("doc123")
-
-        // Ensure that entries were added correctly
         assertTrue(entries.isNotEmpty(), "Entries should not be empty after adding an event")
 
-        // Delete the entries retrieved
         activityLogger.deleteEntries(entries)
-
-        // Check that the storage is empty after deletion
         assertTrue(mockStorage.enumerate().isEmpty(), "Storage should be empty after deleting all entries")
+    }
+
+    companion object {
+        @JvmStatic
+        @Parameterized.Parameters
+        fun data(): Collection<Array<Any>> {
+            val data = mutableListOf<Array<Any>>()
+            // Add test cases for Anonymous requester
+            data.add(arrayOf(EventLogger.Requester.Anonymous(), EventLogger.ShareType.SHARED_IN_PERSON))
+            data.add(arrayOf(EventLogger.Requester.Anonymous(), EventLogger.ShareType.SHARED_WITH_APPLICATION))
+            data.add(arrayOf(EventLogger.Requester.Anonymous(), EventLogger.ShareType.SHARED_WITH_WEBSITE))
+            data.add(arrayOf(EventLogger.Requester.Anonymous(), EventLogger.ShareType.UNKNOWN))
+
+            // Add test cases for Named requester
+            data.add(arrayOf(EventLogger.Requester.Named("Bank of America"), EventLogger.ShareType.SHARED_IN_PERSON))
+            data.add(arrayOf(EventLogger.Requester.Named("TSA"), EventLogger.ShareType.SHARED_WITH_APPLICATION))
+
+            // Add test cases for Unknown requester
+            data.add(arrayOf(EventLogger.Requester.Unknown(), EventLogger.ShareType.SHARED_WITH_WEBSITE))
+            data.add(arrayOf(EventLogger.Requester.Unknown(), EventLogger.ShareType.UNKNOWN))
+
+            return data
+        }
     }
 }


### PR DESCRIPTION
This change include changes to the activity viewer where a high level list of activities is shown. The user gets to click on each activity and can see the specific requested fields. This change required storing the requester information.

Tested by: local testing for presentment activity and viewing of the logged events.

Signed-off-by: Hamzeh Zawawy <hamzeh@google.com>

- [x] Tests pass
- [ ] Appropriate changes to README are included in PR