### PR TITLE
OpenId4VCI interoperability fixes.

### DIFF
--- a/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/EvidenceRequestCredentialOffer.kt
+++ b/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/EvidenceRequestCredentialOffer.kt
@@ -4,4 +4,4 @@ package com.android.identity.issuance.evidence
  * Request pre-authorized code from the client. Pre-authorized code is given to a wallet app
  * as a part of an OpenId4VCI credential offer.
  */
-class EvidenceRequestPreauthorizedCode : EvidenceRequest()
+class EvidenceRequestCredentialOffer : EvidenceRequest()

--- a/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/EvidenceResponseCredentialOffer.kt
+++ b/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/EvidenceResponseCredentialOffer.kt
@@ -1,0 +1,8 @@
+package com.android.identity.issuance.evidence
+
+/**
+ * Provides OpenId4VCI credential offer data.
+ */
+data class EvidenceResponseCredentialOffer(
+    val credentialOffer: Openid4VciCredentialOffer
+) : EvidenceResponse()

--- a/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/EvidenceResponsePreauthorizedCode.kt
+++ b/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/EvidenceResponsePreauthorizedCode.kt
@@ -1,9 +1,0 @@
-package com.android.identity.issuance.evidence
-
-/**
- * Provides OpenId4VCI pre-authorized code to the issuer.
- */
-data class EvidenceResponsePreauthorizedCode(
-    val code: String,  // preauthorized code
-    val txCode: String?  // transaction code entered by the user (may or may not be required)
-) : EvidenceResponse()

