### PR TITLE
Appverifier: Fix NFC engagement problem on first run after install.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/RequestOptionsFragment.kt
@@ -237,7 +237,6 @@ class RequestOptionsFragment() : Fragment() {
             // Always call to cancel any connection that could be on progress
             transferManager.disconnect()
         }
-        transferManager.initVerificationHelper()
         observeTransferManager()
     }
 
@@ -301,6 +300,7 @@ class RequestOptionsFragment() : Fragment() {
         checkRequiredPermissions()
         val adapter = NfcAdapter.getDefaultAdapter(requireContext())
         if (adapter != null) {
+            transferManager.initVerificationHelper()
             transferManager.setNdefDeviceEngagement(
                 adapter,
                 requireActivity()

--- a/samples/simple-verifier/src/main/java/com/android/identity/simple_verifier/MdocReaderPrompt.kt
+++ b/samples/simple-verifier/src/main/java/com/android/identity/simple_verifier/MdocReaderPrompt.kt
@@ -325,6 +325,11 @@ class MdocReaderPrompt(
         verification.disconnect()
         super.onDismiss(dialog)
     }
+
+    override fun onResume() {
+        super.onResume()
+        initializeWithContext()
+    }
 }
 
 @Composable

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/reader/ReaderScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/reader/ReaderScreen.kt
@@ -118,7 +118,7 @@ fun ReaderScreen(
     val lifecycleOwner = LocalLifecycleOwner.current
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) {
+            if (event in listOf(Lifecycle.Event.ON_START, Lifecycle.Event.ON_RESUME)) {
                 model.startRequest(
                     activity,
                     availableRequests[0].second,


### PR DESCRIPTION
This change addresses an NFC engagement issue that could occur on the first run of AppVerifier after installation. The root cause was an incorrect handling of the Android activity lifecycle events that occur when the permission-requesting activity returns to the main application activity or fragment. The fix ensures that the VerificationHelper instance is initialized during the ON_RESUME lifecycle event, rather than ON_START, to avoid race conditions and ensure proper setup.

Tested manually. Tap each with the phone running Wallet.

- [x] Tests pass