### PR TITLE
Making credential offer url handling more robust.

### DIFF
--- a/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/AuthorizeServlet.kt
+++ b/server-openid4vci/src/main/java/com/android/identity/server/openid4vci/AuthorizeServlet.kt
@@ -93,7 +93,6 @@ class AuthorizeServlet : BaseServlet() {
     override fun doPost(req: HttpServletRequest, resp: HttpServletResponse) {
         val code = req.getParameter("authorizationCode")
         val pidData = req.getParameter("pidData")
-        val extraInfo = req.getParameter("extraInfo")
         val id = codeToId(OpaqueIdType.AUTHORIZATION_STATE, code)
         val storage = environment.getInterface(Storage::class)!!
         val baseUri = URI(this.baseUrl)
@@ -130,7 +129,6 @@ class AuthorizeServlet : BaseServlet() {
                 }
             }
 
-            data.putEntry("com.android.identity.server.openid4vci", "extraInfo", Cbor.encode(Tstr(extraInfo)))
             state.credentialData = data.build()
             storage.update("IssuanceState", "", id, ByteString(state.toCbor()))
         }

--- a/server/src/main/resources/resources/openid4vci/authorize.html
+++ b/server/src/main/resources/resources/openid4vci/authorize.html
@@ -11,8 +11,6 @@
     <input type="hidden" name="authorizationCode" value="$authorizationCode"/>
     <input type="hidden" name="pidData" id="pidData" value=""/>
     <button id="verify" data-code="$pidReadingCode">Verify PID</button><br/>
-    <label for="extraInfo">Extra info (optional):</label>
-    <input type="text" id="extraInfo" name="extraInfo">
 </form>
 <script src="authorize.js"></script>
 </body>

--- a/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/MainActivity.kt
@@ -81,6 +81,11 @@ class MainActivity : FragmentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         application = getApplication() as WalletApplication
+        provisioningViewModel.init(
+            walletServerProvider = application.walletServerProvider,
+            documentStore = application.documentStore,
+            settingsModel = application.settingsModel
+        )
         permissionTracker.updatePermissions()
         // handle intents with schema openid-credential-offer://
         handleOid4vciCredentialOfferIntent(intent)
@@ -106,7 +111,6 @@ class MainActivity : FragmentActivity() {
                         application = application,
                         provisioningViewModel = provisioningViewModel,
                         permissionTracker = permissionTracker,
-                        sharedPreferences = application.sharedPreferences,
                         qrEngagementViewModel = qrEngagementViewModel,
                         documentModel = application.documentModel,
                         readerModel = application.readerModel,
@@ -143,14 +147,11 @@ class MainActivity : FragmentActivity() {
                     val query = getUrlQueryFromCustomSchemeUrl(intent.dataString!!)
                     val offer = extractCredentialIssuerData(query)
                     if (offer != null) {
+                        routeRequest.value = WalletDestination.ProvisionDocument.route
                         provisioningViewModel.start(
-                            walletServerProvider = application.walletServerProvider,
-                            documentStore = application.documentStore,
-                            settingsModel = application.settingsModel,
                             issuerIdentifier = null,
                             openid4VciCredentialOffer = offer
                         )
-                        routeRequest.value = WalletDestination.ProvisionDocument.route
                     }
                 }
             }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -1,6 +1,5 @@
 package com.android.identity_credential.wallet.navigation
 
-import android.content.SharedPreferences
 import androidx.compose.runtime.Composable
 import androidx.navigation.NavController
 import androidx.navigation.NavHostController
