### PR TITLE
Fix for unexpected Ausweis SDK responses.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/EvidenceRequest.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/EvidenceRequest.kt
@@ -1593,6 +1593,8 @@ fun AusweisView(
                         text = stringResource(
                             if (status.value == AusweisModel.NetworkError) {
                                 R.string.eid_network_error
+                            } else if (status.value == AusweisModel.PinError) {
+                                R.string.eid_pin_error
                             } else {
                                 R.string.eid_generic_error
                             }),

--- a/wallet/src/main/res/values/strings.xml
+++ b/wallet/src/main/res/values/strings.xml
@@ -389,6 +389,7 @@
     <string name="eid_nfc_scanning">Scanning eID using NFC</string>
     <string name="eid_enter_pin">Enter your PIN</string>
     <string name="eid_network_error">Error establishing network connection</string>
+    <string name="eid_pin_error">Incorrect PIN entered too many times. The card is locked. Use Ausweis App to unlock the card.</string>
     <string name="eid_generic_error">Error scanning or processing the card</string>
     <string name="eid_try_again">Try again</string>
 


### PR DESCRIPTION
Fixes the crash that happens due to unexpected Ausweis SDK response. In particular, handle locked card case (e.g. incorrect PIN entered too many times) by instructing the user to utilize Ausweis App to unlock it.