### PR TITLE
Correct Github name for Alex Koukarine

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,7 @@
 | Maintainer      | GitHub ID      | LFID | Email                | Chat ID    | Company Affiliation | Scope     |
 |-----------------|----------------|------|----------------------|------------| ------------------- | --------- |
 | Akash Shah      | @dyiop         | -    | dyiop@google.com     | -          | Google LLC          | -         |
-| Alex Koukarine  | @halxinate     | -    | koukarine@google.com | -          | Google LLC          | -         |
+| Alex Koukarine  | @koukarine     | -    | koukarine@google.com | -          | Google LLC          | -         |
 | Cory Barker     | @TheCoryBarker | -    | cobark@google.com    | -          | Google LLC          | -         |
 | David Zeuthen   | @davidz25      | -    | zeuthen@google.com   | davidz25   | Google LLC          | -         |
 | Hamzeh Zawawy   | @hzawawy       | -    | hamzeh@google.com    | -          | Google LLC          | -         |


### PR DESCRIPTION
The dedicated account for Alex Koukarine changed.

Update the MAINTAINERS.md with the new name.