### PR TITLE
Fixes a typo in the server URL.

### DIFF
--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeProofingState.kt
@@ -125,7 +125,7 @@ class FunkeProofingState(
                     } else {
                         if (openid4VpRequest != null) {
                             val uri = URI(authorizationMetadata.authorizationChallengeEndpoint!!)
-                            val origin = uri.scheme + "//:" + uri.authority
+                            val origin = uri.scheme + "://" + uri.authority
                             list.add(EvidenceRequestOpenid4Vp(origin, openid4VpRequest!!))
                         }
                         list.add(EvidenceRequestWeb(authorizeUrl, proofingInfo.landingUrl))


### PR DESCRIPTION
We accidentally had //: instead of ://.

Tested by:
- Manual testing
- ./gradlew check

- [X] Tests pass