### PR TITLE
Display Driving Privileges in a human-friendly format.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -281,6 +281,8 @@ class ShowDocumentFragment : Fragment() {
                     } else if (doc.docType == MDL_DOCTYPE && ns == MDL_NAMESPACE && elem == "signature_usual_mark") {
                         valueStr = String.format("(%d bytes, shown below)", value.size)
                         signatureBytes = doc.getIssuerEntryByteString(ns, elem)
+                    } else if (doc.docType == MDL_DOCTYPE && ns == MDL_NAMESPACE && elem == "driving_privileges") {
+                        valueStr = createDrivingPrivilegesHtml(value)
                     } else if (mdocDataElement != null) {
                         valueStr = mdocDataElement.renderValue(Cbor.decode(value))
                     } else {
@@ -301,6 +303,22 @@ class ShowDocumentFragment : Fragment() {
             }
         }
         return sb.toString()
+    }
+
+    private fun createDrivingPrivilegesHtml(encodedElementValue: ByteArray): String {
+        val decodedValue = Cbor.decode(encodedElementValue).asArray
+        val htmlDisplayValue = buildString {
+            for (categoryMap in decodedValue) {
+                val categoryCode =
+                    categoryMap.getOrNull("vehicle_category_code")?.asTstr ?: "Unspecified"
+                val vehicleIndent = "&nbsp;".repeat(4)
+                append("<div>${vehicleIndent}Vehicle class: $categoryCode</div>")
+                val indent = "&nbsp;".repeat(8)
+                categoryMap.getOrNull("issue_date")?.asDateString?.let { append("<div>${indent}Issued: $it</div>") }
+                categoryMap.getOrNull("expiry_date")?.asDateString?.let { append("<div>${indent}Expires: $it</div>") }
+            }
+        }
+        return htmlDisplayValue
     }
 
     private fun isPortraitApplicable(docType: String, namespace: String?): Boolean {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/AttributeDisplayInfo.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/AttributeDisplayInfo.kt
@@ -1,0 +1,9 @@
+package com.android.identity_credential.wallet
+
+import android.graphics.Bitmap
+
+sealed class AttributeDisplayInfo
+
+data class AttributeDisplayInfoPlainText(val name: String, val value: String) : AttributeDisplayInfo()
+data class AttributeDisplayInfoHtml(val name: String, val value: String) : AttributeDisplayInfo()
+data class AttributeDisplayInfoImage(val name: String, val image: Bitmap) : AttributeDisplayInfo()

--- a/wallet/src/main/java/com/android/identity_credential/wallet/DocumentInfo.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/DocumentInfo.kt
@@ -40,14 +40,9 @@ data class DocumentInfo(
     // Human-readable string explaining the user what state the document is in.
     val status: String,
 
-    // Data attributes
-    val attributes: Map<String, String>,
-
-    // Data attribute: Portrait of the document holder, if available
-    val attributePortrait: Bitmap?,
-
-    // Data attribute: Signature or usual mark of the holder, if available
-    val attributeSignatureOrUsualMark: Bitmap?,
+    // Data attributes (mapped from attribute identifier to information about how to display the
+    // name and value of the attribute).
+    val attributes: Map<String, AttributeDisplayInfo>,
 
     // A list of the underlying credentials
     val credentialInfos: List<CredentialInfo>

--- a/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
@@ -303,8 +303,6 @@ class DocumentModel(
             lastRefresh = document.state.timestamp,
             status = statusString,
             attributes = data.attributes,
-            attributePortrait = data.portrait,
-            attributeSignatureOrUsualMark = data.signatureOrUsualMark,
             credentialInfos = keyInfos,
         )
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/CommonUI.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/CommonUI.kt
@@ -30,7 +30,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.fromHtml
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import com.android.identity_credential.wallet.R
@@ -122,6 +124,30 @@ fun KeyValuePairText(
         )
         Text(
             text = valueText,
+            style = MaterialTheme.typography.bodyMedium
+        )
+    }
+}
+
+@Composable
+fun KeyValuePairHtml(
+    keyText: String,
+    html: String
+) {
+    Column(
+        Modifier
+            .padding(8.dp)
+            .fillMaxWidth()) {
+        Text(
+            text = keyText,
+            fontWeight = FontWeight.Bold,
+            style = MaterialTheme.typography.titleMedium
+        )
+        Text(
+            // TODO: Find a KMM-friendly alternative to fromHtml. This has been removed from common
+            // and is now Android-only (see
+            // https://android-review.googlesource.com/c/platform/frameworks/support/+/3150316).
+            text = AnnotatedString.Companion.fromHtml(html),
             style = MaterialTheme.typography.bodyMedium
         )
     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/reader/ReaderScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/reader/ReaderScreen.kt
@@ -76,7 +76,9 @@ import com.android.identity_credential.wallet.ReaderDocument
 import com.android.identity_credential.wallet.ReaderModel
 import com.android.identity_credential.wallet.SettingsModel
 import com.android.identity_credential.wallet.WalletApplication
+import com.android.identity_credential.wallet.createDrivingPrivilegesHtml
 import com.android.identity_credential.wallet.navigation.WalletDestination
+import com.android.identity_credential.wallet.ui.KeyValuePairHtml
 import com.android.identity_credential.wallet.ui.KeyValuePairText
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
 import com.android.identity_credential.wallet.ui.qrscanner.ScanQrDialog
@@ -615,7 +617,12 @@ private fun ShowResultDocument(
                         )
                     )
                 }
-                KeyValuePairText(key, value)
+                if (dataElementName == "driving_privileges") {
+                    val html = createDrivingPrivilegesHtml(dataElement.value)
+                    KeyValuePairHtml(key, html)
+                } else {
+                    KeyValuePairText(key, value)
+                }
 
                 if (dataElement.bitmap != null) {
                     Row(


### PR DESCRIPTION
This required refactoring the way we store the display data for mdoc attributes. Now, instead of mapping from human-readable name to a value string, we map from attribute name to a AttributeDisplayInfo object that includes the attribute's human-readable name and information about how to display the value.

Tested by:
- Manual testing of both the wallet and appverifier.
- ./gradlew check
- ./gradlew connectedCheck

- [X] Tests pass