### PR TITLE
testapp: Fix key material, remove personal build details.

### DIFF
--- a/samples/testapp/iosApp/TestApp.xcodeproj/project.pbxproj
+++ b/samples/testapp/iosApp/TestApp.xcodeproj/project.pbxproj
@@ -317,7 +317,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"testApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 74HWMG89B3;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -329,7 +329,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.sorotokin.identity.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
@@ -347,7 +347,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"testApp/Preview Content\"";
-				DEVELOPMENT_TEAM = 74HWMG89B3;
+				DEVELOPMENT_TEAM = "";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -359,7 +359,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.sorotokin.identity.testapp;
+				PRODUCT_BUNDLE_IDENTIFIER = "${BUNDLE_ID}${TEAM_ID}";
 				PRODUCT_NAME = "${APP_NAME}";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppUtils.kt
@@ -196,9 +196,9 @@ object TestAppUtils {
         iacaKeyPub = EcPublicKey.fromPem(
             """
                 -----BEGIN PUBLIC KEY-----
-                MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAElQdbKvX5mU29gS+xH/XLa5hSRRzMGpdN
-                5PCLJHKIQYUWdnRRH6A0oLiCt0I/gX90D5NZN27LY2VGaiDkgHI9J3CW99YHZ/5N
-                /4x1uBkz7X66R5oKAOFP9nCAKhM2C+PI
+                MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+QDye70m2O0llPXMjVjxVZz3m5k6agT+
+                wih+L79b7jyqUl99sbeUnpxaLD+cmB3HK3twkA7fmVJSobBc+9CDhkh3mx6n+YoH
+                5RulaSWThWBfMyRjsfVODkosHLCDnbPV
                 -----END PUBLIC KEY-----
             """.trimIndent().trim(),
             EcCurve.P384
@@ -206,8 +206,10 @@ object TestAppUtils {
         iacaKey = EcPrivateKey.fromPem(
             """
                 -----BEGIN PRIVATE KEY-----
-                MFcCAQAwEAYHKoZIzj0CAQYFK4EEACIEQDA+AgEBBDBLCuy17r0A6FtCd552BGW12sQKD095yEaG
-                nZxSDva2gKvmaKex2dylcZg5cR39M0SgBwYFK4EEACI=
+                MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCcRuzXW3pW2h9W8pu5
+                /CSR6JSnfnZVATq+408WPoNC3LzXqJEQSMzPsI9U1q+wZ2yhZANiAAT5APJ7vSbY
+                7SWU9cyNWPFVnPebmTpqBP7CKH4vv1vuPKpSX32xt5SenFosP5yYHccre3CQDt+Z
+                UlKhsFz70IOGSHebHqf5igflG6VpJZOFYF8zJGOx9U4OSiwcsIOds9U=
                 -----END PRIVATE KEY-----
             """.trimIndent().trim(),
             iacaKeyPub
@@ -237,9 +239,9 @@ object TestAppUtils {
         readerRootKeyPub = EcPublicKey.fromPem(
             """
                 -----BEGIN PUBLIC KEY-----
-                MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEzNWVQ0OxOAProyZdCezqfKr8vwUoIP1A
-                k8Plq8GCN9v41faZPELuQUk21A2RNj0IXqsuLN4/MtYDLvkOaXpoWJ/3ODjGF2WP
-                Lg/reFqPVBaEg5BW75bpmf3LjuU0wCO+
+                MHYwEAYHKoZIzj0CAQYFK4EEACIDYgAE+QDye70m2O0llPXMjVjxVZz3m5k6agT+
+                wih+L79b7jyqUl99sbeUnpxaLD+cmB3HK3twkA7fmVJSobBc+9CDhkh3mx6n+YoH
+                5RulaSWThWBfMyRjsfVODkosHLCDnbPV
                 -----END PUBLIC KEY-----
             """.trimIndent().trim(),
             EcCurve.P384
@@ -247,8 +249,10 @@ object TestAppUtils {
         readerRootKey = EcPrivateKey.fromPem(
             """
                 -----BEGIN PRIVATE KEY-----
-                MFcCAQAwEAYHKoZIzj0CAQYFK4EEACIEQDA+AgEBBDDxgrZBXnoO54/hZM2DAGrByoWRatjH9hGs
-                lrW+vvdmRHBgS+ss56uWyYor6W7ah9ygBwYFK4EEACI=
+                MIG2AgEAMBAGByqGSM49AgEGBSuBBAAiBIGeMIGbAgEBBDCcRuzXW3pW2h9W8pu5
+                /CSR6JSnfnZVATq+408WPoNC3LzXqJEQSMzPsI9U1q+wZ2yhZANiAAT5APJ7vSbY
+                7SWU9cyNWPFVnPebmTpqBP7CKH4vv1vuPKpSX32xt5SenFosP5yYHccre3CQDt+Z
+                UlKhsFz70IOGSHebHqf5igflG6VpJZOFYF8zJGOx9U4OSiwcsIOds9U=
                 -----END PRIVATE KEY-----
             """.trimIndent().trim(),
             readerRootKeyPub


### PR DESCRIPTION
The keys used in the testapp doesn't work with iOS CryptoKit's ASN1 parser (which is a bit finicky) so update them with keys that do work. The long-term fix for this is to write our own PEM parser (easily done now that we have a ASN1 library) but for now this fix will do it.

Also remove references to personal build details.

Test: Manually tested testapp on iOS
