### PR TITLE
Add toolchains resolver plugin.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.9.0")
+}
+
 include(":processor")
 include(":processor-annotations")
 include(":identity")


### PR DESCRIPTION
Simplify local project configuration effort by automatically provisioning needed Java 17 toolchains, using the `foojay-toolchains` plugin (See https://github.com/gradle/foojay-toolchains ).

Fixes #817

- Minor convenience change in the project configuration file.
- Verified with the fresh Android Studio Ladybug | 2024.2.1 Patch 3 installation.