@@ -65,13 +64,11 @@ fun WalletNavigation(
     application: WalletApplication,
     provisioningViewModel: ProvisioningViewModel,
     permissionTracker: PermissionTracker,
-    sharedPreferences: SharedPreferences,
     qrEngagementViewModel: QrEngagementViewModel,
     documentModel: DocumentModel,
     readerModel: ReaderModel,
 ) {
     val onNavigate = { routeWithArgs: String -> navigateTo(navController, routeWithArgs) }
-    val credentialStore = application.documentStore
     NavHost(
         navController = navController,
         startDestination = WalletDestination.Main.route
@@ -123,12 +120,9 @@ fun WalletNavigation(
          */
         composable(WalletDestination.AddToWallet.route) {
             AddToWalletScreen(
-                documentModel = documentModel,
                 provisioningViewModel = provisioningViewModel,
                 onNavigate = onNavigate,
-                documentStore = application.documentStore,
-                walletServerProvider = application.walletServerProvider,
-                settingsModel = application.settingsModel,
+                walletServerProvider = application.walletServerProvider
             )
         }
 
@@ -212,7 +206,6 @@ fun WalletNavigation(
                 onNavigate = onNavigate,
                 permissionTracker = permissionTracker,
                 walletServerProvider = application.walletServerProvider,
-                documentStore = application.documentStore,
                 developerMode = application.settingsModel.developerModeEnabled.value ?: false
             )
         }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/addtowallet/AddToWalletScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/addtowallet/AddToWalletScreen.kt
@@ -29,14 +29,11 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.android.identity.document.DocumentStore
 import com.android.identity.issuance.IssuingAuthorityConfiguration
 import com.android.identity.issuance.remote.WalletServerProvider
 import com.android.identity.util.Logger
-import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.ProvisioningViewModel
 import com.android.identity_credential.wallet.R
-import com.android.identity_credential.wallet.SettingsModel
 import com.android.identity_credential.wallet.WalletApplication
 import com.android.identity_credential.wallet.credentialoffer.extractCredentialIssuerData
 import com.android.identity_credential.wallet.navigation.WalletDestination
@@ -76,12 +73,9 @@ private suspend fun getIssuerDisplayDatas(
 
 @Composable
 fun AddToWalletScreen(
-    documentModel: DocumentModel,
     provisioningViewModel: ProvisioningViewModel,
     onNavigate: (String) -> Unit,
-    documentStore: DocumentStore,
     walletServerProvider: WalletServerProvider,
-    settingsModel: SettingsModel,
 ) {
     val loadingIssuerDisplayDatas = remember { mutableStateOf(true) }
     val loadingIssuerDisplayError = remember { mutableStateOf<Throwable?>(null) }
@@ -144,9 +138,6 @@ fun AddToWalletScreen(
                                     if (offer != null) {
                                         // initiate getting issuing authority dynamically from specified Issuer Uri and Credential Id
                                         provisioningViewModel.start(
-                                            walletServerProvider = walletServerProvider,
-                                            settingsModel = settingsModel,
-                                            documentStore = documentStore,
                                             issuerIdentifier = null,
                                             openid4VciCredentialOffer = offer,
                                         )
@@ -161,9 +152,6 @@ fun AddToWalletScreen(
                     AddToWalletScreenWithIssuerDisplayDatas(
                         provisioningViewModel,
                         onNavigate,
-                        documentStore,
-                        walletServerProvider,
-                        settingsModel,
                         issuerDisplayDatas,
                         onShowScanQrDialog = {
                             showQrScannerDialog.value = true
@@ -221,9 +209,6 @@ private fun AddToWalletScreenLoading() {
 private fun AddToWalletScreenWithIssuerDisplayDatas(
     provisioningViewModel: ProvisioningViewModel,
     onNavigate: (String) -> Unit,
-    documentStore: DocumentStore,
-    walletServerProvider: WalletServerProvider,
-    settingsModel: SettingsModel,
     issuerDisplayDatas: SnapshotStateList<IssuerDisplayData>,
     onShowScanQrDialog: () -> Unit,
 ) {
@@ -248,10 +233,7 @@ private fun AddToWalletScreenWithIssuerDisplayDatas(
             onClick = {
                 provisioningViewModel.reset()
                 provisioningViewModel.start(
-                    walletServerProvider = walletServerProvider,
-                    documentStore = documentStore,
                     issuerIdentifier = issuerDisplayData.configuration.identifier,
-                    settingsModel = settingsModel,
                 )
                 onNavigate(WalletDestination.ProvisionDocument.route)
             }) {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
@@ -92,7 +92,6 @@ fun ProvisionDocumentScreen(
     onNavigate: (String) -> Unit,
     permissionTracker: PermissionTracker,
     walletServerProvider: WalletServerProvider,
-    documentStore: DocumentStore,
     developerMode: Boolean = false
 ) {
     val context = application.applicationContext
@@ -147,8 +146,7 @@ fun ProvisionDocumentScreen(
                             evidenceRequest,
                             onAccept = { inputString ->
                                 provisioningViewModel.provideEvidence(
-                                    evidence = EvidenceResponseQuestionString(inputString),
-                                    walletServerProvider = walletServerProvider
+                                    evidence = EvidenceResponseQuestionString(inputString)
                                 )
                             }
                         )
@@ -160,8 +158,7 @@ fun ProvisionDocumentScreen(
                             evidenceRequest,
                             onAccept = { inputString ->
                                 provisioningViewModel.provideEvidence(
-                                    evidence = EvidenceResponseCreatePassphrase(inputString),
-                                    walletServerProvider = walletServerProvider
+                                    evidence = EvidenceResponseCreatePassphrase(inputString)
                                 )
                             }
                         )
@@ -175,15 +172,12 @@ fun ProvisionDocumentScreen(
                             onAccept = {
                                 provisioningViewModel.provideEvidence(
                                     evidence = EvidenceResponseSetupCloudSecureArea(
-                                        evidenceRequest.cloudSecureAreaIdentifier),
-                                    walletServerProvider = walletServerProvider
+                                        evidenceRequest.cloudSecureAreaIdentifier)
                                 )
                             },
                             onError = { error ->
                                 provisioningViewModel.evidenceCollectionFailed(
-                                    error = error,
-                                    walletServerProvider = walletServerProvider,
-                                    documentStore = documentStore
+                                    error = error
                                 )
                             }
                         )
@@ -192,27 +186,21 @@ fun ProvisionDocumentScreen(
                     is EvidenceRequestMessage -> {
                         EvidenceRequestMessageView(
                             evidenceRequest = evidenceRequest,
-                            provisioningViewModel = provisioningViewModel,
-                            walletServerProvider = walletServerProvider,
-                            documentStore = documentStore
+                            provisioningViewModel = provisioningViewModel
                         )
                     }
 
                     is EvidenceRequestCompletionMessage -> {
                         EvidenceRequestCompletedScreen(
                             evidenceRequest = evidenceRequest,
-                            provisioningViewModel = provisioningViewModel,
-                            walletServerProvider = walletServerProvider,
-                            documentStore = documentStore
+                            provisioningViewModel = provisioningViewModel
                         )
                     }
 
                     is EvidenceRequestNotificationPermission -> {
                         EvidenceRequestNotificationPermissionView(
                             evidenceRequest,
-                            provisioningViewModel = provisioningViewModel,
-                            walletServerProvider = walletServerProvider,
-                            documentStore = documentStore
+                            provisioningViewModel = provisioningViewModel
                         )
                     }
 
@@ -221,8 +209,7 @@ fun ProvisionDocumentScreen(
                             evidenceRequest,
                             onAccept = { selectedOption ->
                                 provisioningViewModel.provideEvidence(
-                                    evidence = EvidenceResponseQuestionMultipleChoice(selectedOption),
-                                    walletServerProvider = walletServerProvider
+                                    evidence = EvidenceResponseQuestionMultipleChoice(selectedOption)
                                 )
                             }
                         )
@@ -232,8 +219,6 @@ fun ProvisionDocumentScreen(
                         EvidenceRequestIcaoPassiveAuthenticationView(
                             evidenceRequest = evidenceRequest,
                             provisioningViewModel = provisioningViewModel,
-                            walletServerProvider = walletServerProvider,
-                            documentStore = documentStore,
                             permissionTracker = permissionTracker
                         )
                     }
@@ -252,19 +237,14 @@ fun ProvisionDocumentScreen(
                         EvidenceRequestSelfieVideoView(
                             evidenceRequest,
                             provisioningViewModel = provisioningViewModel,
-                            permissionTracker = permissionTracker,
-                            walletServerProvider = walletServerProvider,
-                            documentStore = documentStore
+                            permissionTracker = permissionTracker
                         )
                     }
 
                     is EvidenceRequestGermanEid -> {
                         EvidenceRequestEIdView(
                             evidenceRequest = evidenceRequest,
-                            provisioningViewModel = provisioningViewModel,
-                            walletServerProvider = walletServerProvider,
-                            documentStore = documentStore,
-                            permissionTracker = permissionTracker
+                            provisioningViewModel = provisioningViewModel
                         )
                     }
 
@@ -272,8 +252,7 @@ fun ProvisionDocumentScreen(
                         EvidenceRequestWebView(
                             evidenceRequest = evidenceRequest,
                             provisioningViewModel = provisioningViewModel,
-                            walletServerProvider = walletServerProvider,
-                            documentStore = documentStore
+                            walletServerProvider = walletServerProvider
                         )
                     }
 
@@ -281,7 +260,6 @@ fun ProvisionDocumentScreen(
                         EvidenceRequestOpenid4Vp(
                             evidenceRequest = evidenceRequest,
                             provisioningViewModel = provisioningViewModel,
-                            walletServerProvider = walletServerProvider,
                             application = application
                         )
                     }


### PR DESCRIPTION
Hardened code for handling of custom url schema for credential offers. This seemed to eliminate flakiness in my testing. Also cleaned up some singleton objects being passed around as parameters.

Tested using our own openid4vci and funke issuance servers.