--- a/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/Openid4VciCredentialOffer.kt
+++ b/identity-issuance-api/src/commonMain/kotlin/com/android/identity/issuance/evidence/Openid4VciCredentialOffer.kt
@@ -1,0 +1,48 @@
+package com.android.identity.issuance.evidence
+
+import com.android.identity.cbor.annotation.CborSerializable
+
+/**
+ * Credential offer as described in OpenId4Vci spec:
+ * https://openid.net/specs/openid-4-verifiable-credential-issuance-1_0.html#name-credential-offer-parameters
+ */
+@CborSerializable
+sealed class Openid4VciCredentialOffer(
+    val issuerUri: String,
+    val configurationId: String,
+    val authorizationServer: String?
+) {
+    companion object
+}
+
+/**
+ * Credential offer with Grant Type `urn:ietf:params:oauth:grant-type:pre-authorized_code`.
+ */
+class Openid4VciCredentialOfferPreauthorizedCode(
+    issuerUri: String,
+    configurationId: String,
+    authorizationServer: String?,
+    val preauthorizedCode: String,
+    val txCode: Openid4VciTxCode?
+) : Openid4VciCredentialOffer(issuerUri, configurationId, authorizationServer)
+
+/**
+ * Credential offer with Grant Type `authorization_code`.
+ */
+class Openid4VciCredentialOfferAuthorizationCode(
+    issuerUri: String,
+    configurationId: String,
+    authorizationServer: String?,
+    val issuerState: String?
+) : Openid4VciCredentialOffer(issuerUri, configurationId, authorizationServer)
+
+
+/**
+ * Describes tx_code parameter (see OpenId4Vci spec referenced above).
+ */
+@CborSerializable
+data class Openid4VciTxCode(
+    val description: String,
+    val isNumeric: Boolean,
+    val length: Int
+)

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeAccess.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeAccess.kt
@@ -19,10 +19,11 @@ class FunkeAccess(
     val accessTokenExpiration: Instant,
     var dpopNonce: String?,
     var cNonce: String?,
+    var tokenEndpoint: String,
     var refreshToken: String?,
 ) {
     companion object {
-        suspend fun parseResponse(tokenResponse: HttpResponse): FunkeAccess {
+        suspend fun parseResponse(tokenEndpoint: String, tokenResponse: HttpResponse): FunkeAccess {
             val dpopNonce = tokenResponse.headers["DPoP-Nonce"]
             val tokenString = String(tokenResponse.readBytes())
             val token = Json.parseToJsonElement(tokenString) as JsonObject
@@ -31,7 +32,8 @@ class FunkeAccess(
             val duration = getField(token, "expires_in").long
             val accessTokenExpiration = Clock.System.now() + duration.seconds
             val refreshToken = token["refresh_token"]?.jsonPrimitive?.content
-            return FunkeAccess(accessToken, accessTokenExpiration, dpopNonce, cNonce, refreshToken)
+            return FunkeAccess(accessToken, accessTokenExpiration, dpopNonce,
+                cNonce, tokenEndpoint, refreshToken)
         }
 
         private fun getField(jsonElement: JsonObject, name: String): JsonPrimitive {

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
@@ -153,7 +153,7 @@ internal object FunkeUtil {
                 )
             }
             return try {
-                FunkeAccess.parseResponse(tokenResponse)
+                FunkeAccess.parseResponse(tokenUrl, tokenResponse)
             } catch (err: IllegalArgumentException) {
                 val tokenString = String(tokenResponse.readBytes())
                 Logger.e(TAG, "Invalid token response: ${err.message}: $tokenString")

--- a/identity/src/commonMain/kotlin/com/android/identity/util/HtmlUtil.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/util/HtmlUtil.kt
@@ -1,0 +1,7 @@
+package com.android.identity.util
+
+fun String.htmlEscape(): String {
+    return replace("&", "&amp;")
+        .replace("<", "&lt;")
+        .replace(">", "&gt;")
+}

--- a/server/src/main/java/com/android/identity/wallet/server/AdminServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/AdminServlet.kt
@@ -13,6 +13,7 @@ import com.android.identity.issuance.hardcoded.IssuerDocument
 import com.android.identity.issuance.hardcoded.IssuingAuthorityState
 import com.android.identity.server.BaseHttpServlet
 import com.android.identity.util.Logger
+import com.android.identity.util.htmlEscape
 import io.ktor.utils.io.core.toByteArray
 import jakarta.servlet.http.Cookie
 import kotlinx.coroutines.runBlocking
@@ -189,13 +190,6 @@ class AdminServlet : BaseHttpServlet() {
         }
     }
 
-    private fun htmlEscape(text: String?): String {
-        return (text ?: "<null>")
-            .replace("&", "&amp;")
-            .replace("<", "&lt;")
-            .replace(">", "&gt;")
-    }
-
     override fun doGet(req: HttpServletRequest, resp: HttpServletResponse) {
         val threadId = Thread.currentThread().id
         val remoteHost = getRemoteHost(req)
@@ -223,10 +217,10 @@ class AdminServlet : BaseHttpServlet() {
                     val documentIds = storage.enumerate("IssuerDocument", clientId)
                     for (documentId in documentIds) {
                         writer.write("<tr>")
-                        writer.write("<td class='code'>${htmlEscape(documentId)}</td>")
+                        writer.write("<td class='code'>${documentId.htmlEscape()}</td>")
                         val documentData = storage.get("IssuerDocument", clientId, documentId)!!
                         val document = IssuerDocument.fromDataItem(Cbor.decode(documentData.toByteArray()))
-                        writer.write("<td>${htmlEscape(document.documentConfiguration?.displayName)}</td>")
+                        writer.write("<td>${document.documentConfiguration?.displayName?.htmlEscape()}</td>")
                         writer.write("<tr>")
                     }
                 }
@@ -241,7 +235,7 @@ class AdminServlet : BaseHttpServlet() {
                 runBlocking {
                     val clients = storage.enumerate("ClientKeys", "")
                     for (client in clients) {
-                        val escaped = htmlEscape(client)
+                        val escaped = client.htmlEscape()
                         val urlenc = URLEncoder.encode(client, "utf-8")
                         writer.write("<li><a href='documents.html?clientId=$urlenc'>$escaped</a></li>")
                     }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/credentialoffer/CredentialOfferIssuance.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/credentialoffer/CredentialOfferIssuance.kt
@@ -1,5 +1,9 @@
 package com.android.identity_credential.wallet.credentialoffer
 
+import com.android.identity.issuance.evidence.Openid4VciCredentialOffer
+import com.android.identity.issuance.evidence.Openid4VciCredentialOfferAuthorizationCode
+import com.android.identity.issuance.evidence.Openid4VciCredentialOfferPreauthorizedCode
+import com.android.identity.issuance.evidence.Openid4VciTxCode
 import com.android.identity.util.Logger
 import com.android.identity_credential.wallet.ProvisioningViewModel
 import io.ktor.client.HttpClient
@@ -7,6 +11,9 @@ import io.ktor.client.request.get
 import io.ktor.client.statement.readBytes
 import io.ktor.http.HttpStatusCode
 import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.intOrNull
 import kotlinx.serialization.json.jsonArray
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -14,13 +21,13 @@ import java.net.URLDecoder
 
 /**
  * Parse the Url Query component of an OID4VCI credential offer Url (from a deep link or Qr scan)
- * and return a [ProvisioningViewModel.Openid4VciCredentialOffer] containing the
+ * and return a [Openid4VciCredentialOffer] containing the
  * Credential Issuer Uri and Credential (Config) Id that are used for initiating the
  * OpenId4VCI Credential Offer Issuance flow using [ProvisioningViewModel.start] call.
  */
 suspend fun extractCredentialIssuerData(
     urlQueryComponent: String
-): ProvisioningViewModel.Openid4VciCredentialOffer? {
+): Openid4VciCredentialOffer? {
     try {
         val params = urlQueryComponent.split('&').map {
             val index = it.indexOf('=')
@@ -45,25 +52,60 @@ suspend fun extractCredentialIssuerData(
             credentialOfferString = String(response.readBytes())
         }
         val json = Json.parseToJsonElement(credentialOfferString).jsonObject
-        // extract Credential Issuer Uri and Credential (Config) Id
-        val credentialIssuerUri = json["credential_issuer"]!!.jsonPrimitive.content
-        val credentialConfigurationIds = json["credential_configuration_ids"]!!.jsonArray
-        // Right now only use the first configuration id
-        val credentialConfigurationId = credentialConfigurationIds[0].jsonPrimitive.content
-        var preauthorizedCode: String? = null
-        if (json.containsKey("grants")) {
-            val codeObject = json["grants"]!!.jsonObject["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
-            if (codeObject != null) {
-                preauthorizedCode = codeObject.jsonObject["pre-authorized_code"]?.jsonPrimitive?.content
-            }
-        }
-        return ProvisioningViewModel.Openid4VciCredentialOffer(
-            credentialIssuerUri,
-            credentialConfigurationId,
-            preauthorizedCode
-        )
+        return Openid4VciCredentialOffer.parse(json)
     } catch (err: Exception) {
         Logger.e("CredentialOffer", "Parsing error", err)
         return null
+    }
+}
+
+fun Openid4VciCredentialOffer.Companion.parse(json: JsonObject): Openid4VciCredentialOffer {
+    val credentialIssuerUri = json["credential_issuer"]!!.jsonPrimitive.content
+    val credentialConfigurationIds = json["credential_configuration_ids"]!!.jsonArray
+    // Right now only use the first configuration id
+    val credentialConfigurationId = credentialConfigurationIds[0].jsonPrimitive.content
+    if (json.containsKey("grants")) {
+        val grants = json["grants"]!!.jsonObject
+        val preAuthGrant = grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
+        if (preAuthGrant != null) {
+            val grant = preAuthGrant.jsonObject
+            val preauthorizedCode = grant["pre-authorized_code"]!!.jsonPrimitive.content
+            val authorizationServer = grant["authorization_server"]?.jsonPrimitive?.content
+            val txCode = extractTxCode(grant["tx_code"])
+            return Openid4VciCredentialOfferPreauthorizedCode(
+                issuerUri = credentialIssuerUri,
+                configurationId = credentialConfigurationId,
+                authorizationServer = authorizationServer,
+                preauthorizedCode = preauthorizedCode,
+                txCode = txCode
+            )
+        } else {
+            val grant = grants["authorization_code"]?.jsonObject
+            if (grant != null) {
+                val issuerState = grant["issuer_state"]?.jsonPrimitive?.content
+                val authorizationServer = grant["authorization_server"]?.jsonPrimitive?.content
+                return Openid4VciCredentialOfferAuthorizationCode(
+                    issuerUri = credentialIssuerUri,
+                    configurationId = credentialConfigurationId,
+                    authorizationServer = authorizationServer,
+                    issuerState = issuerState
+                )
+            }
+        }
+    }
+    throw IllegalArgumentException("Could not parse credential offer")
+}
+
+private fun extractTxCode(txCodeJson: JsonElement?): Openid4VciTxCode? {
+    return if (txCodeJson == null) {
+        null
+    } else {
+        val obj = txCodeJson.jsonObject
+        Openid4VciTxCode(
+            description = obj["description"]?.jsonPrimitive?.content ?:
+            "Enter transaction code that was previously communicated to you",
+            length = obj["length"]?.jsonPrimitive?.intOrNull ?: Int.MAX_VALUE,
+            isNumeric = obj["input_mode"]?.jsonPrimitive?.content != "text"
+        )
     }
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/provisioncredential/ProvisionCredentialScreen.kt
@@ -28,7 +28,6 @@ import com.android.identity.appsupport.ui.consent.MdocConsentField
 import com.android.identity.credential.Credential
 import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.Crypto
-import com.android.identity.document.DocumentStore
 import com.android.identity.issuance.DocumentExtensions.documentConfiguration
 import com.android.identity.issuance.IssuingAuthorityException
 import com.android.identity.issuance.evidence.EvidenceRequestCompletionMessage
@@ -39,7 +38,7 @@ import com.android.identity.issuance.evidence.EvidenceRequestIcaoPassiveAuthenti
 import com.android.identity.issuance.evidence.EvidenceRequestMessage
 import com.android.identity.issuance.evidence.EvidenceRequestNotificationPermission
 import com.android.identity.issuance.evidence.EvidenceRequestOpenid4Vp
-import com.android.identity.issuance.evidence.EvidenceRequestPreauthorizedCode
+import com.android.identity.issuance.evidence.EvidenceRequestCredentialOffer
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionMultipleChoice
 import com.android.identity.issuance.evidence.EvidenceRequestQuestionString
 import com.android.identity.issuance.evidence.EvidenceRequestSelfieVideo
@@ -264,7 +263,7 @@ fun ProvisionDocumentScreen(
                         )
                     }
 
-                    is EvidenceRequestPreauthorizedCode -> {
+                    is EvidenceRequestCredentialOffer -> {
                         // should have been processed by the model internally
                         Logger.e(TAG, "Unexpected evidence request type: EvidenceRequestPreauthorizedCode")
                         Row(


### PR DESCRIPTION
Reworked how and when we deliver credential offer to the wallet server for openid4vci provisioning. Moved to the model where the credential offer always comes as the first evidence request/response for openid4vci. This also moves more responsibility to proofing flow handler (`FunkeProofingState` in our code, in particular `performPushedAuthorizationRequest` method has been moved). This makes proofing more self-contained.

Manually tested with our openid4vci server and external servers. Also tested with our hardcoded issuer.