### PR TITLE
B64-encode documentId in routes for the Activity Log Event details page

### DIFF
--- a/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/navigation/WalletNavigation.kt
@@ -7,6 +7,7 @@ import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.navArgument
+import com.android.identity.util.fromBase64Url
 import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.PermissionTracker
 import com.android.identity_credential.wallet.ProvisioningViewModel
@@ -134,7 +135,8 @@ fun WalletNavigation(
             )
         ) { backStackEntry ->
             // Extract arguments from the back stack entry
-            val documentId = backStackEntry.arguments?.getString("documentId") ?: ""
+            val encodedDocumentId = backStackEntry.arguments?.getString("documentId") ?: ""
+            val documentId = String(encodedDocumentId.fromBase64Url())
             val timestamp = backStackEntry.arguments?.getString("timestamp") ?: ""
 
             EventDetailsScreen(

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/EventLogScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/EventLogScreen.kt
@@ -17,13 +17,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import androidx.compose.runtime.remember
 import androidx.navigation.NavHostController
+import com.android.identity.util.toBase64Url
 import com.android.identity_credential.wallet.DocumentModel
 import com.android.identity_credential.wallet.EventInfo
 import com.android.identity_credential.wallet.R
@@ -110,7 +111,8 @@ fun EventLogScreen(
                                 .padding(4.dp)
                                 .clickable {
                                     // Pass documentId and timestamp as arguments
-                                    navController.navigate("${WalletDestination.EventDetails.route}/$documentId/${eventInfo.timestamp}")
+                                    val encodedDocId = documentId.toByteArray().toBase64Url()
+                                    navController.navigate("${WalletDestination.EventDetails.route}/$encodedDocId/${eventInfo.timestamp}")
                                 },
                             verticalAlignment = Alignment.CenterVertically
                         ) {


### PR DESCRIPTION
Some document IDs are URLs, so they have slashes in them. That messes with our route strings, which use slashes to separate parameters. Encoding the docId fixes a crash when trying to navigate to the Activity Log for a single event, when using the German or EU PIDs.

Tested by:
- Manual testing of Utopia, German, and EU PIDs.
- ./gradlew check
- ./gradlew connectedCheck

- [X] Tests pass