### PR TITLE
Fix the duplicated root issue.

### DIFF
--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -112,7 +112,6 @@ android {
 
     sourceSets["main"].manifest.srcFile("src/androidMain/AndroidManifest.xml")
     sourceSets["main"].res.srcDirs("src/androidMain/res")
-    sourceSets["main"].resources.srcDirs("src/commonMain/resources")
 
     defaultConfig {
         applicationId = "com.android.identity.testapp"


### PR DESCRIPTION
Remove the redundant project dependency, triggering the "Duplicate content roots" automatic deletion action for the generated commonMain/resources folder.

Fixes #829 

- Tested rebuilding project clean, cofirmed no warning.
- Ran the testapp to confirm no visible issues.
- Unit tests passing OK locally.