### PR TITLE
Implement NFC data retrieval for new multiplatform stack.

### DIFF
--- a/identity-appsupport/src/commonMain/composeResources/values/strings.xml
+++ b/identity-appsupport/src/commonMain/composeResources/values/strings.xml
@@ -55,6 +55,7 @@
     <string name="presentment_success">The information was shared</string>
     <string name="presentment_error">Something went wrong</string>
     <string name="presentment_canceled">Presentment was canceled</string>
+    <string name="presentment_timeout">Timed out waiting for reader</string>
     <string name="presentment_waiting_for_request">Waiting for request</string>
     <string name="presentment_document_picker_title">Select Document</string>
     <string name="presentment_document_picker_text">Multiple documents can fulfill the request. Please select one</string>

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/PresentmentTimeout.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/PresentmentTimeout.kt
@@ -1,0 +1,8 @@
+package com.android.identity.appsupport.ui.presentment
+
+/**
+ * Thrown when timing out waiting for the reader to connect.
+ *
+ * @property message message to display.
+ */
+class PresentmentTimeout(message: String): Exception(message)

--- a/identity-mdoc/src/androidMain/kotlin/com/android/identity/mdoc/transport/MdocTransportFactory.android.kt
+++ b/identity-mdoc/src/androidMain/kotlin/com/android/identity/mdoc/transport/MdocTransportFactory.android.kt
@@ -2,6 +2,7 @@ package com.android.identity.mdoc.transport
 
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
+import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
 
 internal actual fun defaultMdocTransportFactoryCreateTransport(
     connectionMethod: ConnectionMethod,
@@ -54,6 +55,24 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                             connectionMethod.peripheralServerModePsm,
                         )
                     }
+                }
+            }
+        }
+        is ConnectionMethodNfc -> {
+            return when (role) {
+                MdocTransport.Role.MDOC -> {
+                    NfcTransportMdoc(
+                        role,
+                        options,
+                        connectionMethod
+                    )
+                }
+                MdocTransport.Role.MDOC_READER -> {
+                    NfcTransportMdocReader(
+                        role,
+                        options,
+                        connectionMethod
+                    )
                 }
             }
         }

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/connectionmethod/ConnectionMethod.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/connectionmethod/ConnectionMethod.kt
@@ -97,8 +97,12 @@ abstract class ConnectionMethod {
                 record.type.decodeToString() == Nfc.MIME_TYPE_CONNECTION_HANDOVER_BLE &&
                 record.id.decodeToString() == "0") {
                 return ConnectionMethodBle.fromNdefRecord(record, role, uuid)
+            } else if (record.tnf == NdefRecord.Tnf.EXTERNAL_TYPE &&
+                record.type.decodeToString() == Nfc.EXTERNAL_TYPE_ISO_18013_5_NFC &&
+                record.id.decodeToString() == "nfc") {
+                return ConnectionMethodNfc.fromNdefRecord(record, role)
             }
-            // TODO: add support for Wifi Aware, NFC, and others.
+            // TODO: add support for Wifi Aware and others.
             Logger.w(TAG, "No support for NDEF record $record")
             return null
         }

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/connectionmethod/ConnectionMethodNfc.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/connectionmethod/ConnectionMethodNfc.kt
@@ -6,7 +6,14 @@ import com.android.identity.cbor.CborArray
 import com.android.identity.cbor.CborMap
 import com.android.identity.mdoc.transport.MdocTransport
 import com.android.identity.nfc.NdefRecord
+import com.android.identity.nfc.Nfc
 import com.android.identity.util.Logger
