### PR TITLE
Disable verifier protocols that aren't compatible with the selected document

### DIFF
--- a/server/src/main/webapp/verifier.html
+++ b/server/src/main/webapp/verifier.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta http-equiv="origin-trial" content="AqrF+vKVQZS3y5OJ3K2wkWZ4yEVxroNpC0oQR3kFeRmnvjBw+T9NPftQV9reLYszk8kNYyF1Zw+u3UZ9PMuxFQIAAACBeyJvcmlnaW4iOiJodHRwczovL2RpZ2l0YWwtY3JlZGVudGlhbHMuZGV2OjQ0MyIsImZlYXR1cmUiOiJXZWJJZGVudGl0eURpZ2l0YWxDcmVkZW50aWFscyIsImV4cGlyeSI6MTc0NDc2MTU5OSwiaXNTdWJkb21haW4iOnRydWV9">
-    <title>OWF Identity Credential Online Verifier</title>
+    <title>OWF Digital Document Online Verifier</title>
     <link rel="icon" type="image/x-icon" href="https://fonts.gstatic.com/s/i/short-term/release/googlesymbols/fingerprint/default/24px.svg">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-4bw+/aepP/YC94hEpVNVgiZdgIC5+VKNBQNGCHeKRQN+PtmoHDEXuppvnDJzQIu9" crossorigin="anonymous">
     <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
@@ -14,13 +14,13 @@
 <div class="col-lg-8 mx-auto p-4 py-md-5">
     <header class="d-flex align-items-center pb-3 mb-4 border-bottom">
         <a href="/" class="d-flex align-items-center text-body-emphasis text-decoration-none">
-            <span class="fs-4">OWF Identity Credential Online Verifier</span>
+            <span class="fs-4">OWF Digital Document Online Verifier</span>
         </a>
     </header>
 
     <main>
-        <h1 class="text-body-emphasis">Request Verified Identity Documents</h1>
-        <p class="fs-5 col-md-8">Request a verified identity document such as a Mobile Driving License (mDL) or EU PID</p>
+        <h1 class="text-body-emphasis">Request Digital Documents</h1>
+        <p class="fs-5 col-md-8">Request a digital document such as a Mobile Driving License (mDL) or EU PID</p>
 
         <ul class="nav nav-pills mb-3" id="pills-tab" role="tablist">
             <!-- Dynamically populated, see addTab() -->
@@ -38,10 +38,10 @@
                     W3C Digital Credentials API (Preview)
                 </button>
                 <ul class="dropdown-menu">
-                    <li><a class="dropdown-item" value="w3c_dc_preview" href="#">
+                    <li><a class="dropdown-item w3c-option" value="w3c_dc_preview" href="#">
                         W3C Digital Credentials API (Preview)
                     </a></li>
-                    <li><a class="dropdown-item" value="w3c_dc_arf" href="#">
+                    <li><a class="dropdown-item w3c-option" value="w3c_dc_arf" href="#">
                         W3C Digital Credentials API (Austroads Request Forwarding)
                     </a></li>
                     <li><a class="dropdown-item" value="openid4vp_plain" href="#">
@@ -59,7 +59,7 @@
 
     </main>
     <footer class="pt-5 my-5 text-body-secondary border-top">
-        This identity verifier is part of the <a href="https://github.com/openwallet-foundation-labs/identity-credential">OWF Identity Credential</a> project
+        This verifier is part of the <a href="https://github.com/openwallet-foundation-labs/identity-credential">OWF Identity Credential</a> project
         and is considered experimental software. Use at your own risk. <a href="verifier/readerRootCert">Reader Root Certificate</a>.
     </footer>
 </div>


### PR DESCRIPTION
Previously, we'd allow the user to select those protocols, but we'd display an error when they tried to use them. Now, if they're selected, we switch to a supported protocol and disable the incompatible ones.

Tested by:
- Manual testing.
