### PR TITLE
Use x509_san_dns Client Id Scheme

### DIFF
--- a/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
@@ -371,9 +371,11 @@ class VerifierServlet : BaseHttpServlet() {
     private val clientId: String by lazy {
         var ret = configuration.getValue("verifierClientId")
         if (ret == null || ret.length == 0) {
-            ret = baseUrl
+            // Remove the http:// or https:// from the baseUrl.
+            val startIndex = baseUrl.findAnyOf(listOf("://"))?.first
+            ret = if (startIndex == null) baseUrl else baseUrl.removeRange(0, startIndex+3)
         }
-        ret
+        "x509_san_dns:$ret"
     }
 
     private fun createSingleUseReaderKey(): Pair<EcPrivateKey, X509CertChain> {
@@ -885,6 +887,7 @@ lrW+vvdmRHBgS+ss56uWyYor6W7ah9ygBwYFK4EEACI=
 
         val claimsSet = JWTClaimsSet.Builder()
             .claim("client_id", clientId)
+            .claim("client_id_scheme", "x509_san_dns")
             .claim("response_uri", responseUri)
             .claim("response_type", "vp_token")
             .claim("response_mode", "direct_post.jwt")

--- a/server/src/main/webapp/WEB-INF/web.xml
+++ b/server/src/main/webapp/WEB-INF/web.xml
@@ -251,7 +251,9 @@
         </init-param>
 
         <init-param>
-            <!-- The ClientID to use. If left blank the value of `verifierBaseUrl` is used. -->
+            <!-- The ClientID to use, without the client_id_scheme prefix.
+                 If left blank the value of `verifierBaseUrl` is used.
+             -->
             <param-name>verifierClientId</param-name>
             <param-value></param-value>
         </init-param>


### PR DESCRIPTION
Update the verifier to pass "client_id_scheme" parameter as x509_san_dns, and adjust client_id param to be prefixed with "x509_san_dns:" as recommended by OpenID for Verifiable Presentations section 5.10.1. Syntax.

Tested manually against wallet app, using OpenID4VP to retrieve both mdoc and sd-jwt credentials.