+import kotlinx.io.Buffer
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
+import kotlinx.io.readByteArray
+import kotlinx.io.readByteString
+import kotlinx.io.write
 
 /**
  * Connection method for NFC.
@@ -40,17 +47,80 @@ class ConnectionMethodNfc(
         )
     }
 
+
+    private fun encodeInt(dataType: Int, value: Int, buf: Buffer) {
+        if (value < 0x100) {
+            buf.writeByte(0x02.toByte()) // Length
+            buf.writeByte(dataType.toByte())
+            buf.writeByte(value.and(0xff).toByte())
+        } else if (value < 0x10000) {
+            buf.writeByte(0x03.toByte()) // Length
+            buf.writeByte(dataType.toByte())
+            buf.writeByte((value / 0x100).toByte())
+            buf.writeByte((value.and(0xff)).toByte())
+        } else {
+            buf.writeByte(0x04.toByte()) // Length
+            buf.writeByte(dataType.toByte())
+            buf.writeByte((value / 0x10000).toByte())
+            buf.writeByte((value / 0x100).and(0xff).toByte())
+            buf.writeByte((value.and(0xff)).toByte())
+        }
+    }
+
     override fun toNdefRecord(
         auxiliaryReferences: List<String>,
         role: MdocTransport.Role,
         skipUuids: Boolean
     ): Pair<NdefRecord, NdefRecord>? {
-        Logger.w(TAG, "toNdefRecord() not yet implemented")
-        return null
+        val carrierDataReference = "nfc".encodeToByteString()
+
+        // This is defined by ISO 18013-5 8.2.2.2 Alternative Carrier Record for device
+        // retrieval using NFC.
+        //
+        val buf = Buffer()
+        buf.writeByte(0x01.toByte()) // Version
+        encodeInt(DATA_TYPE_MAXIMUM_COMMAND_DATA_LENGTH, commandDataFieldMaxLength.toInt(), buf)
+        encodeInt(DATA_TYPE_MAXIMUM_RESPONSE_DATA_LENGTH, responseDataFieldMaxLength.toInt(), buf)
+        val record = NdefRecord(
+            NdefRecord.Tnf.EXTERNAL_TYPE,
+            Nfc.EXTERNAL_TYPE_ISO_18013_5_NFC.encodeToByteString(),
+            carrierDataReference,
+            buf.readByteString()
+        )
+
+        // From NFC Forum Connection Handover v1.5 section 7.1 Alternative Carrier Record
+        //
+        check(auxiliaryReferences.size < 0x100)
+        val acrBuf = Buffer()
+        acrBuf.writeByte(0x01) // CPS: active
+        acrBuf.writeByte(carrierDataReference.size.toByte()) // Length of carrier data reference
+        acrBuf.write(carrierDataReference)
+        acrBuf.writeByte(auxiliaryReferences.size.toByte()) // Number of auxiliary references
+        for (auxRef in auxiliaryReferences) {
+            // Each auxiliary reference consists of a single byte for the length and then as
+            // many bytes for the reference itself.
+            val auxRefUtf8 = auxRef.encodeToByteString()
+            check(auxRefUtf8.size < 0x100)
+            acrBuf.writeByte(auxRefUtf8.size.toByte())
+            acrBuf.write(auxRefUtf8)
+        }
+        val acRecordPayload = acrBuf.readByteArray()
+        val acRecord = NdefRecord(
+            tnf = NdefRecord.Tnf.WELL_KNOWN,
+            type = Nfc.RTD_ALTERNATIVE_CARRIER,
+            payload = ByteString(acRecordPayload)
+        )
+        return Pair(record, acRecord)
     }
 
     companion object {
         private const val TAG = "ConnectionMethodNfc"
+
+        // Defined in ISO 18013-5 8.2.2.2 Alternative Carrier Record for device retrieval using NFC
+        //
+        private const val DATA_TYPE_MAXIMUM_COMMAND_DATA_LENGTH = 0x01
+        private const val DATA_TYPE_MAXIMUM_RESPONSE_DATA_LENGTH = 0x02
+
         const val METHOD_TYPE = 1L
         const val METHOD_MAX_VERSION = 1L
         private const val OPTION_KEY_COMMAND_DATA_FIELD_MAX_LENGTH = 0L
@@ -68,6 +138,53 @@ class ConnectionMethodNfc(
             return ConnectionMethodNfc(
                 map[OPTION_KEY_COMMAND_DATA_FIELD_MAX_LENGTH].asNumber,
                 map[OPTION_KEY_RESPONSE_DATA_FIELD_MAX_LENGTH].asNumber
+            )
+        }
+
+        internal fun fromNdefRecord(
+            record: NdefRecord,
+            role: MdocTransport.Role,
+        ): ConnectionMethodNfc? {
+            val payload = Buffer()
+            payload.write(record.payload)
+            val version = payload.readByte().toInt()
+            if (version != 0x01) {
+                Logger.w(TAG, "Expected version 0x01, found $version")
+                return null
+            }
+            val cmdLen = payload.readByte().toInt().and(0xff)
+            val cmdType = payload.readByte().toInt().and(0xff)
+            if (cmdType != DATA_TYPE_MAXIMUM_COMMAND_DATA_LENGTH) {
+                Logger.w(TAG, "expected type 0x01, found $cmdType")
+                return null
+            }
+            if (cmdLen < 2 || cmdLen > 3) {
+                Logger.w(TAG, "expected cmdLen in range 2-3, got $cmdLen")
+                return null
+            }
+            var commandDataFieldMaxLength = 0
+            for (n in 0 until cmdLen - 1) {
+                commandDataFieldMaxLength *= 256
+                commandDataFieldMaxLength += payload.readByte().toInt().and(0xff)
+            }
+            val rspLen = payload.readByte().toInt().and(0xff)
+            val rspType = payload.readByte().toInt().and(0xff)
+            if (rspType != DATA_TYPE_MAXIMUM_RESPONSE_DATA_LENGTH) {
+                Logger.w(TAG, "expected type 0x02, found $rspType")
+                return null
+            }
+            if (rspLen < 2 || rspLen > 4) {
+                Logger.w(TAG, "expected rspLen in range 2-4, got $rspLen")
+                return null
+            }
+            var responseDataFieldMaxLength = 0
+            for (n in 0 until rspLen - 1) {
+                responseDataFieldMaxLength *= 256
+                responseDataFieldMaxLength += payload.readByte().toInt().and(0xff)
+            }
+            return ConnectionMethodNfc(
+                commandDataFieldMaxLength.toLong(),
+                responseDataFieldMaxLength.toLong()
             )
         }
     }

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/nfc/MdocNfcEngagementHelper.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/nfc/MdocNfcEngagementHelper.kt
@@ -93,7 +93,7 @@ class MdocNfcEngagementHelper(
         val requestedApplicationId = command.payload
         if (requestedApplicationId != Nfc.NDEF_APPLICATION_ID) {
             raiseError("SelectApplication: Expected NDEF AID but got ${requestedApplicationId.toByteArray().toHex()}")
-            return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
         }
         ndefApplicationSelected = true
         return ResponseApdu(Nfc.RESPONSE_STATUS_SUCCESS)
@@ -181,7 +181,7 @@ class MdocNfcEngagementHelper(
             }
             else -> {
                 raiseError("SelectFile: Unexpected File ID $selectedFileId")
-                return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+                return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
             }
         }
         return ResponseApdu(Nfc.RESPONSE_STATUS_SUCCESS)
@@ -335,7 +335,7 @@ class MdocNfcEngagementHelper(
             selectedFilePayload = bsb.toByteString()
             return ResponseApdu(Nfc.RESPONSE_STATUS_SUCCESS)
         } catch (error: Throwable) {
-            raiseError(error.message!!)
+            raiseError(error.message!!, error)
             return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
         }
     }
@@ -353,17 +353,17 @@ class MdocNfcEngagementHelper(
                 if (lenInData == 0) {
                     if (updateBinaryData != null) {
                         raiseError("Got reset but is already active")
-                        return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+                        return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
                     }
                     updateBinaryData = ByteStringBuilder()
                 } else {
                     if (updateBinaryData == null) {
                         raiseError("Got length but we are not active")
-                        return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+                        return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
                     }
                     if (lenInData != updateBinaryData!!.size) {
                         raiseError("Length $lenInData doesn't match received data of ${updateBinaryData!!.size} bytes")
-                        return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+                        return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
                     }
 
                     // At this point we got the whole NDEF message that the reader wanted to send.
@@ -374,24 +374,24 @@ class MdocNfcEngagementHelper(
             } else {
                 if (updateBinaryData != null) {
                     raiseError("Got data in single UPDATE_BINARY but we are already active")
-                    return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+                    return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
                 }
                 val ndefMessage = NdefMessage.fromEncoded(data.toByteArray(2))
                 return processUpdateBinaryNdefMessage(ndefMessage)
             }
         } else if (offset == 1) {
             raiseError("Unexpected offset $offset")
-            return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
         } else {
             // offset >= 2
             if (updateBinaryData == null) {
                 raiseError("Got data but we are not active")
-                return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+                return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
             }
             // Writes must be sequential
             if (offset - 2 != updateBinaryData!!.size) {
                 raiseError("Got data to write at offset $offset but we currently have ${updateBinaryData!!.size}")
-                return ResponseApdu(Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
+                return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND)
             }
             updateBinaryData!!.append(data)
         }

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/nfc/mdocReaderNfcHandover.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/nfc/mdocReaderNfcHandover.kt
@@ -20,7 +20,6 @@ import com.android.identity.nfc.ServiceSelectRecord
 import com.android.identity.nfc.TnepStatusRecord
 import com.android.identity.util.Logger
 import com.android.identity.util.UUID
-import kotlinx.datetime.Clock
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.decodeToString
 import kotlinx.io.bytestring.encodeToByteString
@@ -60,7 +59,7 @@ suspend fun mdocReaderNfcHandover(
         // user will be shown UI to convey another tap should happen. So since we're the mdoc reader, we
         // want to keep scanning...
         //
-        if (e.status == Nfc.RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND) {
+        if (e.status == Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND) {
             Logger.i(TAG, "NDEF application not found, continuing scanning")
             return null
         }

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/nfc/scanNfcMdocReader.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/nfc/scanNfcMdocReader.kt
@@ -6,23 +6,20 @@ import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
 import com.android.identity.mdoc.transport.MdocTransport
 import com.android.identity.mdoc.transport.MdocTransportFactory
 import com.android.identity.mdoc.transport.MdocTransportOptions
+import com.android.identity.mdoc.transport.NfcTransportMdocReader
 import com.android.identity.nfc.scanNfcTag
 import com.android.identity.util.Logger
 import com.android.identity.util.UUID
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
 import kotlin.time.Duration.Companion.seconds
 
 const private val TAG = "scanNfcMdocReader"
 
-/**
- * The result of performing NFC engagement as a mdoc reader.
- *
- * @property transport the [MdocTransport] connected to the remote mdoc.
- * @property encodedDeviceEngagement the Device Engagement.
- * @property handover the handover.
- */
-data class ScanNfcMdocReaderResult(
+private data class ScanNfcMdocReaderResult(
     val transport: MdocTransport,
     val encodedDeviceEngagement: ByteString,
     val handover: DataItem,
@@ -33,13 +30,25 @@ data class ScanNfcMdocReaderResult(
  *
  * This uses [scanNfcTag] to show a dialog prompting the user to tap the mdoc.
  *
+ * When a connection has been established, [onHandover] is called with the created transport as well as
+ * the device engagement and handover structures used.
+ *
+ * If the given transport is for [com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc] the
+ * [onHandover] callback is called in the same coroutine used for interacting with the tag to ensure
+ * continued communications with the remote NFC tag reader and the `updateMessage` parameter to [onHandover]
+ * will be non-`null` which the application can use to update the message in the NFC scanning dialog.
+ * Otherwise [onHandover] is called in the calling coroutine right after the NFC interaction with
+ * `updateMessage` set to `null`. In either case, any exception thrown in [onHandover] will be thrown
+ * from this method.
+ *
  * @param message the message to display in the NFC tag scanning dialog.
  * @param options the [MdocTransportOptions] used to create new [MdocTransport] instances.
  * @param transportFactory the factory used to create [MdocTransport] instances.
  * @param selectConnectionMethod used to choose a connection method if the remote mdoc is using NFC static handover.
  * @param negotiatedHandoverConnectionMethods the connection methods to offer if the remote mdoc is using NFC
  * Negotiated Handover.
- * @return a [ScanNfcMdocReaderResult], `null` if the dialog was dismissed or [selectConnectionMethod] returned `null`.
+ * @param onHandover: Will be called on successful handover.
+ * @return `true` if [onHandover] was invoked, `false` if no handover happened.
  */
 suspend fun scanNfcMdocReader(
     message: String,
@@ -47,7 +56,13 @@ suspend fun scanNfcMdocReader(
     transportFactory: MdocTransportFactory = MdocTransportFactory.Default,
     selectConnectionMethod: suspend (connectionMethods: List<ConnectionMethod>) -> ConnectionMethod?,
     negotiatedHandoverConnectionMethods: List<ConnectionMethod>,
-): ScanNfcMdocReaderResult? {
+    onHandover: suspend (
+        transport: MdocTransport,
+        encodedDeviceEngagement: ByteString,
+        handover: DataItem,
+        updateMessage: ((message: String) -> Unit)?
+    ) -> Unit,
+): Boolean {
     // Start creating transports for Negotiated Handover and start advertising these
     // immediately. This helps with connection time because the holder's device will
     // get a chance to opportunistically read the UUIDs which helps reduce scanning
@@ -66,53 +81,74 @@ suspend fun scanNfcMdocReader(
     val transportsToClose = negotiatedHandoverTransports.toMutableList()
 
     try {
-        val handoverResult = scanNfcTag(
+        val result = scanNfcTag(
             message = message,
             tagInteractionFunc = { tag, updateMessage ->
-                mdocReaderNfcHandover(
+                val handoverResult = mdocReaderNfcHandover(
                     tag = tag,
                     negotiatedHandoverConnectionMethods = negotiatedHandoverTransports.map { it.connectionMethod },
                 )
-            }
-        )
-        if (handoverResult == null) {
-            return null
-        } else {
-            val connectionMethod = if (handoverResult.connectionMethods.size == 1) {
-                handoverResult.connectionMethods[0]
-            } else {
-                selectConnectionMethod(handoverResult.connectionMethods)
-            }
-            if (connectionMethod == null) {
-                return null
-            } else {
-                // Now that we're connected, close remaining transports and see if one of the warmed-up
-                // transports was chosen (can happen for negotiated handover, never for static handover)
-                //
-                var transport: MdocTransport? = null
-                transportsToClose.forEach {
-                    if (it.connectionMethod == connectionMethod) {
-                        transport = it
+                if (handoverResult == null) {
+                    null
+                } else {
+                    val connectionMethod = if (handoverResult.connectionMethods.size == 1) {
+                        handoverResult.connectionMethods[0]
                     } else {
-                        Logger.i(TAG, "Closing connection with CM ${it.connectionMethod}")
-                        it.close()
+                        selectConnectionMethod(handoverResult.connectionMethods)
+                    }
+                    if (connectionMethod == null) {
+                        null
+                    } else {
+                        // Now that we're connected, close remaining transports and see if one of the warmed-up
+                        // transports was chosen (can happen for negotiated handover, never for static handover)
+                        //
+                        var transport: MdocTransport? = null
+                        transportsToClose.forEach {
+                            if (it.connectionMethod == connectionMethod) {
+                                transport = it
+                            } else {
+                                Logger.i(TAG, "Closing connection with CM ${it.connectionMethod}")
+                                it.close()
+                            }
+                        }
+                        transportsToClose.clear()
+                        if (transport == null) {
+                            transport = transportFactory.createTransport(
+                                connectionMethod,
+                                MdocTransport.Role.MDOC_READER,
+                                options
+                            )
+                        }
+
+                        val result = ScanNfcMdocReaderResult(
+                            transport = transport,
+                            encodedDeviceEngagement = handoverResult.encodedDeviceEngagement,
+                            handover = handoverResult.handover
+                        )
+
+                        // If using NFC transport, run onHandover synchronously to keep the NFC tag reading
+                        // dialog visible and NfcIsoTag instance alive.
+                        if (result.transport is NfcTransportMdocReader) {
+                            result.transport.setTag(tag)
+                            onHandover(
+                                result.transport,
+                                result.encodedDeviceEngagement,
+                                result.handover,
+                                updateMessage
+                            )
+                        }
+                        result
                     }
                 }
-                transportsToClose.clear()
-                if (transport == null) {
-                    transport = transportFactory.createTransport(
-                        connectionMethod,
-                        MdocTransport.Role.MDOC_READER,
-                        options
-                    )
-                }
-                return ScanNfcMdocReaderResult(
-                    transport,
-                    handoverResult.encodedDeviceEngagement,
-                    handoverResult.handover,
-                )
             }
+        )
+        if (result == null) {
+            return false
         }
+        if (result.transport !is NfcTransportMdocReader) {
+            onHandover(result.transport, result.encodedDeviceEngagement, result.handover, null)
+        }
+        return true
     } finally {
         // Close listening transports that went unused.
         transportsToClose.forEach {

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/transport/NfcTransportMdoc.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/transport/NfcTransportMdoc.kt
@@ -1,0 +1,336 @@
+package com.android.identity.mdoc.transport
+
+import com.android.identity.crypto.EcPublicKey
+import com.android.identity.mdoc.connectionmethod.ConnectionMethod
+import com.android.identity.nfc.CommandApdu
+import com.android.identity.nfc.Nfc
+import com.android.identity.nfc.ResponseApdu
+import com.android.identity.util.Logger
+import com.android.identity.util.toHex
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.ByteStringBuilder
+import kotlinx.io.bytestring.append
+import kotlin.math.min
+import kotlin.time.Duration
+
+class NfcTransportMdoc(
+    override val role: Role,
+    private val options: MdocTransportOptions,
+    override val connectionMethod: ConnectionMethod
+) : MdocTransport() {
+    companion object {
+        private const val TAG = "NfcTransportMdoc"
+
+        // Must be called by platform when receiving APDUs for Nfc.ISO_MDOC_NFC_DATA_TRANSFER_APPLICATION_ID
+        //
+        fun processCommandApdu(
+            commandApdu: ByteArray,
+            sendResponse: (responseApdu: ByteArray) -> Unit,
+        ) {
+            val command = CommandApdu.decode(commandApdu)
+            if (instances.isEmpty()) {
+                Logger.w(TAG, "No NfcTransportMdoc instances")
+            } else {
+                if (instances.size > 1) {
+                    Logger.w(TAG, "${instances.size} NfcTransportMdoc instances, expected just one")
+                }
+                runBlocking {
+                    instances.forEach { instance ->
+                        instance.processApdu(
+                            command = command,
+                            sendResponse = { response ->
+                                sendResponse(response.encode())
+                            }
+                        )
+                    }
+                }
+            }
+        }
+
+        // Must be called by platform for deactivation event for Nfc.ISO_MDOC_NFC_DATA_TRANSFER_APPLICATION_ID
+        //
+        fun onDeactivated() {
+            Logger.i(TAG, "onDeactivated")
+            if (instances.isEmpty()) {
+                Logger.w(TAG, "No NfcTransportMdoc instances")
+            } else {
+                if (instances.size > 1) {
+                    Logger.w(TAG, "${instances.size} NfcTransportMdoc instances, expected just one")
+                }
+                runBlocking {
+                    // Get a read-only copy since the caller may modify `instances` variable.
+                    instances.toList().forEach { instance ->
+                        instance.onDeactivated()
+                    }
+                }
+            }
+        }
+
+        private val instances = mutableListOf<NfcTransportMdoc>()
+    }
+
+    private val mutex = Mutex()
+
+    private val _state = MutableStateFlow<State>(State.IDLE)
+    override val state: StateFlow<State> = _state.asStateFlow()
+
+    override val scanningTime: Duration?
+        get() = null
+
+    override suspend fun advertise() {
+    }
+
+    private var leReceived = 0
+    private val outgoingChunks = mutableListOf<ByteString>()
+    private var outgoingChunksRemainingBytesAvailable = 0
+    private var envelopeResponseDeferred = false
+
+    private fun getNextOutgoingChunkResponse(): ResponseApdu? {
+        if (outgoingChunks.isEmpty()) {
+            return null
+        }
+        val chunk = outgoingChunks.removeAt(0)
+        outgoingChunksRemainingBytesAvailable -= chunk.size
+
+        /* Following excerpts are from ISO/IEC 18013-5:2021 clause 8.3.3.1.2 Data retrieval using
+         * near field communication (NFC)
+         */
+        val isLastChunk = outgoingChunks.isEmpty()
+        if (isLastChunk) {
+            /* If Le ≥ the number of available bytes, the mdoc shall include all
+             * available bytes in the response and set the status words to ’90 00’.
+             */
+            return ResponseApdu(
+                status = Nfc.RESPONSE_STATUS_SUCCESS,
+                payload = chunk
+            )
+        } else {
+            if (outgoingChunksRemainingBytesAvailable <= leReceived + 255) {
+                /* If Le < the number of available bytes ≤ Le + 255, the mdoc shall
+                 * include as many bytes in the response as indicated by Le and shall
+                 * set the status words to ’61 XX’, where XX is the number of available
+                 * bytes remaining. The mdoc reader shall respond with a GET RESPONSE
+                 * command where Le is set to XX.
+                 */
+                val numBytesRemaining = outgoingChunksRemainingBytesAvailable - leReceived
+                return ResponseApdu(
+                    status = Nfc.RESPONSE_STATUS_CHAINING_RESPONSE_BYTES_STILL_AVAILABLE + numBytesRemaining.and(0xff),
+                    payload = chunk
+                )
+            } else {
+                /* If the number of available bytes > Le + 255, the mdoc shall include
+                 * as many bytes in the response as indicated by Le and shall set the
+                 * status words to ’61 00’. The mdoc reader shall respond with a GET
+                 * RESPONSE command where Le is set to the maximum length of the
+                 * response data field that is supported by both the mdoc and the mdoc
+                 * reader.
+                 */
+                return ResponseApdu(
+                    status = Nfc.RESPONSE_STATUS_CHAINING_RESPONSE_BYTES_STILL_AVAILABLE,
+                    payload = chunk
+                )
+            }
+        }
+    }
+
+    override suspend fun open(eSenderKey: EcPublicKey) {
+        mutex.withLock {
+            check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
+            Logger.i(TAG, "open")
+            instances.add(this)
+        }
+    }
+
+    override suspend fun sendMessage(message: ByteArray) {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+            Logger.i(TAG, "sendMessage")
+
+            if (leReceived == 0) {
+                val e = IllegalStateException("Trying to send a message before having received one (leReceived is 0)")
+                failTransport(e)
+                throw e
+            }
+
+            val encapsulatedMessage = encapsulateInDo53(ByteString(message))
+            val maxChunkSize = leReceived
+            val offsets = 0 until encapsulatedMessage.size step maxChunkSize
+            for (offset in offsets) {
+                val chunkSize = min(maxChunkSize, encapsulatedMessage.size - offset)
+                val chunk = encapsulatedMessage.substring(offset, offset + chunkSize)
+                outgoingChunks.add(chunk)
+            }
+            outgoingChunksRemainingBytesAvailable += encapsulatedMessage.size
+
+            if (envelopeResponseDeferred) {
+                Logger.i(TAG, "envelopeResponseDeferred = true, sending")
+                sendResponse(getNextOutgoingChunkResponse()!!)
+                envelopeResponseDeferred = false
+            }
+        }
+    }
+
+    override suspend fun waitForMessage(): ByteArray {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+            Logger.i(TAG, "waitForMessage")
+        }
+        return incomingMessages.receive().toByteArray()
+    }
+
+    override suspend fun close() {
+        mutex.withLock {
+            if (_state.value == State.FAILED || _state.value == State.CLOSED) {
+                return
+            }
+            Logger.i(TAG, "close")
+            incomingMessages.close()
+            _state.value = State.CLOSED
+        }
+    }
+
+    private var inError = false
+    private var applicationSelected = false
+
+    private fun failTransport(error: Throwable) {
+        check(mutex.isLocked) { "failTransport called without holding lock" }
+        inError = true
+        if (_state.value == State.FAILED || _state.value == State.CLOSED) {
+            return
+        }
+        Logger.w(TAG, "Failing transport with error", error)
+        incomingMessages.close()
+        _state.value = State.FAILED
+    }
+
+    class NfcError(
+        val status: Int,
+        message: String
+    ): Exception(message) {}
+
+    private fun processSelectApplication(command: CommandApdu): ResponseApdu {
+        check(!applicationSelected) { "Application already selected" }
+        val requestedApplicationId = command.payload
+        if (requestedApplicationId != Nfc.ISO_MDOC_NFC_DATA_TRANSFER_APPLICATION_ID) {
+            throw NfcError(
+                status = Nfc.RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND,
+                message = "SelectApplication: Expected AID " +
+                        "${Nfc.ISO_MDOC_NFC_DATA_TRANSFER_APPLICATION_ID.toByteArray().toHex()} but got " +
+                        "${requestedApplicationId.toByteArray().toHex()}"
+            )
+        }
+        applicationSelected = true
+        // We're open for business..
+        _state.value = State.CONNECTED
+        return ResponseApdu(Nfc.RESPONSE_STATUS_SUCCESS)
+    }
+
+    private var currentIncomingEncapsulatedMessage = ByteStringBuilder()
+    private val incomingMessages = Channel<ByteString>(Channel.UNLIMITED)
+
+    private fun processEnvelope(command: CommandApdu): ResponseApdu? {
+        Logger.i(TAG, "processEnvelope")
+        check(applicationSelected) { "Application not selected" }
+        currentIncomingEncapsulatedMessage.append(command.payload)
+        if (command.cla == Nfc.CLA_CHAIN_LAST) {
+
+            // For the last ENVELOPE command in a chain, Le shall be set to the maximum length
+            // of the response data field that is supported by both the mdoc and the mdoc reader.
+            //
+            // We'll need this for later.
+            if (leReceived == 0) {
+                leReceived = command.le
+                Logger.i(TAG, "LE in last ENVELOPE is $leReceived")
+            }
+
+            // No more data coming.
+            val message = extractFromDo53(currentIncomingEncapsulatedMessage.toByteString())
+            currentIncomingEncapsulatedMessage = ByteStringBuilder()
+            incomingMessages.trySend(message)
+
+            val chunkResponse = getNextOutgoingChunkResponse()
+            if (chunkResponse == null) {
+                envelopeResponseDeferred = true
+                return null
+            } else {
+                return chunkResponse
+            }
+        } else if (command.cla == Nfc.CLA_CHAIN_NOT_LAST) {
+            // More data is coming
+            check(command.le == 0) { "Expected LE 0 for non-last ENVELOPE, got ${command.le}" }
+            Logger.i(TAG, "processEnvelope: returning SUCCESS")
+            return ResponseApdu(status = Nfc.RESPONSE_STATUS_SUCCESS)
+        } else {
+            throw IllegalStateException("Expected CLA 0x00 or 0x10 for ENVELOPE, got ${command.cla}")
+        }
+    }
+
+    private fun processGetResponse(command: CommandApdu): ResponseApdu {
+        Logger.i(TAG, "processGetResponse")
+        check(applicationSelected) { "Application not selected" }
+        val chunkResponse = getNextOutgoingChunkResponse()
+        check(chunkResponse != null)
+        return chunkResponse
+    }
+
+    private lateinit var sendResponse: (response: ResponseApdu) -> Unit
+
+    internal suspend fun processApdu(
+        command: CommandApdu,
+        sendResponse: (response: ResponseApdu) -> Unit,
+    ) {
+        this.sendResponse = sendResponse
+        val response = processApdu(command)
+        if (response != null) {
+            mutex.withLock {
+                sendResponse(response)
+            }
+        }
+    }
+
+    private suspend fun processApdu(
+        command: CommandApdu,
+    ): ResponseApdu? {
+        if (inError) {
+            Logger.w(TAG, "processApdu: Already in error state, responding to APDU with status 6f00")
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS)
+        }
+        try {
+            when (command.ins) {
+                Nfc.INS_SELECT -> {
+                    when (command.p1) {
+                        Nfc.INS_SELECT_P1_APPLICATION -> return processSelectApplication(command)
+                    }
+                }
+                Nfc.INS_ENVELOPE -> return processEnvelope(command)
+                Nfc.INS_GET_RESPONSE -> return processGetResponse(command)
+            }
+            failTransport(Error("Command APDU $command not supported, returning 6d00"))
+            return ResponseApdu(Nfc.RESPONSE_STATUS_ERROR_INSTRUCTION_NOT_SUPPORTED_OR_INVALID)
+        } catch (error: Throwable) {
+            error.printStackTrace()
+            failTransport(Error("Error processing APDU: ${error.message}", error))
+            val status = if (error is NfcError) {
+                error.status
+            } else {
+                Nfc.RESPONSE_STATUS_ERROR_NO_PRECISE_DIAGNOSIS
+            }
+            return ResponseApdu(status)
+        }
+    }
+
+    internal suspend fun onDeactivated() {
+        mutex.withLock {
+            instances.remove(this)
+            failTransport(Error("onDeactivated"))
+        }
+    }
+}
+

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/transport/NfcTransportMdocReader.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/transport/NfcTransportMdocReader.kt
@@ -1,0 +1,318 @@
+package com.android.identity.mdoc.transport
+
+import com.android.identity.crypto.EcPublicKey
+import com.android.identity.mdoc.connectionmethod.ConnectionMethod
+import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
+import com.android.identity.nfc.CommandApdu
+import com.android.identity.nfc.Nfc
+import com.android.identity.nfc.NfcCommandFailedException
+import com.android.identity.nfc.NfcIsoTag
+import com.android.identity.nfc.ResponseApdu
+import com.android.identity.util.Logger
+import com.android.identity.util.toHex
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.ByteStringBuilder
+import kotlinx.io.bytestring.append
+import kotlin.math.min
+import kotlin.time.Duration
+
+class NfcTransportMdocReader(
+    override val role: Role,
+    private val options: MdocTransportOptions,
+    override val connectionMethod: ConnectionMethodNfc
+) : MdocTransport() {
+    companion object {
+        private const val TAG = "NfcTransportMdocReader"
+    }
+
+    private val mutex = Mutex()
+
+    private lateinit var tag: NfcIsoTag
+
+    private val _state = MutableStateFlow<State>(State.IDLE)
+    override val state: StateFlow<State> = _state.asStateFlow()
+
+    override val scanningTime: Duration?
+        get() = null
+
+    override suspend fun advertise() {
+    }
+
+    private var commandDataFieldMaxLength: Int = connectionMethod.commandDataFieldMaxLength.toInt()
+    private var responseDataFieldMaxLength: Int = connectionMethod.responseDataFieldMaxLength.toInt()
+
+    /**
+     * Set underlying [NfcIsoTag] to use
+     *
+     * @param tag the tag to use.
+     */
+    fun setTag(tag: NfcIsoTag) {
+        this.tag = tag
+        commandDataFieldMaxLength = min(
+            connectionMethod.commandDataFieldMaxLength.toInt(),
+            tag.maxTransceiveLength - 7
+        )
+        responseDataFieldMaxLength = min(
+            connectionMethod.responseDataFieldMaxLength.toInt(),
+            tag.maxTransceiveLength - 7
+        )
+    }
+
+    private var ioJob: Job? = null
+
+    override suspend fun open(eSenderKey: EcPublicKey) {
+        mutex.withLock {
+            check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
+            try {
+                _state.value = State.CONNECTING
+                tag.selectApplication(Nfc.ISO_MDOC_NFC_DATA_TRANSFER_APPLICATION_ID)
+                _state.value = State.CONNECTED
+            } catch (error: Throwable) {
+                failTransport(error)
+                throw MdocTransportException("Failed while opening transport", error)
+            }
+        }
+
+        ioJob = CoroutineScope(currentCoroutineContext()).launch {
+            try {
+                while (true) {
+                    val messageToSend = writingQueue.receive()
+                    val responseMessage = nfcTransceive(messageToSend)
+                    incomingMessages.send(responseMessage)
+                }
+            } catch (e: Throwable) {
+                Logger.i(TAG, "Error while waiting for message to send", e)
+                e.printStackTrace()
+                mutex.withLock {
+                    failTransport(e)
+                }
+            }
+        }
+    }
+
+    private val writingQueue = Channel<ByteString>(Channel.UNLIMITED)
+    private val incomingMessages = Channel<ByteString>(Channel.UNLIMITED)
+
+    override suspend fun sendMessage(message: ByteArray) {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+            Logger.i(TAG, "sendMessage")
+        }
+        writingQueue.send(ByteString(message))
+    }
+
+    private suspend fun nfcTransceive(message: ByteString): ByteString {
+        val encMessage = encapsulateInDo53(message)
+
+        val maxChunkSize = commandDataFieldMaxLength
+        val offsets = 0 until encMessage.size step maxChunkSize
+        var lastEnvelopeResponse: ResponseApdu? = null
+        for (offset in offsets) {
+            val moreDataComing = (offset != offsets.last)
+            val size = min(maxChunkSize, encMessage.size - offset)
+            val le = if (!moreDataComing) {
+                responseDataFieldMaxLength
+            } else {
+                0
+            }
+            val response = tag.transceive(
+                CommandApdu(
+                    cla = if (moreDataComing) Nfc.CLA_CHAIN_NOT_LAST else Nfc.CLA_CHAIN_LAST,
+                    ins = Nfc.INS_ENVELOPE,
+                    p1 = 0x00,
+                    p2 = 0x00,
+                    payload = ByteString(encMessage.toByteArray(), offset, offset + size),
+                    le = le
+                )
+            )
+            if (response.status != Nfc.RESPONSE_STATUS_SUCCESS && response.status.and(0xff00) != 0x6100) {
+                throw NfcCommandFailedException("Unexpected ENVELOPE status ${response.statusHexString}", response.status)
+            }
+            lastEnvelopeResponse = response
+        }
+        Logger.i(TAG, "Successfully sent message, waiting for response")
+
+        check(lastEnvelopeResponse != null)
+        val encapsulatedMessageBuilder = ByteStringBuilder()
+        encapsulatedMessageBuilder.append(lastEnvelopeResponse.payload)
+        if (lastEnvelopeResponse.status == Nfc.RESPONSE_STATUS_SUCCESS) {
+            // Woohoo, entire response fits
+            Logger.i(TAG, "Entire response fits")
+        } else {
+            // More bytes are coming, have to use GET RESPONSE to get the rest
+
+            var leForGetResponse = responseDataFieldMaxLength
+            if (lastEnvelopeResponse.status.and(0xff) != 0) {
+                leForGetResponse = lastEnvelopeResponse.status.and(0xff)
+            }
+            while (true) {
+                Logger.i(TAG, "Sending GET RESPONSE")
+                val response = tag.transceive(
+                    CommandApdu(
+                        cla = 0x00,
+                        ins = Nfc.INS_GET_RESPONSE,
+                        p1 = 0x00,
+                        p2 = 0x00,
+                        payload = ByteString(),
+                        le = leForGetResponse
+                    )
+                )
+                encapsulatedMessageBuilder.append(response.payload)
+                if (response.status == Nfc.RESPONSE_STATUS_SUCCESS) {
+                    /* If Le ≥ the number of available bytes, the mdoc shall include
+                     * all available bytes in the response and set the status words
+                     * to ’90 00’.
+                     */
+                    break
+                } else if (response.status == 0x6100) {
+                    /* If the number of available bytes > Le + 255, the mdoc shall
+                     * include as many bytes in the response as indicated by Le and
+                     * shall set the status words to ’61 00’. The mdoc reader shall
+                     * respond with a GET RESPONSE command where Le is set to the
+                     * maximum length of the response data field that is supported
+                     * by both the mdoc and the mdoc reader.
+                     */
+                    leForGetResponse = responseDataFieldMaxLength
+                } else if (response.status.and(0xff00) == 0x6100) {
+                    /* If Le < the number of available bytes ≤ Le + 255, the
+                     * mdoc shall include as many bytes in the response as
+                     * indicated by Le and shall set the status words to ’61 XX’,
+                     * where XX is the number of available bytes remaining. The
+                     * mdoc reader shall respond with a GET RESPONSE command where
+                     * Le is set to XX.
+                     */
+                    leForGetResponse = response.status.and(0xff)
+                } else {
+                    throw NfcCommandFailedException(
+                        "Unexpected GET RESPONSE status ${response.statusHexString}",
+                        response.status
+                    )
+                }
+            }
+        }
+        val encapsulatedMessage = encapsulatedMessageBuilder.toByteString()
+        val message = extractFromDo53(encapsulatedMessage)
+        return message
+    }
+
+    override suspend fun waitForMessage(): ByteArray {
+        mutex.withLock {
+            check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
+            Logger.i(TAG, "waitForMessage")
+        }
+        try {
+            return incomingMessages.receive().toByteArray()
+        } catch (error: Throwable) {
+            if (_state.value == State.CLOSED) {
+                throw MdocTransportClosedException("Transport was closed while waiting for message")
+            } else {
+                mutex.withLock {
+                    failTransport(error)
+                }
+                throw MdocTransportException("Failed while waiting for message", error)
+            }
+        }
+    }
+
+    override suspend fun close() {
+        mutex.withLock {
+            if (_state.value == State.FAILED || _state.value == State.CLOSED) {
+                return
+            }
+            Logger.i(TAG, "close")
+            incomingMessages.close()
+            ioJob?.cancel()
+            ioJob = null
+            incomingMessages.close()
+            _state.value = State.CLOSED
+        }
+    }
+
+    private var inError = false
+
+    private fun failTransport(error: Throwable) {
+        check(mutex.isLocked) { "failTransport called without holding lock" }
+        inError = true
+        if (_state.value == State.FAILED || _state.value == State.CLOSED) {
+            return
+        }
+        Logger.w(TAG, "Failing transport with error", error)
+        incomingMessages.close(error)
+        ioJob?.cancel()
+        ioJob = null
+        incomingMessages.close()
+        _state.value = State.FAILED
+    }
+
+}
+
+internal fun extractFromDo53(encapsulatedData: ByteString): ByteString {
+    check(encapsulatedData.size >= 2) {
+        "DO53 length ${encapsulatedData.size}, expected at least 2"
+    }
+    val tag = encapsulatedData[0].toInt().and(0xff)
+    check(tag == 0x53) {
+        "DO53 first byte is $tag, expected 0x53"
+    }
+    var length = encapsulatedData[1].toInt().and(0xff)
+    check(length <= 0x83) {
+        "DO53 first byte of length is $length"
+    }
+    var offset = 2
+    when (length) {
+        0x80 -> throw IllegalStateException("DO53 first byte of length is 0x80")
+        0x81 -> {
+            length = encapsulatedData[2].toInt().and(0xff)
+            offset = 3
+        }
+        0x82 -> {
+            length = (encapsulatedData[2].toInt().and(0xff)) * 0x100
+            length += encapsulatedData[3].toInt().and(0xff)
+            offset = 4
+        }
+        0x83 -> {
+            length = (encapsulatedData[2].toInt().and(0xff)) * 0x10000
+            length += (encapsulatedData[3].toInt().and(0xff)) * 0x100
+            length += encapsulatedData[4].toInt().and(0xff)
+            offset = 5
+        }
+    }
+    if (encapsulatedData.size != offset + length) {
+        throw IllegalStateException("Malformed BER-TLV encoding, ${encapsulatedData.size} $offset $length")
+    }
+    return encapsulatedData.substring(offset, offset + length)
+}
+
+internal fun encapsulateInDo53(data: ByteString): ByteString {
+    val bsb = ByteStringBuilder()
+    bsb.append(0x53)
+    if (data.size < 0x80) {
+        bsb.append(data.size.and(0xff).toByte())
+    } else if (data.size < 0x100) {
+        bsb.append(0x81.and(0xff).toByte())
+        bsb.append(data.size.and(0xff).toByte())
+    } else if (data.size < 0x10000) {
+        bsb.append(0x82.and(0xff).toByte())
+        bsb.append((data.size / 0x100).and(0xff).toByte())
+        bsb.append((data.size.and(0xff)).and(0xff).toByte())
+    } else if (data.size < 0x1000000) {
+        bsb.append(0x83.and(0xff).toByte())
+        bsb.append((data.size / 0x10000).and(0xff).toByte())
+        bsb.append((data.size / 0x100).and(0xff).toByte())
+        bsb.append(data.size.and(0xff).toByte())
+    } else {
+        throw IllegalStateException("Data length cannot be bigger than 0x1000000")
+    }
+    bsb.append(data)
+    return bsb.toByteString()
+}

--- a/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/connectionmethod/ConnectionMethodTest.kt
+++ b/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/connectionmethod/ConnectionMethodTest.kt
@@ -17,6 +17,7 @@ package com.android.identity.mdoc.connectionmethod
 
 import com.android.identity.cbor.Cbor
 import com.android.identity.cbor.DiagnosticOption
+import com.android.identity.mdoc.transport.MdocTransport
 import com.android.identity.util.UUID
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -33,7 +34,7 @@ class ConnectionMethodTest {
         val cm = ConnectionMethodNfc(4096, 32768)
         val decoded = ConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodNfc?
         assertNotNull(decoded)
-        assertEquals(decoded!!.commandDataFieldMaxLength, decoded.commandDataFieldMaxLength)
+        assertEquals(decoded.commandDataFieldMaxLength, decoded.commandDataFieldMaxLength)
         assertEquals(decoded.responseDataFieldMaxLength, decoded.responseDataFieldMaxLength)
         assertEquals(
             """[
@@ -45,6 +46,9 @@ class ConnectionMethodTest {
   }
 ]""", Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
         )
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false)!!.first
+        val decodedNfc = ConnectionMethodNfc.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC)!!
+        assertEquals(cm, decodedNfc)
     }
 
     @Test
@@ -84,6 +88,9 @@ class ConnectionMethodTest {
             uuidBoth,
             uuidBoth
         )
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false).first
+        val decodedNfc = ConnectionMethodBle.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC, null)!!
+        assertEquals(cm, decodedNfc)
     }
 
     @Test
@@ -112,6 +119,10 @@ class ConnectionMethodTest {
   }
 ]""", Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
         )
+
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false).first
+        val decodedNfc = ConnectionMethodBle.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC, null)!!
+        assertEquals(cm, decodedNfc)
     }
 
     @Test
@@ -140,6 +151,10 @@ class ConnectionMethodTest {
   }
 ]""", Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
         )
+
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false).first
+        val decodedNfc = ConnectionMethodBle.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC, null)!!
+        assertEquals(cm, decodedNfc)
     }
 
     @Test

