### PR TITLE
Hide the top bar, for a cleaner look.

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/CommonUI.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/CommonUI.kt
@@ -55,14 +55,12 @@ fun ScreenWithAppBar(
         topBar = {
             CenterAlignedTopAppBar(
                 colors = TopAppBarDefaults.topAppBarColors(
-                    containerColor = MaterialTheme.colorScheme.primaryContainer,
+                    // The app looks cleaner if the top bar is invisible (same color as the bg).
+                    containerColor = MaterialTheme.colorScheme.background,
                     titleContentColor = MaterialTheme.colorScheme.primary,
                 ),
-                title = {
-                    Text(
-                        title, maxLines = 1, overflow = TextOverflow.Ellipsis
-                    )
-                },
+                // The app looks cleaner if we omit the title.
+                title = {},
                 navigationIcon = navigationIcon,
                 scrollBehavior = scrollBehavior,
                 actions = actions,


### PR DESCRIPTION
The app looks much cleaner if the top bar blends in with the background (same color) and if we omit the title.

Tested by:
- Manual testing of several screens.
- ./gradlew connectedCheck
- ./gradlew check

- [X] Tests pass