### PR TITLE
Adds support for direct_post for verification.

### DIFF
--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -247,7 +247,7 @@
                  works out of the box for development without any configuration.
             -->
             <param-name>verifierBaseUrl</param-name>
-            <param-value></param-value>
+            <param-value>http://127.0.0.1:8080/server</param-value>
         </init-param>
 
         <init-param>

--- a/server/src/main/webapp/verifier.html
+++ b/server/src/main/webapp/verifier.html
@@ -63,6 +63,20 @@
             </div>
         </div>
 
+        Response mode
+        <div class="d-flex gap-4 flex-wrap">
+            <div class="dropdown">
+                <button class="btn btn-secondary dropdown-toggle btn-lg overflow-visible" type="button"
+                        data-bs-toggle="dropdown" aria-expanded="false" id="responseModeDropdown">
+                    direct_post.jwt
+                </button>
+                <ul class="dropdown-menu">
+                    <li><a class="dropdown-item" href="#">direct_post.jwt</a></li>
+                    <li><a class="dropdown-item" href="#">direct_post</a></li>
+                </ul>
+            </div>
+        </div>
+
     </main>
     <footer class="pt-5 my-5 text-body-secondary border-top">
         This verifier is part of the <a href="https://github.com/openwallet-foundation-labs/identity-credential">OWF Identity Credential</a> project

--- a/server/src/main/webapp/verifier.js
+++ b/server/src/main/webapp/verifier.js
@@ -10,6 +10,8 @@ var preferredProtocol = selectedProtocol
 
 var openid4vpUri = ''
 
+var selectedResponseMode = 'direct_post.jwt'
+
 async function onLoad() {
     const protocolDropdown = document.getElementById('protocolDropdown')
     protocolDropdown.addEventListener('hide.bs.dropdown', event => {
@@ -28,6 +30,12 @@ async function onLoad() {
             const scheme = document.getElementById("scheme-form");
             scheme.hidden = selected !== 'openid4vp_custom';
         }
+    })
+    const responseModeDropdown = document.getElementById('responseModeDropdown')
+    responseModeDropdown.addEventListener('hide.bs.dropdown', event => {
+        var target = event.clickEvent.target
+        responseModeDropdown.innerHTML = target.innerHTML
+        selectedResponseMode = target.innerHTML
     })
 
     // Ask server what document types / requests are available and use this to
@@ -145,38 +153,30 @@ function redirectClose() {
 
 async function requestDocument(format, docType, requestId) {
     console.log('requestDocument, format=' + format + ' docType=' + docType + ' requestId=' + requestId + ' protocol=' + selectedProtocol)
+    let scheme = ''
     if (selectedProtocol === 'openid4vp_custom') {
         if (document.getElementById("scheme-input").value === "") {
             alert("You must specify a non-empty scheme when performing a custom OpenID4VP request.")
             return
         }
-        const response = await callServer(
-            'openid4vpBegin',
-            {
-                format: format,
-                docType: docType,
-                requestId: requestId,
-                protocol: selectedProtocol,
-                origin: location.origin,
-                scheme: document.getElementById("scheme-input").value
-            }
-        )
-        console.log("URI " + response.uri)
-        window.open(response.uri, '_blank').focus()
-    } else if (selectedProtocol.startsWith('openid4vp_')) {
-              const response = await callServer(
-                  'openid4vpBegin',
-                  {
-                      format: format,
-                      docType: docType,
-                      requestId: requestId,
-                      protocol: selectedProtocol,
-                      origin: location.origin,
-                      scheme: ""
-                  }
-              )
-              console.log("URI " + response.uri)
-              window.open(response.uri, '_blank').focus()
+        scheme = document.getElementById("scheme-input").value
+    }
+
+    if (selectedProtocol.startsWith('openid4vp_')) {
+          const response = await callServer(
+              'openid4vpBegin',
+              {
+                  format: format,
+                  docType: docType,
+                  requestId: requestId,
+                  protocol: selectedProtocol,
+                  origin: location.origin,
+                  scheme: scheme,
+                  responseMode: selectedResponseMode
+              }
+          )
+          console.log("URI " + response.uri)
+          window.open(response.uri, '_blank').focus()
     } else if (selectedProtocol === "w3c_dc_preview") {
         try {
             const response = await callServer(


### PR DESCRIPTION
Previously we only supported direct_post.jwt. This adds support for direct_post. The main difference is in OpenID4VPPresentationActivity.kt, the new getDirectPostAuthorizationResponseBody function (in contrast to the getDirectPostJwtAuthorizationResponseBody function). Most of the other changes are just plumbing, or allowing the user to decide between direct_post and direct_post.jwt.

Tested by:
- Manual testing of both direct_post and direct_post.jwt, using openid4vp:// and both mdoc and VC.
- ./gradlew check
- ./gradlew connectedCheck

- [X] Tests pass