--- a/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/nfc/MdocNfcEngagementHelperTest.kt
+++ b/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/nfc/MdocNfcEngagementHelperTest.kt
@@ -2,8 +2,11 @@ package com.android.identity.mdoc.nfc
 
 import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
+import com.android.identity.crypto.EcPublicKey
+import com.android.identity.crypto.EcPublicKeyDoubleCoordinate
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
+import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
 import com.android.identity.nfc.CommandApdu
 import com.android.identity.nfc.Nfc
 import com.android.identity.nfc.NfcCommandFailedException
@@ -29,14 +32,23 @@ class MdocNfcEngagementHelperTest {
 
     // Provides access to MdocNfcEngagementHelper via NfcIsoTag abstraction
     class LoopbackIsoTag(val engagementHelper: MdocNfcEngagementHelper): NfcIsoTag() {
-        override suspend fun transceive(apdu: CommandApdu): ResponseApdu {
-            return engagementHelper.processApdu(apdu)
+        val transcript = StringBuilder()
+
+        override val maxTransceiveLength: Int
+            get() = 65536
+
+        override suspend fun transceive(command: CommandApdu): ResponseApdu {
+            transcript.appendLine("${command}")
+            val response = engagementHelper.processApdu(command)
+            transcript.appendLine("${response}")
+            return response
         }
     }
 
     private fun getConnectionMethods(): List<ConnectionMethod> {
-        // Include all ConnectionMethods that can exist in OOB data
-        val bleUuid = UUID.randomUUID()
+        // Include all ConnectionMethods that can exist in OOB data. Use static identifiers
+        // to ensure we get the same transcripts every time.
+        val bleUuid = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb6")
         return listOf(
             ConnectionMethodBle(
                 supportsPeripheralServerMode = false,
@@ -49,7 +61,20 @@ class MdocNfcEngagementHelperTest {
                 supportsCentralClientMode = false,
                 peripheralServerModeUuid = bleUuid,
                 centralClientModeUuid = null
+            ),
+            ConnectionMethodNfc(
+                commandDataFieldMaxLength = 0xffff,
+                responseDataFieldMaxLength = 0x10000
             )
+        )
+    }
+
+    private fun getEDeviceKeyPub(): EcPublicKey {
+        // Use static key to ensure we get the same transcripts every time.
+        return EcPublicKeyDoubleCoordinate(
+            curve = EcCurve.P256,
+            x = "7104f7e2c2e95ca76482c0c963d454b7e5d053c5b59ce89d00ff7c7d7ab6ff7d".fromHex(),
+            y = "f442821292c2453ec67c75233ea56e1734c211ae26b259fdf232b5b3d82b1ba2".fromHex()
         )
     }
 
@@ -57,9 +82,9 @@ class MdocNfcEngagementHelperTest {
     fun testStaticHandover() = runTest {
         val staticHandoverConnectionMethods = getConnectionMethods()
 
-        val eDeviceKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val eDeviceKeyPub = getEDeviceKeyPub()
         val engagementHelper = MdocNfcEngagementHelper(
-            eDeviceKey = eDeviceKey.publicKey,
+            eDeviceKey = eDeviceKeyPub,
             onHandoverComplete = { connectionMethods, encodedDeviceEngagement, handover ->
                 assertEquals(staticHandoverConnectionMethods, connectionMethods)
             },
@@ -69,21 +94,40 @@ class MdocNfcEngagementHelperTest {
             staticHandoverMethods = staticHandoverConnectionMethods,
         )
 
+        val tag = LoopbackIsoTag(engagementHelper)
         val handoverResult = mdocReaderNfcHandover(
-            tag = LoopbackIsoTag(engagementHelper),
+            tag = tag,
             negotiatedHandoverConnectionMethods = getConnectionMethods(),
         )
         assertNotNull(handoverResult)
         assertEquals(staticHandoverConnectionMethods, handoverResult.connectionMethods)
+
+        assertEquals(
+            """
+                CommandApdu(cla=0, ins=164, p1=4, p2=0, payload=ByteString(size=7 hex=d2760000850101), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=164, p1=0, p2=12, payload=ByteString(size=2 hex=e103), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=176, p1=0, p2=0, payload=ByteString(size=0), le=15)
+                ResponseApdu(status=36864, payload=ByteString(size=15 hex=000f207fff7fff0406e1047fff00ff))
+                CommandApdu(cla=0, ins=164, p1=0, p2=12, payload=ByteString(size=2 hex=e104), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=176, p1=0, p2=0, payload=ByteString(size=0), le=2)
+                ResponseApdu(status=36864, payload=ByteString(size=2 hex=0146))
+                CommandApdu(cla=0, ins=176, p1=0, p2=2, payload=ByteString(size=0), le=326)
+                ResponseApdu(status=36864, payload=ByteString(size=326 hex=91022d487315910209616301013001046d646f63110209616301013001046d646f6351020b616301036e666301046d646f631c1e580469736f2e6f72673a31383031333a646576696365656e676167656d656e746d646f63a20063312e30018201d818584ba4010220012158207104f7e2c2e95ca76482c0c963d454b7e5d053c5b59ce89d00ff7c7d7ab6ff7d225820f442821292c2453ec67c75233ea56e1734c211ae26b259fdf232b5b3d82b1ba21a2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c011107b66eef55ee782ea2514bb6a1c42ad5b31a2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c001107b66eef55ee782ea2514bb6a1c42ad5b35c110a0369736f2e6f72673a31383031333a6e66636e6663010301ffff0402010000))
+            """.trimIndent().trim(),
+            tag.transcript.toString().trim()
+        )
     }
 
     @Test
     fun testNegotiatedHandover() = runTest {
         val negotiatedHandoverConnectionMethods = getConnectionMethods()
 
-        val eDeviceKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val eDeviceKeyPub = getEDeviceKeyPub()
         val engagementHelper = MdocNfcEngagementHelper(
-            eDeviceKey = eDeviceKey.publicKey,
+            eDeviceKey = eDeviceKeyPub,
             onHandoverComplete = { connectionMethods, encodedDeviceEngagement, handover ->
                 assertEquals(1, connectionMethods.size)
             },
@@ -93,8 +137,9 @@ class MdocNfcEngagementHelperTest {
             negotiatedHandoverPicker = { methods -> methods.first() }
         )
 
+        val tag = LoopbackIsoTag(engagementHelper)
         val handoverResult = mdocReaderNfcHandover(
-            tag = LoopbackIsoTag(engagementHelper),
+            tag = tag,
             negotiatedHandoverConnectionMethods = negotiatedHandoverConnectionMethods,
         )
         assertNotNull(handoverResult)
@@ -102,6 +147,36 @@ class MdocNfcEngagementHelperTest {
         assertEquals(
             negotiatedHandoverConnectionMethods.first(),
             handoverResult.connectionMethods.first()
+        )
+
+        assertEquals(
+            """
+                CommandApdu(cla=0, ins=164, p1=4, p2=0, payload=ByteString(size=7 hex=d2760000850101), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=164, p1=0, p2=12, payload=ByteString(size=2 hex=e103), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=176, p1=0, p2=0, payload=ByteString(size=0), le=15)
+                ResponseApdu(status=36864, payload=ByteString(size=15 hex=000f207fff7fff0406e1047fff0000))
+                CommandApdu(cla=0, ins=164, p1=0, p2=12, payload=ByteString(size=2 hex=e104), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=176, p1=0, p2=0, payload=ByteString(size=0), le=2)
+                ResponseApdu(status=36864, payload=ByteString(size=2 hex=001f))
+                CommandApdu(cla=0, ins=176, p1=0, p2=2, payload=ByteString(size=0), le=31)
+                ResponseApdu(status=36864, payload=ByteString(size=31 hex=d1021a5470101375726e3a6e66633a736e3a68616e646f76657200000fffff))
+                CommandApdu(cla=0, ins=214, p1=0, p2=0, payload=ByteString(size=27 hex=0019d1021454731375726e3a6e66633a736e3a68616e646f766572), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=176, p1=0, p2=0, payload=ByteString(size=0), le=2)
+                ResponseApdu(status=36864, payload=ByteString(size=2 hex=0006))
+                CommandApdu(cla=0, ins=176, p1=0, p2=2, payload=ByteString(size=0), le=6)
+                ResponseApdu(status=36864, payload=ByteString(size=6 hex=d10201546500))
+                CommandApdu(cla=0, ins=214, p1=0, p2=0, payload=ByteString(size=237 hex=00eb91021e487215910204616301013000110204616301013000510206616301036e6663001c1e060a69736f2e6f72673a31383031333a726561646572656e676167656d656e746d646f63726561646572a10063312e301a2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c001107b66eef55ee782ea2514bb6a1c42ad5b31a2015016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c011107b66eef55ee782ea2514bb6a1c42ad5b35c110a0369736f2e6f72673a31383031333a6e66636e6663010301ffff0402010000), le=0)
+                ResponseApdu(status=36864, payload=ByteString(size=0))
+                CommandApdu(cla=0, ins=176, p1=0, p2=0, payload=ByteString(size=0), le=2)
+                ResponseApdu(status=36864, payload=ByteString(size=2 hex=00ba))
+                CommandApdu(cla=0, ins=176, p1=0, p2=2, payload=ByteString(size=0), le=186)
+                ResponseApdu(status=36864, payload=ByteString(size=186 hex=91020f487315d10209616301013001046d646f631c1e580469736f2e6f72673a31383031333a646576696365656e676167656d656e746d646f63a20063312e30018201d818584ba4010220012158207104f7e2c2e95ca76482c0c963d454b7e5d053c5b59ce89d00ff7c7d7ab6ff7d225820f442821292c2453ec67c75233ea56e1734c211ae26b259fdf232b5b3d82b1ba25a2003016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c01))
+            """.trimIndent().trim(),
+            tag.transcript.toString().trim()
         )
     }
 
@@ -172,7 +247,7 @@ class MdocNfcEngagementHelperTest {
     // TODO: add more tests to exercise implementation of READ_BINARY and UPDATE_BINARY
 
     @Test
-    fun testBuilder() {
+    fun testConstructor() {
         assertFailsWith(
             IllegalStateException::class,
             "Must use either static or negotiated handover, none are selected"

--- a/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/transport/NfcTransportTests.kt
+++ b/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/transport/NfcTransportTests.kt
@@ -1,0 +1,173 @@
+package com.android.identity.mdoc.transport
+
+import com.android.identity.crypto.Crypto
+import com.android.identity.crypto.EcCurve
+import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
+import com.android.identity.nfc.CommandApdu
+import com.android.identity.nfc.NfcIsoTag
+import com.android.identity.nfc.ResponseApdu
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertEquals
+
+private fun String.truncateTo(maxLength: Int): String {
+    if (this.length < maxLength) {
+        return this
+    } else {
+        return this.substring(0, maxLength) + "..."
+    }
+}
+
+class NfcTransportTests {
+
+    companion object {
+        private const val TAG = "NfcTransportTests"
+    }
+
+    class LoopbackIsoTag(val transport: NfcTransportMdoc): NfcIsoTag() {
+        val transcript = StringBuilder()
+
+        override var maxTransceiveLength = 0xfeff
+
+        @OptIn(ExperimentalCoroutinesApi::class)
+        override suspend fun transceive(command: CommandApdu): ResponseApdu {
+            transcript.appendLine("${command.toString().truncateTo(100)} (${command.encode().size} bytes)")
+            val response = suspendCancellableCoroutine<ResponseApdu> { continuation ->
+                runBlocking {
+                    transport.processApdu(
+                        command = command,
+                        sendResponse = { response ->
+                            continuation.resume(response, null)
+                        }
+                    )
+                }
+            }
+            transcript.appendLine("${response.toString().truncateTo(100)} (${response.encode().size} bytes)")
+            return response
+        }
+    }
+
+    @Test
+    fun testHappyPath() = runTest {
+        val mdoc = NfcTransportMdoc(
+            role = MdocTransport.Role.MDOC,
+            options = MdocTransportOptions(),
+            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+        )
+        val mdocReader = NfcTransportMdocReader(
+            role = MdocTransport.Role.MDOC_READER,
+            options = MdocTransportOptions(),
+            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+        )
+        val tag = LoopbackIsoTag(mdoc)
+        mdocReader.setTag(tag)
+
+        val eDeviceKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val eReaderKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        mdoc.open(eSenderKey = eReaderKey.publicKey)
+        mdocReader.open(eSenderKey = eDeviceKey.publicKey)
+
+        // Do two ping-pongs, one where messages won't need chunking, one where they do.
+
+        val request0 = ByteArray(1*1024)
+        mdocReader.sendMessage(request0)
+        assertContentEquals(request0, mdoc.waitForMessage())
+        val response0 = ByteArray(2*1024)
+        mdoc.sendMessage(response0)
+        assertContentEquals(response0, mdocReader.waitForMessage())
+
+        val request1 = ByteArray(100*1024)
+        mdocReader.sendMessage(request1)
+        assertContentEquals(request1, mdoc.waitForMessage())
+        val response1 = ByteArray(200*1024)
+        mdoc.sendMessage(response1)
+        assertContentEquals(response1, mdocReader.waitForMessage())
+
+        mdoc.close()
+        mdocReader.close()
+
+        // Check via the transcript that only the second interaction was chunked.
+        assertEquals(
+            """
+CommandApdu(cla=0, ins=164, p1=4, p2=0, payload=ByteString(size=7 hex=a0000002480400), le=0) (12 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=0)) (2 bytes)
+CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=1028 hex=538204000000000000000000000... (1037 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=2052 hex=5382080000000000000000000000000000000000... (2054 bytes)
+CommandApdu(cla=16, ins=195, p1=0, p2=0, payload=ByteString(size=65272 hex=5383019000000000000000000... (65279 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=0)) (2 bytes)
+CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=37133 hex=00000000000000000000000000... (37142 bytes)
+ResponseApdu(status=24832, payload=ByteString(size=65272 hex=538303200000000000000000000000000000000... (65274 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=65272) (7 bytes)
+ResponseApdu(status=24832, payload=ByteString(size=65272 hex=000000000000000000000000000000000000000... (65274 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=65272) (7 bytes)
+ResponseApdu(status=24869, payload=ByteString(size=65272 hex=000000000000000000000000000000000000000... (65274 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=37) (5 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=8989 hex=0000000000000000000000000000000000000000... (8991 bytes)
+            """.trimIndent().trim(),
+            tag.transcript.toString().trim()
+        )
+    }
+
+    @Test
+    fun testLowTransceiveLength() = runTest {
+        val mdoc = NfcTransportMdoc(
+            role = MdocTransport.Role.MDOC,
+            options = MdocTransportOptions(),
+            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+        )
+        val mdocReader = NfcTransportMdocReader(
+            role = MdocTransport.Role.MDOC_READER,
+            options = MdocTransportOptions(),
+            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+        )
+        val tag = LoopbackIsoTag(mdoc)
+        tag.maxTransceiveLength = 4096
+        mdocReader.setTag(tag)
+
+        val eDeviceKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        val eReaderKey = Crypto.createEcPrivateKey(EcCurve.P256)
+        mdoc.open(eSenderKey = eReaderKey.publicKey)
+        mdocReader.open(eSenderKey = eDeviceKey.publicKey)
+
+        // Check that maxTransceiveLength of 4 KiB is respected
+
+        val request0 = ByteArray(10*1024)
+        mdocReader.sendMessage(request0)
+        assertContentEquals(request0, mdoc.waitForMessage())
+        val response0 = ByteArray(20*1024)
+        mdoc.sendMessage(response0)
+        assertContentEquals(response0, mdocReader.waitForMessage())
+
+        mdoc.close()
+        mdocReader.close()
+
+        // Check via the transcript messages are chunked to fit in 4 KiB APDUs
+        assertEquals(
+            """
+CommandApdu(cla=0, ins=164, p1=4, p2=0, payload=ByteString(size=7 hex=a0000002480400), le=0) (12 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=0)) (2 bytes)
+CommandApdu(cla=16, ins=195, p1=0, p2=0, payload=ByteString(size=4089 hex=53822800000000000000000000... (4096 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=0)) (2 bytes)
+CommandApdu(cla=16, ins=195, p1=0, p2=0, payload=ByteString(size=4089 hex=00000000000000000000000000... (4096 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=0)) (2 bytes)
+CommandApdu(cla=0, ins=195, p1=0, p2=0, payload=ByteString(size=2066 hex=000000000000000000000000000... (2075 bytes)
+ResponseApdu(status=24832, payload=ByteString(size=4089 hex=5382500000000000000000000000000000000000... (4091 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=4089) (7 bytes)
+ResponseApdu(status=24832, payload=ByteString(size=4089 hex=0000000000000000000000000000000000000000... (4091 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=4089) (7 bytes)
+ResponseApdu(status=24832, payload=ByteString(size=4089 hex=0000000000000000000000000000000000000000... (4091 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=4089) (7 bytes)
+ResponseApdu(status=24871, payload=ByteString(size=4089 hex=0000000000000000000000000000000000000000... (4091 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=39) (5 bytes)
+ResponseApdu(status=24878, payload=ByteString(size=4089 hex=0000000000000000000000000000000000000000... (4091 bytes)
+CommandApdu(cla=0, ins=192, p1=0, p2=0, payload=ByteString(size=0), le=46) (5 bytes)
+ResponseApdu(status=36864, payload=ByteString(size=39 hex=000000000000000000000000000000000000000000... (41 bytes)
+            """.trimIndent().trim(),
+            tag.transcript.toString().trim()
+        )
+    }
+}

--- a/identity-mdoc/src/iosMain/kotlin/com/android/identity/mdoc/transport/MdocTransportFactory.ios.kt
+++ b/identity-mdoc/src/iosMain/kotlin/com/android/identity/mdoc/transport/MdocTransportFactory.ios.kt
@@ -2,6 +2,7 @@ package com.android.identity.mdoc.transport
 
 import com.android.identity.mdoc.connectionmethod.ConnectionMethod
 import com.android.identity.mdoc.connectionmethod.ConnectionMethodBle
+import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
 
 internal actual fun defaultMdocTransportFactoryCreateTransport(
     connectionMethod: ConnectionMethod,
@@ -54,6 +55,18 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                             connectionMethod.peripheralServerModePsm,
                         )
                     }
+                }
+            }
+        }
+        is ConnectionMethodNfc -> {
+            return when (role) {
+                MdocTransport.Role.MDOC -> throw NotImplementedError("Not yet implemented")
+                MdocTransport.Role.MDOC_READER -> {
+                    NfcTransportMdocReader(
+                        role,
+                        options,
+                        connectionMethod
+                    )
                 }
             }
         }

--- a/identity/src/androidMain/kotlin/com/android/identity/nfc/scanNfcTag.android.kt
+++ b/identity/src/androidMain/kotlin/com/android/identity/nfc/scanNfcTag.android.kt
@@ -47,9 +47,11 @@ private class NfcTagReader<T> {
                     // Note: onTagDiscovered() is called in a dedicated thread and we're not supposed
                     // to return until we're done interrogating the tag.
                     runBlocking {
+                        Logger.i(TAG, "maxTransceiveLength: ${isoDep.maxTransceiveLength}")
+                        val isoTag = NfcIsoTagAndroid(isoDep, currentCoroutineContext())
                         try {
                             val ret = tagInteractionFunc(
-                                NfcIsoTagAndroid(isoDep, currentCoroutineContext()),
+                                isoTag,
                                 { message -> dialogMessage.value = message }
                             )
                             if (ret != null) {

--- a/identity/src/commonMain/kotlin/com/android/identity/nfc/Nfc.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/nfc/Nfc.kt
@@ -17,6 +17,13 @@ object Nfc {
     val NDEF_APPLICATION_ID = ByteString("D2760000850101".fromHex())
 
     /**
+     * The Application ID for ISO mdoc NFC data transfer.
+     *
+     * Reference: ISO/IEC 18013-5:2021 clause 8.3.3.1.2
+     */
+    val ISO_MDOC_NFC_DATA_TRANSFER_APPLICATION_ID = ByteString("A0000002480400".fromHex())
+
+    /**
      * The File Identifier for the NDEF Capability Container file.
      */
     const val NDEF_CAPABILITY_CONTAINER_FILE_ID = 0xe103
@@ -47,7 +54,28 @@ object Nfc {
      *
      * Reference: ISO/IEC 7816-4 clause 5.6
      */
-    const val RESPONSE_ERROR_FILE_OR_APPLICATION_NOT_FOUND = 0x6a82
+    const val RESPONSE_STATUS_ERROR_FILE_OR_APPLICATION_NOT_FOUND = 0x6a82
+
+    /**
+     * The [ResponseApdu.status] for indicating that bytes are are still available.
+     *
+     * Reference: ISO/IEC 7816-4 clause 5.3.4
+     */
+    const val RESPONSE_STATUS_CHAINING_RESPONSE_BYTES_STILL_AVAILABLE = 0x6100
+
+    /**
+     * Command chaining control flag indicating this is the last or only part of a chain.
+     *
+     * Reference: ISO/IEC 7816-4 clause 5.4.1
+     */
+    const val CLA_CHAIN_LAST = 0x00
+
+    /**
+     * Command chaining control flag indicating this is not the last part of a chain.
+     *
+     * Reference: ISO/IEC 7816-4 clause 5.4.1
+     */
+    const val CLA_CHAIN_NOT_LAST = 0x10
 
     /**
      * SELECT command.
@@ -95,6 +123,20 @@ object Nfc {
      * Reference: ISO/IEC 7816-4 clause 11.3.5
      */
     const val INS_UPDATE_BINARY = 0xd6
+
+    /**
+     * ENVELOPE command.
+     *
+     * Reference: ISO/IEC 7816-4 clause 11.8.2
+     */
+    const val INS_ENVELOPE = 0xc3
+
+    /**
+     * GET RESPONSE command.
+     *
+     * Reference: ISO/IEC 7816-4 clause 11.8.1
+     */
+    const val INS_GET_RESPONSE = 0xc0
 
     /**
      * RTD Text type, for use with [Tnf.WELL_KNOWN].
@@ -159,4 +201,11 @@ object Nfc {
      * Reference: NFC Forum Connection Handover Technical Specification section 4.1.2.
      */
     const val MIME_TYPE_CONNECTION_HANDOVER_BLE = "application/vnd.bluetooth.le.oob"
+
+    /**
+     * The external type for NFC data transfer.
+     *
+     * Reference: ISO/IEC 18013-5:2021 clause 8.2.2.2.
+     */
+    const val EXTERNAL_TYPE_ISO_18013_5_NFC = "iso.org:18013:nfc"
 }

--- a/identity/src/commonMain/kotlin/com/android/identity/nfc/NfcIsoTag.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/nfc/NfcIsoTag.kt
@@ -10,14 +10,22 @@ import kotlin.time.Duration
  * This is an abstract super class intended for OS-specific code to implement the [transceive] method.
  */
 abstract class NfcIsoTag {
+
+    /**
+     * The maximum size of an APDU that can be sent via [transceive].
+     *
+     * This varies depending on the NFC tag reader hardware.
+     */
+    abstract val maxTransceiveLength: Int
+
     /**
      * Sends an APDU to the tag and waits for a response APDU.
      *
-     * @param apdu the [CommandApdu] to send.
+     * @param command the [CommandApdu] to send.
      * @return the [ResponseApdu] which was received.
      * @throws NfcTagLostException if the tag was lost.
      */
-    abstract suspend fun transceive(apdu: CommandApdu): ResponseApdu
+    abstract suspend fun transceive(command: CommandApdu): ResponseApdu
 
     /**
      * Selects an application according to ISO 7816-4 clause 11.2.2.

--- a/identity/src/iosMain/kotlin/com/android/identity/nfc/scanNfcTag.ios.kt
+++ b/identity/src/iosMain/kotlin/com/android/identity/nfc/scanNfcTag.ios.kt
@@ -63,11 +63,11 @@ private class NfcTagReader<T> {
                 if (error != null) {
                     Logger.e(TAG, "Connection failed", error.toKotlinError())
                 } else {
-                    val isoTag = tag as NFCISO7816TagProtocol
+                    val isoTag = NfcIsoTagIos(tag as NFCISO7816TagProtocol)
                     CoroutineScope(Dispatchers.IO).launch {
                         try {
                             val ret = tagInteractionFunc(
-                                NfcIsoTagIos(isoTag),
+                                isoTag,
                                 { message -> session.alertMessage = message }
                             )
                             if (ret != null) {

--- a/samples/testapp/iosApp/TestApp/Info.plist
+++ b/samples/testapp/iosApp/TestApp/Info.plist
@@ -51,6 +51,7 @@
     <array>
         <string>D2760000850101</string>
         <string>A0000002471001</string>
+        <string>A0000002480400</string>
     </array>
 	<key>UISupportedInterfaceOrientations~ipad</key>
 	<array>

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -48,6 +48,7 @@
             android:name=".CredmanPresentmentActivity"
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:theme="@android:style/Theme.Holo.NoActionBar.Fullscreen"
             android:launchMode="singleInstance">
             <intent-filter>
                 <action android:name="androidx.credentials.registry.provider.action.GET_CREDENTIAL" />
@@ -66,6 +67,7 @@
             android:turnScreenOn="true"
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:theme="@android:style/Theme.Holo.NoActionBar.Fullscreen"
             android:launchMode="singleInstance">
         </activity>
 
@@ -81,6 +83,20 @@
             <meta-data
                 android:name="android.nfc.cardemulation.host_apdu_service"
                 android:resource="@xml/nfc_ndef_service" />
+        </service>
+
+        <service
+            android:name=".MdocNfcDataTransferService"
+            android:exported="true"
+            android:label="@string/nfc_ndef_service_description"
+            android:permission="android.permission.BIND_NFC_SERVICE">
+            <intent-filter>
+                <action android:name="android.nfc.cardemulation.action.HOST_APDU_SERVICE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.nfc.cardemulation.host_apdu_service"
+                android:resource="@xml/mdoc_nfc_data_transfer_service" />
         </service>
     </application>
 

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/CredmanPresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/CredmanPresentmentActivity.kt
@@ -3,6 +3,11 @@ package com.android.identity.testapp
 import android.content.Intent
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Scaffold
+import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import com.android.identity.appsupport.ui.AppTheme
 import com.android.identity.appsupport.ui.digitalcredentials.DigitalCredentials
@@ -29,9 +34,10 @@ class CredmanPresentmentActivity: FragmentActivity() {
 
     private val presentmentModel = PresentmentModel()
 
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AndroidContexts.setCurrentActivity(this)
+        enableEdgeToEdge()
 
         try {
             val request = IntentHelper.extractGetCredentialRequest(intent)
@@ -86,14 +92,17 @@ class CredmanPresentmentActivity: FragmentActivity() {
 
         setContent {
             AppTheme {
-                Presentment(
-                    presentmentModel = presentmentModel,
-                    documentTypeRepository = TestAppUtils.documentTypeRepository,
-                    source = TestAppPresentmentSource(App.settingsModel),
-                    onPresentmentComplete = { finish() },
-                    appName = stringResource(Res.string.app_name),
-                    appIconPainter = painterResource(Res.drawable.app_icon),
-                )
+                Scaffold { innerPadding ->
+                    Presentment(
+                        presentmentModel = presentmentModel,
+                        documentTypeRepository = TestAppUtils.documentTypeRepository,
+                        source = TestAppPresentmentSource(App.settingsModel),
+                        onPresentmentComplete = { finish() },
+                        appName = stringResource(Res.string.app_name),
+                        appIconPainter = painterResource(Res.drawable.app_icon),
+                        modifier = Modifier.consumeWindowInsets(innerPadding),
+                    )
+                }
             }
         }
     }

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/MainActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/MainActivity.kt
@@ -1,7 +1,11 @@
 package com.android.identity.testapp
 
+import android.content.ComponentName
+import android.nfc.NfcAdapter
+import android.nfc.cardemulation.CardEmulation
 import android.os.Bundle
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.fragment.app.FragmentActivity
@@ -40,15 +44,22 @@ class MainActivity : FragmentActivity() {
     override fun onResume() {
         super.onResume()
         AndroidContexts.setCurrentActivity(this)
+        NfcAdapter.getDefaultAdapter(this)?.let {
+            CardEmulation.getInstance(it)?.setPreferredService(this, ComponentName(this, NdefService::class::class.java))
+        }
     }
 
     override fun onPause() {
         super.onPause()
         AndroidContexts.setCurrentActivity(null)
+        NfcAdapter.getDefaultAdapter(this)?.let {
+            CardEmulation.getInstance(it)?.unsetPreferredService(this)
+        }
     }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
 
         initBouncyCastle()
 

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/MdocNfcDataTransferService.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/MdocNfcDataTransferService.kt
@@ -1,0 +1,41 @@
+package com.android.identity.testapp
+
+import android.nfc.cardemulation.HostApduService
+import android.os.Bundle
+import com.android.identity.mdoc.transport.NfcTransportMdoc
+import com.android.identity.util.Logger
+
+class MdocNfcDataTransferService: HostApduService() {
+    companion object {
+        private val TAG = "MdocNfcDataTransferService"
+    }
+
+    override fun onDestroy() {
+        Logger.i(TAG, "onDestroy")
+        super.onDestroy()
+    }
+
+    override fun onCreate() {
+        Logger.i(TAG, "onCreate")
+        super.onCreate()
+    }
+
+    override fun processCommandApdu(commandApdu: ByteArray, extras: Bundle?): ByteArray? {
+        Logger.i(TAG, "processCommandApdu")
+        try {
+            NfcTransportMdoc.processCommandApdu(
+                commandApdu = commandApdu,
+                sendResponse = { responseApdu -> sendResponseApdu(responseApdu) }
+            )
+        } catch (e: Throwable) {
+            Logger.e(TAG, "processCommandApdu", e)
+            e.printStackTrace()
+        }
+        return null
+    }
+
+    override fun onDeactivated(reason: Int) {
+        Logger.i(TAG, "onDeactivated $reason")
+        NfcTransportMdoc.onDeactivated()
+    }
+}

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NfcPresentmentActivity.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NfcPresentmentActivity.kt
@@ -1,7 +1,18 @@
 package com.android.identity.testapp
 
 import android.os.Bundle
+import android.view.View.SYSTEM_UI_FLAG_FULLSCREEN
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.foundation.layout.consumeWindowInsets
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.ui.Modifier
 import androidx.fragment.app.FragmentActivity
 import com.android.identity.appsupport.ui.AppTheme
 import com.android.identity.appsupport.ui.presentment.Presentment
@@ -17,19 +28,24 @@ class NfcPresentmentActivity : FragmentActivity() {
         private const val TAG = "NfcPresentmentActivity"
     }
 
+    @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        AndroidContexts.setCurrentActivity(this)
+        enableEdgeToEdge()
+
         setContent {
             AppTheme {
-                Presentment(
-                    presentmentModel = NdefService.presentmentModel,
-                    documentTypeRepository = TestAppUtils.documentTypeRepository,
-                    source = TestAppPresentmentSource(App.settingsModel),
-                    onPresentmentComplete = { finish() },
-                    appName = stringResource(Res.string.app_name),
-                    appIconPainter = painterResource(Res.drawable.app_icon),
-                )
+                Scaffold { innerPadding ->
+                    Presentment(
+                        presentmentModel = NdefService.presentmentModel,
+                        documentTypeRepository = TestAppUtils.documentTypeRepository,
+                        source = TestAppPresentmentSource(App.settingsModel),
+                        onPresentmentComplete = { finish() },
+                        appName = stringResource(Res.string.app_name),
+                        appIconPainter = painterResource(Res.drawable.app_icon),
+                        modifier = Modifier.consumeWindowInsets(innerPadding),
+                    )
+                }
             }
         }
     }

--- a/samples/testapp/src/androidMain/res/values/strings.xml
+++ b/samples/testapp/src/androidMain/res/values/strings.xml
@@ -2,4 +2,5 @@
     <string name="app_name">Test App</string>
     <string name="nfc_ndef_service_description">@string/app_name</string>
     <string name="nfc_ndef_service_aid_group_description">ISO/IEC 18013-5:2021 NFC engagement</string>
+    <string name="mdoc_nfc_data_transfer_service_aid_group_description">ISO/IEC 18013-5:2021 NFC data transfer</string>
 </resources>

--- a/samples/testapp/src/androidMain/res/xml/mdoc_nfc_data_transfer_service.xml
+++ b/samples/testapp/src/androidMain/res/xml/mdoc_nfc_data_transfer_service.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<!-- NOTE: This app uses made-up credentials so it's not a concern to handle credential
+           requests on the lock screen because there is no PII. For an app with real
+           user data it might be a privacy problem to show PII on the lock screen.
+-->
+<host-apdu-service xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/nfc_ndef_service_description"
+    android:requireDeviceUnlock="false"
+    android:requireDeviceScreenOn="false">
+
+    <aid-group android:description="@string/mdoc_nfc_data_transfer_service_aid_group_description" android:category="other">
+        <!-- Defined in ISO 18013-5:2021 clause 8.3.3.1.2 -->
+        <aid-filter android:name="A0000002480400"/>
+    </aid-group>
+
+</host-apdu-service>

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
@@ -16,30 +16,35 @@ class TestAppSettingsModel {
 
     val presentmentBleCentralClientModeEnabled = MutableStateFlow<Boolean>(true)
     val presentmentBlePeripheralServerModeEnabled = MutableStateFlow<Boolean>(false)
-    val presentmentBleL2CapEnabled = MutableStateFlow<Boolean>(true)
+    val presentmentNfcDataTransferEnabled = MutableStateFlow<Boolean>(false)
+    val presentmentBleL2CapEnabled = MutableStateFlow<Boolean>(false)
     val presentmentUseNegotiatedHandover = MutableStateFlow<Boolean>(true)
     val presentmentAllowMultipleRequests = MutableStateFlow<Boolean>(false)
     val presentmentNegotiatedHandoverPreferredOrder = MutableStateFlow<List<String>>(listOf(
         "ble:central_client_mode:",
         "ble:peripheral_server_mode:",
+        "nfc:"
     ))
     val presentmentShowConsentPrompt = MutableStateFlow<Boolean>(true)
 
     fun resetPresentmentSettings() {
         presentmentBleCentralClientModeEnabled.value = true
         presentmentBlePeripheralServerModeEnabled.value = false
+        presentmentNfcDataTransferEnabled.value = false
         presentmentBleL2CapEnabled.value = true
         presentmentUseNegotiatedHandover.value = true
         presentmentAllowMultipleRequests.value = false
         presentmentNegotiatedHandoverPreferredOrder.value = listOf(
             "ble:central_client_mode:",
             "ble:peripheral_server_mode:",
+            "nfc:"
         )
         presentmentShowConsentPrompt.value = true
     }
 
     val readerBleCentralClientModeEnabled = MutableStateFlow<Boolean>(true)
     val readerBlePeripheralServerModeEnabled = MutableStateFlow<Boolean>(true)
+    val readerNfcDataTransferEnabled = MutableStateFlow<Boolean>(true)
     val readerBleL2CapEnabled = MutableStateFlow<Boolean>(true)
     val readerAutomaticallySelectTransport = MutableStateFlow<Boolean>(false)
     val readerAllowMultipleRequests = MutableStateFlow<Boolean>(false)
@@ -47,6 +52,7 @@ class TestAppSettingsModel {
     fun resetReaderSettings() {
         readerBleCentralClientModeEnabled.value = true
         readerBlePeripheralServerModeEnabled.value = true
+        readerNfcDataTransferEnabled.value = true
         readerBleL2CapEnabled.value = true
         readerAutomaticallySelectTransport.value = false
         readerAllowMultipleRequests.value = false

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
@@ -41,6 +41,7 @@ import com.android.identity.mdoc.transport.MdocTransportFactory
 import com.android.identity.mdoc.transport.MdocTransportOptions
 import com.android.identity.appsupport.ui.presentment.PresentmentModel
 import com.android.identity.mdoc.transport.advertiseAndWait
+import com.android.identity.mdoc.connectionmethod.ConnectionMethodNfc
 import com.android.identity.testapp.Platform
 import com.android.identity.testapp.TestAppSettingsModel
 import com.android.identity.testapp.platform
@@ -137,6 +138,13 @@ fun IsoMdocProximitySharingScreen(
                     title = "BLE (mdoc peripheral server mode)",
                     isChecked = settingsModel.presentmentBlePeripheralServerModeEnabled.collectAsState().value,
                     onCheckedChange = { settingsModel.presentmentBlePeripheralServerModeEnabled.value = it },
+                )
+            }
+            item {
+                SettingToggle(
+                    title = "NFC Data Transfer",
+                    isChecked = settingsModel.presentmentNfcDataTransferEnabled.collectAsState().value,
+                    onCheckedChange = { settingsModel.presentmentNfcDataTransferEnabled.value = it },
                 )
             }
             item {
@@ -260,6 +268,14 @@ fun IsoMdocProximitySharingScreen(
                                         )
                                     )
                                 }
+                                if (settingsModel.presentmentNfcDataTransferEnabled.value) {
+                                    connectionMethods.add(
+                                        ConnectionMethodNfc(
+                                            commandDataFieldMaxLength = 0xffff,
+                                            responseDataFieldMaxLength = 0x10000
+                                        )
+                                    )
+                                }
                                 val options = MdocTransportOptions(
                                     bleUseL2CAP = settingsModel.presentmentBleL2CapEnabled.value
                                 )
@@ -332,6 +348,7 @@ private suspend fun doHolderFlow(
 private val prefixToDisplayNameMap = mapOf<String, String>(
     "ble:central_client_mode:" to "BLE (mdoc central client mode)",
     "ble:peripheral_server_mode:" to "BLE (mdoc peripheral server mode)",
+    "nfc:" to "NFC Data Transfer"
 )
 
 private fun TestAppSettingsModel.swapNegotiatedHandoverOrder(index1: Int, index2: Int) {


### PR DESCRIPTION
On Android, this works on both the mdoc and mdoc reader side. On iOS this only works on the mdoc reader side since HCE isn't generally available.

In addition to NfcTransportMdoc and NfcTransportMdocReader, also add unit tests for the happy path and cases where the tag reader has limits on APDU. Also slightly improve tests for
MdocNfcEngagementHelper.

Change scanNfcMdocReader() so it's possible to run the code handling the resulting MdocTransport in the coroutine for handling the NfcIsoTag. This is needed on the reader side when doing NFC data retrieval.

Also add support for the somewhat dubious configuration of QR engagement and NFC data retrieval. This includes prompting the user to move the mdoc into the NFC field of the mdoc reader.

Enable edge-to-edge and consume window insets for a more immersive experience, especially for Credman or NFC engagement presentments (no title bar, etc). Add a TODO about needing to examine display cutouts so the close button isn't overlapping with the cutout.

Also introduce PresentmentTimeout so the UI layer can show appropriate message. Update NFC engagement to emit this and Presentable composable to react on it.

Test: Manually tested on both Android and iOS.
Test: New unit tests and all unit tests pass.
