### PR TITLE
Add toolchains resolver plugin.

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -33,6 +33,10 @@ dependencyResolutionManagement {
     }
 }
 
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version("0.9.0")
+}
+
 include(":processor")
 include(":processor-annotations")
 include(":identity")


### PR DESCRIPTION
Fix #817 by adding opensource toolcahins resolver plugin to help simplify the local project configuration set up.

Fixes #817

- Tested on a clean build with the fresh installation of Android Studio Ladybug | 2024.2.1 Patch 3. The issue is not manifesting.