### PR TITLE
Use two digits year for times before 2050 in ASN.1 as the spec mandates.

### DIFF
--- a/identity/src/commonTest/kotlin/com/android/identity/asn1/ASN1Tests.kt
+++ b/identity/src/commonTest/kotlin/com/android/identity/asn1/ASN1Tests.kt
@@ -346,6 +346,7 @@ class ASN1Tests {
                     LocalDateTime(2024, 1, 1, 0, 0, 0,
                         0.5.seconds.inWholeNanoseconds.toInt()
                     ).toInstant(TimeZone.UTC),
+                    ASN1TimeTag.GENERALIZED_TIME.tag
                 ),
                 ASN1Time(
                     LocalDateTime(1999, 12, 31, 10, 20, 30).toInstant(TimeZone.UTC),


### PR DESCRIPTION
According to this RFC, time before year 2050 must use two-digit year in X.509 certificates:

https://datatracker.ietf.org/doc/html/rfc5280#section-4.1.2.5

Use this rule as a default, which makes our certificates more compliant; otherwise openssl rejects them.

Added a smoke-test unit test, but also tested manually with openssl and looked at the der encoding bytes. 