### PR TITLE
Add a developer option to trigger syncing all documents.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/settings/SettingsScreen.kt
@@ -40,6 +40,7 @@ import androidx.compose.ui.unit.dp
 import com.android.identity.document.DocumentStore
 import com.android.identity_credential.wallet.R
 import com.android.identity_credential.wallet.SettingsModel
+import com.android.identity_credential.wallet.WalletApplication
 import com.android.identity_credential.wallet.WalletApplicationConfiguration
 import com.android.identity_credential.wallet.navigation.WalletDestination
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
@@ -234,6 +235,18 @@ fun SettingsScreen(
                     subtitle = settingsModel.minServerUrl.observeAsState().value!!,
                     onClicked = { showMinServerUrlDialog = true }
                 )
+            }
+            if (settingsModel.developerModeEnabled.value == true) {
+                SettingSectionSubtitle(title = stringResource(R.string.settings_screen_debug_actions_section))
+                val context = LocalContext.current
+                val walletApplication = context.applicationContext as WalletApplication
+                Button(
+                    onClick = {
+                        walletApplication.documentModel.periodicSyncForAllDocuments()
+                    }
+                ) {
+                    Text(text = stringResource(R.string.settings_screen_trigger_periodic_sync_button))
+                }
             }
         }
     }

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -566,4 +566,6 @@
     <string name="qr_alert_dialog_bt_disabled_text">Bluetooth must be enabled to share a QR connection code</string>
     <string name="qr_alert_dialog_bt_enable_button">Enable</string>
     <string name="presentation_result_no_matching_document_message">No available documents can fulfill the request.</string>
+    <string name="settings_screen_debug_actions_section">Debug actions</string>
+    <string name="settings_screen_trigger_periodic_sync_button">Trigger Periodic Sync</string>
 </resources>


### PR DESCRIPTION
When Developer Options are enabled, this adds a new button to the Settings screen to trigger our periodic sync that refreshes all documents/credentials.

Tested by:
- Manual testing
- ./gradlew check
- ./gradlew connectedCheck

- [X] Tests pass