### PR TITLE
Add vct Field to OpenID4VP flows

### DIFF
--- a/identity/src/commonMain/kotlin/com/android/identity/documenttype/DocumentType.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/documenttype/DocumentType.kt
@@ -243,7 +243,7 @@ class DocumentType private constructor(
                     }
                     list
                 }
-                VcRequest(claims)
+                VcRequest(vcBuilder!!.type, claims)
             }
             sampleRequests.add(DocumentWellKnownRequest(id, displayName, mdocRequest, vcRequest))
         }

--- a/identity/src/commonMain/kotlin/com/android/identity/documenttype/VcRequest.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/documenttype/VcRequest.kt
@@ -3,8 +3,12 @@ package com.android.identity.documenttype
 /**
  * A class representing a request for claims.
  *
+ * @param vct the verifiable credential type, as defined in section 3.2.2.1.1.
+ * "Verifiable Credential Type - vct Claim" of IETF
+ * [SD-JWT-based Verifiable Credentials (SD-JWT VC)](https://datatracker.ietf.org/doc/html/draft-ietf-oauth-sd-jwt-vc-05)
  * @param claimsToRequest the claims to request.
  */
 data class VcRequest(
+    val vct: String,
     val claimsToRequest: List<DocumentAttribute>
 )

--- a/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
@@ -1382,6 +1382,14 @@ private fun sdjwtCalcPresentationDefinition(
     format.put("jwt_vc", algContainer)
 
     val fields = JSONArray()
+    val vctArray = JSONArray()
+    vctArray.add("\$.vct")
+    val vctFilter = JSONObject()
+    vctFilter.put("const", request.vcRequest!!.vct)
+    val vctField = JSONObject()
+    vctField.put("path", vctArray)
+    vctField.put("filter", vctFilter)
+    fields.add(vctField)
     for (claim in request.vcRequest!!.claimsToRequest) {
         var array = JSONArray()
         array.add("\$.${claim.identifier}")


### PR DESCRIPTION
Added vct field as const to the verifier, and updated wallet to send documents which match the defined vct if defined as a const.

Tested manually with verifier changes + with verifiers without defined vct.