### PR TITLE
Support verification of non-keybound credentials.

### DIFF
--- a/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
@@ -1114,7 +1114,7 @@ lrW+vvdmRHBgS+ss56uWyYor6W7ah9ygBwYFK4EEACI=
 
         // on the verifier, check that the key binding can be verified with the
         // key mentioned in the SD-JWT:
-        presentation.verifyKeyBinding(
+        val isKeyBound = presentation.verifyKeyBinding(
             checkAudience = { clientId == it },
             checkNonce = { nonceStr == it },
             checkCreationTime = { true /* TODO: sometimes flaky it < Clock.System.now() */ }
@@ -1154,6 +1154,9 @@ lrW+vvdmRHBgS+ss56uWyYor6W7ah9ygBwYFK4EEACI=
             lines.add(OpenID4VPResultLine(key, value))
             disclosedClaims.add(key)
             Logger.i(TAG, "Adding special case $key: $value")
+        }
+        if (!isKeyBound) {
+            lines.add(OpenID4VPResultLine("Key bound", "false"))
         }
 
         val json = Json { ignoreUnknownKeys = true }


### PR DESCRIPTION
Most of this just loosens class casting and plumbs Credential or SdJwtCredential through to functions that don't care about keybinding. For the couple of functions that do care, this provides empty values and removes checks, allowing non-keybound credentials to pass verification.

Tested by:
- Manual testing.
- ./gradlew check
- ./gradlew connectedCheck

- [X] Tests pass