### PR TITLE
SecureArea: Add mechanism to automatically show authentication dialogs.

### DIFF
--- a/identity-appsupport/src/commonMain/composeResources/values/strings.xml
+++ b/identity-appsupport/src/commonMain/composeResources/values/strings.xml
@@ -62,4 +62,10 @@
     <string name="presentment_document_picker_cancel">Cancel</string>
     <string name="presentment_document_picker_continue">Continue</string>
 
+    <!-- PassphrasePinScreen -->
+    <string name="passphrase_pin_screen_delete">Delete</string>
+    <string name="passphrase_pin_screen_cancel">Cancel</string>
+    <string name="passphrase_pin_screen_done">Done</string>
+    <string name="passphrase_prompt_bottom_sheet_cancel">Cancel</string>
+
 </resources>

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/passphrase/PassphrasePromptBottomSheet.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/passphrase/PassphrasePromptBottomSheet.kt
@@ -1,0 +1,165 @@
+@file:OptIn(ExperimentalMaterial3Api::class)
+
+package com.android.identity.appsupport.ui.passphrase
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
+import androidx.compose.foundation.layout.imePadding
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import com.android.identity.securearea.PassphraseConstraints
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * A [ModalBottomSheet] used for obtaining a passphrase.
+ *
+ * @param sheetState a [SheetState] for state.
+ * @param title the title in the sheet.
+ * @param subtitle the subtitle to display in the sheet.
+ * @param passphraseConstraints a [PassphraseConstraints] describing the passphrase to be collected.
+ * @param showKeyboard a [StateFlow] that should be set to `true` once the bottom sheet is fully shown.
+ * @param onPassphraseEntered called when the passphrase has been collected. Return `null` to indicate success
+ *   otherwise a message to display in the prompt conveying the user entered the wrong passphrase.
+ * @param onDismissed called if the user dismisses the sheet.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PassphrasePromptBottomSheet(
+    sheetState: SheetState,
+    title: String,
+    subtitle: String,
+    passphraseConstraints: PassphraseConstraints,
+    showKeyboard: StateFlow<Boolean>,
+    onPassphraseEntered: suspend (passphrase: String) -> String?,
+    onDismissed: () -> Unit,
+) {
+    val coroutineScope = rememberCoroutineScope()
+
+    ModalBottomSheet(
+        modifier = Modifier.imePadding(),
+        onDismissRequest = { onDismissed() },
+        sheetState = sheetState,
+        dragHandle = null,
+        containerColor = MaterialTheme.colorScheme.surface,
+        contentWindowInsets = { WindowInsets.ime },
+    ) {
+        val wrongPassphraseMessage = remember { mutableStateOf<String>("") }
+        val hideWrongPassphraseMessageJob = remember { mutableStateOf<Job?>(null) }
+        Box(
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            IconButton(
+                modifier = Modifier.align(Alignment.TopEnd).padding(8.dp),
+                onClick = { onDismissed() }
+            ) {
+                Icon(
+                    imageVector = Icons.Filled.Close,
+                    contentDescription = null,
+                )
+            }
+        }
+
+        Column(
+            modifier = Modifier.padding(8.dp),
+            verticalArrangement = Arrangement.Top
+        ) {
+            Column(
+                modifier = Modifier
+                    .padding(bottom = 16.dp)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(bottom = 16.dp),
+                    verticalArrangement = Arrangement.Center
+                ) {
+                    Text(
+                        modifier = Modifier.fillMaxWidth(),
+                        text = title,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.titleLarge,
+                    )
+
+                    Text(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(top = 8.dp),
+                        text = subtitle,
+                        textAlign = TextAlign.Center,
+                        style = MaterialTheme.typography.bodyMedium
+                    )
+                }
+
+                PassphrasePromptInputField(
+                    constraints = passphraseConstraints,
+                    showKeyboard = showKeyboard,
+                    onChanged = { passphrase, donePressed ->
+                        // Note: onChanged is invoked in a coroutine because onPassphraseEntered
+                        // might need to perform suspendable calls when checking the passphrase.
+                        var matchResult: String? = null
+                        if (!passphraseConstraints.isFixedLength()) {
+                            // notify of the typed passphrase when user taps 'Done' on the keyboard
+                            if (donePressed) {
+                                matchResult = onPassphraseEntered(passphrase)
+                            }
+                        } else {
+                            // when the user enters the maximum numbers of characters, send
+                            if (passphrase.length == passphraseConstraints.maxLength) {
+                                matchResult = onPassphraseEntered(passphrase)
+                            }
+                        }
+                        if (matchResult != null) {
+                            wrongPassphraseMessage.value = matchResult
+                            hideWrongPassphraseMessageJob.value?.cancel()
+                            hideWrongPassphraseMessageJob.value = coroutineScope.launch {
+                                delay(3.seconds)
+                                wrongPassphraseMessage.value = ""
+                                hideWrongPassphraseMessageJob.value = null
+                            }
+                            true  // Signals that the input field should be cleared
+                        } else {
+                            false
+                        }
+                    }
+                )
+
+                Text(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(top = 8.dp),
+                    text = wrongPassphraseMessage.value,
+                    textAlign = TextAlign.Center,
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.error
+                )
+            }
+        }
+    }
+}

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/passphrase/PassphrasePromptInputField.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/passphrase/PassphrasePromptInputField.kt
@@ -1,4 +1,4 @@
-package com.android.identity.appsupport.ui
+package com.android.identity.appsupport.ui.passphrase
 
 import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Arrangement
@@ -15,13 +15,12 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -35,44 +34,35 @@ import androidx.compose.ui.text.input.TransformedText
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import com.android.identity.securearea.PassphraseConstraints
-import identitycredential.identity_appsupport.generated.resources.Res
-import identitycredential.identity_appsupport.generated.resources.passphrase_entry_field_passphrase_is_weak
-import identitycredential.identity_appsupport.generated.resources.passphrase_entry_field_pin_is_weak
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
-import org.jetbrains.compose.resources.getString
 
+// U+2022 Bullet, see https://en.wikipedia.org/wiki/Bullet_(typography)
+//
+private const val BULLET = "\u2022"
 
-/**
- * A composable for entering a passphrase or PIN.
- *
- * Three parameters are passed to the [onChanged] callback, the first is the current passphrase,
- * the second is whether this meets requirements, and they third is a boolean which is set to
- * `true` only if the user pressed the "Done" button on the virtual keyboard.
- *
- * Note that [onChanged] will be fired right after the composable is first shown. This is to
- * enable the calling code to update e.g. a "Next" button based on whether the currently
- * entered passphrase meets requirements.
- *
- * @param constraints the constraints for the passphrase.
- * @param checkWeakPassphrase if true, checks and disallows for weak passphrase/PINs and also
- *   shows a hint if one is input
- * @param onChanged called when the user is entering text or pressing the "Done" IME action
- */
 @Composable
-fun PassphraseEntryField(
+internal fun PassphrasePromptInputField(
     constraints: PassphraseConstraints,
-    checkWeakPassphrase: Boolean = false,
-    onChanged: (passphrase: String, meetsRequirements: Boolean, donePressed: Boolean) -> Unit,
+    showKeyboard: StateFlow<Boolean>,
+    onChanged: suspend (passphrase: String, donePressed: Boolean) -> Boolean,
 ) {
-    // if no imeAction specified define the default to be ImeAction.Done
+    val coroutineScope = rememberCoroutineScope()
+    var inputText by remember { mutableStateOf("") }
+
+    val imeAction = if (constraints.isFixedLength()) {
+        ImeAction.None
+    } else {
+        if (inputText.length >= constraints.minLength) {
+            ImeAction.Done
+        } else {
+            ImeAction.None
+        }
+    }
+
     val focusRequester = remember { FocusRequester() }
 
-    var inputText by remember { mutableStateOf("") }
-    var passphraseAnalysis by remember {
-        mutableStateOf(PassphraseAnalysis(false, null))
-    }
     var obfuscateAll by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
     // Put boxes around the entered chars for fixed length and six or fewer characters
@@ -88,12 +78,12 @@ fun PassphraseEntryField(
                     val digit =
                         if (digitIndex == inputText.length - 1) {
                             if (obfuscateAll) {
-                                "\u2022"  // U+2022 Bullet
+                                BULLET
                             } else {
                                 inputText[digitIndex].toString()
                             }
                         } else if (digitIndex < inputText.length) {
-                            "\u2022"  // U+2022 Bullet
+                            BULLET
                         } else {
                             ""
                         }
@@ -106,8 +96,8 @@ fun PassphraseEntryField(
                         textAlign = TextAlign.Center,
                         style = MaterialTheme.typography.headlineLarge.copy(
                             color = MaterialTheme.colorScheme.primary,
-                            // make the "dot" \u2022 be a bit bolder/bigger
-                            fontWeight = if (digit == "\u2022") {
+                            // make the BULLET be a bit bolder/bigger
+                            fontWeight = if (digit == BULLET) {
                                 FontWeight.Black
                             } else {
                                 MaterialTheme.typography.headlineLarge.fontWeight
@@ -119,7 +109,6 @@ fun PassphraseEntryField(
             }
         }
     }
-
     Row(
         modifier = Modifier.fillMaxWidth(),
         horizontalArrangement = Arrangement.Center,
@@ -129,18 +118,16 @@ fun PassphraseEntryField(
             modifier = Modifier
                 .padding(8.dp)
                 .focusRequester(focusRequester),
-            onValueChange = {
-                if (it.length > constraints.maxLength) {
+            onValueChange = { newText ->
+                if (newText.length > constraints.maxLength) {
                     return@BasicTextField
                 }
                 if (constraints.requireNumerical) {
-                    if (!(it.all { it.isDigit() })) {
+                    if (!(newText.all { it.isDigit() })) {
                         return@BasicTextField
                     }
                 }
-
-                inputText = it
-                passphraseAnalysis = analyzePassphrase(inputText, constraints, checkWeakPassphrase)
+                inputText = newText
 
                 obfuscateAll = false
                 scope.launch {
@@ -151,27 +138,40 @@ fun PassphraseEntryField(
                     inputText = value
                 }
 
-                onChanged(inputText, passphraseAnalysis.meetsRequirements, false)
+                coroutineScope.launch {
+                    if (onChanged(inputText, false)) {
+                        inputText = ""
+                    }
+                }
             },
             singleLine = true,
             textStyle = MaterialTheme.typography.headlineMedium.copy(color = MaterialTheme.colorScheme.primary),
             decorationBox = decorationBox,
             keyboardOptions = KeyboardOptions(
-                keyboardType = if (constraints.requireNumerical) KeyboardType.NumberPassword else KeyboardType.Password,
-                imeAction = ImeAction.Done,
+                keyboardType = if (constraints.requireNumerical) {
+                    KeyboardType.NumberPassword
+                } else {
+                    KeyboardType.Password
+                },
+                imeAction = imeAction,
             ),
             keyboardActions = KeyboardActions(
                 onDone = {
-                    onChanged(inputText, passphraseAnalysis.meetsRequirements, true)
+                    if (inputText.length >= constraints.minLength) {
+                        coroutineScope.launch {
+                            if (onChanged(inputText, true)) {
+                                inputText = ""
+                            }
+                        }
+                    }
                 }
             ),
             visualTransformation = { text ->
-                val mask = '\u2022'
                 val result = if (text.isNotEmpty()) {
                     if (obfuscateAll) {
-                        mask.toString().repeat(text.text.length)
+                        BULLET.repeat(text.text.length)
                     } else {
-                        mask.toString().repeat(text.text.length - 1) + text.last()
+                        BULLET.repeat(text.text.length - 1) + text.last()
                     }
                 } else {
                     ""
@@ -192,88 +192,7 @@ fun PassphraseEntryField(
         )
     }
 
-    passphraseAnalysis.weakHint?.let {
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(8.dp),
-            horizontalArrangement = Arrangement.Center,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            Text(
-                text = it,
-                style = MaterialTheme.typography.bodyMedium,
-                color = MaterialTheme.colorScheme.error
-            )
-        }
-    }
-
-    LaunchedEffect(Unit) {
-        // Bring up keyboard when entering screen
+    if (showKeyboard.collectAsState().value == true) {
         focusRequester.requestFocus()
-        passphraseAnalysis = analyzePassphrase(inputText, constraints, checkWeakPassphrase)
-        // Fire initially so caller can adjust e.g. sensitivity of a possible "Next" button
-        onChanged(inputText, passphraseAnalysis.meetsRequirements, false)
     }
-}
-
-private data class PassphraseAnalysis(
-    val meetsRequirements: Boolean,
-    val weakHint: String?,
-)
-
-private fun analyzePassphrase(
-    passphrase: String,
-    constraints: PassphraseConstraints,
-    checkWeakPassphrase: Boolean
-): PassphraseAnalysis {
-    // For a fixed-length passphrase, never give any hints until user has typed it in.
-    if (constraints.isFixedLength()) {
-        if (passphrase.length < constraints.minLength) {
-            return PassphraseAnalysis(meetsRequirements = false, weakHint = null)
-        }
-    }
-
-    if (passphrase.length < constraints.minLength) {
-        return PassphraseAnalysis(meetsRequirements = false, weakHint = null)
-    }
-
-    if (checkWeakPassphrase && isWeakPassphrase(passphrase)) {
-        return PassphraseAnalysis(
-            meetsRequirements = false,
-            weakHint = if (constraints.requireNumerical)
-                runBlocking { getString(Res.string.passphrase_entry_field_pin_is_weak) }
-            else
-                runBlocking { getString(Res.string.passphrase_entry_field_passphrase_is_weak) },
-        )
-    }
-
-    return PassphraseAnalysis(
-        meetsRequirements = true,
-        weakHint = null
-    )
-}
-
-private fun isWeakPassphrase(passphrase: String): Boolean {
-    if (passphrase.isEmpty()) {
-        return true
-    }
-
-    // Check all characters being the same
-    if (passphrase.all { it.equals(passphrase.first()) }) {
-        return true
-    }
-
-    // Check consecutive characters (e.g. 1234 or abcd)
-    var nextChar = passphrase.first().inc()
-    for (n in IntRange(1, passphrase.length - 1)) {
-        if (passphrase[n] != nextChar) {
-            return false
-        }
-        nextChar = nextChar.inc()
-    }
-
-    // TODO: add more checks
-
-    return true
 }

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/passphrase/PassphrasePromptProvider.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/passphrase/PassphrasePromptProvider.kt
@@ -1,0 +1,108 @@
+package com.android.identity.appsupport.ui.passphrase
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import com.android.identity.securearea.PassphraseConstraints
+import com.android.identity.securearea.PassphrasePromptModel
+import com.android.identity.securearea.PassphrasePromptView
+import kotlinx.coroutines.CancellableContinuation
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+private data class PassphraseRequestData(
+    val title: String,
+    val subtitle: String,
+    val passphraseConstraints: PassphraseConstraints,
+    val passphraseEvaluator: (suspend (enteredPassphrase: String) -> String?)?,
+    val continuation: CancellableContinuation<String?>,
+)
+
+/**
+ * A composable for asking the user for a passphrase.
+ *
+ * This connects to the underlying libraries using [PassphrasePromptModel] when the composable is
+ * part of the composition. It shows requests using a modal bottom sheet. Applications wishing
+ * to use [SecureArea] instances using passphrases should include this composable on screens
+ * that are visible when using keys that may need to be unlocked.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PassphrasePromptProvider() {
+
+    val showPassphrasePrompt = remember { mutableStateOf<PassphraseRequestData?>(null) }
+
+    val provider = object: PassphrasePromptView {
+        override suspend fun requestPassphrase(
+            title: String,
+            subtitle: String,
+            passphraseConstraints: PassphraseConstraints,
+            passphraseEvaluator: (suspend (enteredPassphrase: String) -> String?)?
+        ): String? {
+            val passphrase = suspendCancellableCoroutine { continuation ->
+                showPassphrasePrompt.value = PassphraseRequestData(
+                    title = title,
+                    subtitle = subtitle,
+                    passphraseConstraints = passphraseConstraints,
+                    passphraseEvaluator = passphraseEvaluator,
+                    continuation = continuation
+                )
+            }
+            showPassphrasePrompt.value = null
+            return passphrase
+        }
+    }
+
+    LaunchedEffect(provider) {
+        PassphrasePromptModel.registerView(provider)
+    }
+    DisposableEffect(provider) {
+        onDispose {
+            PassphrasePromptModel.unregisterView(provider)
+        }
+    }
+
+    // To avoid jank, we request the keyboard to be shown only when the sheet is fully expanded.
+    //
+    val showKeyboard = MutableStateFlow<Boolean>(false)
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+        confirmValueChange = { value ->
+            showKeyboard.value = true
+            true
+        }
+    )
+    if (showPassphrasePrompt.value != null) {
+        PassphrasePromptBottomSheet(
+            sheetState = sheetState,
+            title = showPassphrasePrompt.value!!.title,
+            subtitle = showPassphrasePrompt.value!!.subtitle,
+            passphraseConstraints = showPassphrasePrompt.value!!.passphraseConstraints,
+            showKeyboard = showKeyboard.asStateFlow(),
+            onPassphraseEntered = { enteredPassphrase ->
+                val evaluator = showPassphrasePrompt.value!!.passphraseEvaluator
+                if (evaluator != null) {
+                    val matchResult = evaluator.invoke(enteredPassphrase)
+                    if (matchResult == null) {
+                        showPassphrasePrompt.value!!.continuation.resume(enteredPassphrase)
+                        null
+                    } else {
+                        matchResult
+                    }
+                } else {
+                    showPassphrasePrompt.value!!.continuation.resume(enteredPassphrase)
+                    null
+                }
+            },
+            onDismissed = {
+                showPassphrasePrompt.value!!.continuation.resume(null)
+            },
+        )
+    }
+}

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/Presentment.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/Presentment.kt
@@ -41,8 +41,10 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.android.identity.appsupport.ui.consent.ConsentDocument
 import com.android.identity.appsupport.ui.consent.ConsentModalBottomSheet
+import com.android.identity.appsupport.ui.passphrase.PassphrasePromptProvider
 import com.android.identity.document.Document
 import com.android.identity.documenttype.DocumentTypeRepository
+import com.android.identity.securearea.PassphrasePromptView
 import identitycredential.identity_appsupport.generated.resources.Res
 import identitycredential.identity_appsupport.generated.resources.presentment_canceled
 import identitycredential.identity_appsupport.generated.resources.presentment_icon_error
@@ -105,6 +107,8 @@ fun Presentment(
             presentmentModel.reset()
         }
     }
+
+    PassphrasePromptProvider()
 
     val state = presentmentModel.state.collectAsState().value
     when (state) {

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/digitalCredentialsPresentment.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/digitalCredentialsPresentment.kt
@@ -24,6 +24,7 @@ import com.android.identity.mdoc.util.MdocUtil
 import com.android.identity.mdoc.util.toMdocRequest
 import com.android.identity.request.MdocRequest
 import com.android.identity.request.Request
+import com.android.identity.securearea.KeyUnlockInteractive
 import com.android.identity.trustmanagement.TrustPoint
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
@@ -374,7 +375,7 @@ private suspend fun calcDocument(
         NameSpacedData.Builder().build(),
         credential.secureArea,
         credential.alias,
-        null,
+        KeyUnlockInteractive(),
         keyInfo.publicKey.curve.defaultSigningAlgorithm,
     )
     return documentGenerator.generate()

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/mdocPresentment.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/mdocPresentment.kt
@@ -7,7 +7,6 @@ import com.android.identity.cbor.CborArray
 import com.android.identity.cbor.Tagged
 import com.android.identity.credential.Credential
 import com.android.identity.document.Document
-import com.android.identity.document.DocumentStore
 import com.android.identity.document.NameSpacedData
 import com.android.identity.documenttype.DocumentTypeRepository
 import com.android.identity.mdoc.credential.MdocCredential
@@ -22,13 +21,12 @@ import com.android.identity.mdoc.transport.MdocTransportClosedException
 import com.android.identity.mdoc.util.MdocUtil
 import com.android.identity.mdoc.util.toMdocRequest
 import com.android.identity.request.Request
+import com.android.identity.securearea.KeyUnlockInteractive
 import com.android.identity.trustmanagement.TrustPoint
 import com.android.identity.util.Constants
 import com.android.identity.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
-import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 
 private const val TAG = "mdocPresentment"
 
@@ -216,7 +214,7 @@ private suspend fun calcDocument(
         NameSpacedData.Builder().build(),
         credential.secureArea,
         credential.alias,
-        null,
+        KeyUnlockInteractive(),
         keyInfo.publicKey.curve.defaultSigningAlgorithm,
     )
     return documentGenerator.generate()

--- a/identity-csa/src/main/java/com/android/identity/securearea/cloud/CloudSecureAreaProtocol.kt
+++ b/identity-csa/src/main/java/com/android/identity/securearea/cloud/CloudSecureAreaProtocol.kt
@@ -438,4 +438,28 @@ object CloudSecureAreaProtocol {
         val zab: ByteArray?,
         val waitDurationMillis: Long
     ) : Command()
+
+    /**
+     * Checks if the given passphrase matches the registered passphrase.
+     *
+     * This can be used in passphrase dialogs to check the passphrase
+     * obtained from the user will work for operations like signing or
+     * key agreement without having to try the whole operation again.
+     *
+     * Wrong passphrase attempts will continue to contribute to policy
+     * enforced by [PassphraseFailureEnforcer].
+     */
+    data class CheckPassphraseRequest(
+        val passphrase: String
+    ) : Command()
+
+    /**
+     * Response for [CheckPassphraseRequest].
+     *
+     * The result is one of [RESULT_OK], [RESULT_WRONG_PASSPHRASE], and
+     * [RESULT_TOO_MANY_PASSPHRASE_ATTEMPTS].
+     */
+    data class CheckPassphraseResponse(
+        val result: Int,
+    ) : Command()
 }

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/util/MdocUtil.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/util/MdocUtil.kt
@@ -668,11 +668,15 @@ object MdocUtil {
  *
  * @param documentTypeRepository a [DocumentTypeRepository] used to determine the display name for claims.
  * @param mdocCredential if set, the returned list is filtered so it only references data
- * elements available in the credential.
+ *     elements available in the credential.
+ * @param requesterAppId the appId if an app is making the request or `null`.
+ * @param requesterWebsiteOrigin the website origin if a website is making the request or `null`.
  */
 fun DeviceRequestParser.DocRequest.toMdocRequest(
     documentTypeRepository: DocumentTypeRepository,
     mdocCredential: MdocCredential?,
+    requesterAppId: String? = null,
+    requesterWebsiteOrigin: String? = null,
 ): MdocRequest {
     val requestedData = mutableMapOf<String, MutableList<Pair<String, Boolean>>>()
     for (namespaceName in namespaces) {
@@ -688,7 +692,9 @@ fun DeviceRequestParser.DocRequest.toMdocRequest(
                 readerCertificateChain
             } else {
                 null
-            }
+            },
+            appId = requesterAppId,
+            websiteOrigin = requesterWebsiteOrigin
         ),
         claims = MdocUtil.generateClaims(
             docType,

--- a/identity/src/androidMain/kotlin/com/android/identity/biometric/showBiometricPrompt.kt
+++ b/identity/src/androidMain/kotlin/com/android/identity/biometric/showBiometricPrompt.kt
@@ -1,0 +1,188 @@
+package com.android.identity.biometric
+
+import android.os.Handler
+import android.os.Looper
+import androidx.biometric.BiometricManager
+import androidx.biometric.BiometricPrompt
+import androidx.biometric.BiometricPrompt.CryptoObject
+import androidx.biometric.BiometricPrompt.PromptInfo
+import androidx.core.content.ContextCompat
+import androidx.fragment.app.FragmentActivity
+import com.android.identity.android.securearea.UserAuthenticationType
+import com.android.identity.util.AndroidContexts
+import com.android.identity.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.resumeWithException
+
+private const val TAG = "showBiometricPrompt"
+
+/**
+ * Prompts user for authentication.
+ *
+ * @param cryptoObject optional [CryptoObject] to be associated with the authentication.
+ * @param title the title for the authentication prompt.
+ * @param subtitle the subtitle for the authentication prompt.
+ * @param userAuthenticationTypes the set of allowed user authentication types, must contain at least one element.
+ * @param requireConfirmation set to `true` to require explicit user confirmation after presenting passive biometric.
+ * @return `true` if authentication succeed, `false` if the user dismissed the prompt.
+ */
+@OptIn(ExperimentalCoroutinesApi::class)
+suspend fun showBiometricPrompt(
+    cryptoObject: CryptoObject?,
+    title: String,
+    subtitle: String,
+    userAuthenticationTypes: Set<UserAuthenticationType>,
+    requireConfirmation: Boolean,
+): Boolean {
+    // BiometricPrompt must be called from the UI thread.
+    return withContext(Dispatchers.Main) {
+        suspendCancellableCoroutine { continuation ->
+            showBiometricPromptAsync(
+                cryptoObject = cryptoObject,
+                title = title,
+                subtitle = subtitle,
+                userAuthenticationTypes = userAuthenticationTypes,
+                requireConfirmation = requireConfirmation,
+                onSuccess = { continuation.resume(true, null) },
+                onDismissed = { continuation.resume(false, null) },
+                onError = { error -> continuation.resumeWithException(error) },
+            )
+        }
+    }
+}
+
+private fun showBiometricPromptAsync(
+    title: String,
+    subtitle: String,
+    cryptoObject: CryptoObject?,
+    userAuthenticationTypes: Set<UserAuthenticationType>,
+    requireConfirmation: Boolean,
+    onSuccess: () -> Unit,
+    onDismissed: () -> Unit,
+    onError: (error: Throwable) -> Unit,
+) {
+    val activity = AndroidContexts.currentActivity ?: throw IllegalStateException("No activity in AndroidContexts")
+    if (userAuthenticationTypes.isEmpty()) {
+        onError(
+            IllegalStateException(
+                "userAuthenticationTypes must contain at least one authentication type"
+            )
+        )
+    }
+    ShowBiometricPrompt(
+        activity = activity,
+        title = title,
+        subtitle = subtitle,
+        cryptoObject = cryptoObject,
+        userAuthenticationTypes = userAuthenticationTypes,
+        requireConfirmation = requireConfirmation,
+        onSuccess = onSuccess,
+        onDismissed = onDismissed,
+        onError = onError
+    ).authenticate()
+}
+
+private class ShowBiometricPrompt(
+    private val activity: FragmentActivity,
+    private val title: String,
+    private val subtitle: String,
+    private val cryptoObject: CryptoObject?,
+    private val userAuthenticationTypes: Set<UserAuthenticationType>,
+    private val requireConfirmation: Boolean,
+    private val onSuccess: () -> Unit,
+    private val onDismissed: () -> Unit,
+    private val onError: (Throwable) -> Unit,
+) {
+    private var lskfOnNegativeBtn: Boolean = false
+
+    private val biometricAuthCallback = object : BiometricPrompt.AuthenticationCallback() {
+        override fun onAuthenticationError(
+            errorCode: Int,
+            errorString: CharSequence
+        ) {
+            super.onAuthenticationError(errorCode, errorString)
+            if (setOf(
+                    BiometricPrompt.ERROR_NEGATIVE_BUTTON,
+                    BiometricPrompt.ERROR_NO_BIOMETRICS,
+                    BiometricPrompt.ERROR_UNABLE_TO_PROCESS
+                ).contains(errorCode) && lskfOnNegativeBtn
+            ) {
+                // if no delay is injected, then biometric prompt's auth callbacks would not be called
+                Handler(Looper.getMainLooper()).postDelayed({
+                    authenticateLskf()
+                }, 100)
+            } else if (errorCode == BiometricPrompt.ERROR_USER_CANCELED) {
+                onDismissed()
+            } else if (errorCode == BiometricPrompt.ERROR_NEGATIVE_BUTTON && !lskfOnNegativeBtn) {
+                onDismissed()
+            } else {
+                onError(IllegalStateException("onAuthenticationError callback with code $errorCode: $errorString"))
+            }
+        }
+
+        override fun onAuthenticationSucceeded(
+            result: BiometricPrompt.AuthenticationResult
+        ) {
+            super.onAuthenticationSucceeded(result)
+            onSuccess()
+        }
+    }
+
+    private val biometricPrompt = BiometricPrompt(
+        activity,
+        ContextCompat.getMainExecutor(activity),
+        biometricAuthCallback
+    )
+
+    fun authenticate() {
+        lskfOnNegativeBtn = userAuthenticationTypes.contains(UserAuthenticationType.LSKF)
+        if (userAuthenticationTypes.contains(UserAuthenticationType.BIOMETRIC)) {
+            authenticateBiometric()
+        } else {
+            authenticateLskf()
+        }
+    }
+
+    private fun authenticateBiometric() {
+        val negativeTxt =
+            if (lskfOnNegativeBtn) {
+                activity.applicationContext.resources.getString(R.string.biometric_prompt_negative_btn_lskf)
+            }
+            else {
+                activity.applicationContext.resources.getString(R.string.biometric_prompt_negative_btn_no_lskf)
+            }
+
+        val biometricPromptInfo = PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setNegativeButtonText(negativeTxt)
+            .setConfirmationRequired(requireConfirmation)
+            .build()
+
+        if (cryptoObject != null) {
+            biometricPrompt.authenticate(biometricPromptInfo, cryptoObject)
+        } else {
+            biometricPrompt.authenticate(biometricPromptInfo)
+        }
+    }
+
+    private fun authenticateLskf() {
+        lskfOnNegativeBtn = false
+
+        val lskfPromptInfo = PromptInfo.Builder()
+            .setTitle(title)
+            .setSubtitle(subtitle)
+            .setAllowedAuthenticators(BiometricManager.Authenticators.DEVICE_CREDENTIAL)
+            .setConfirmationRequired(requireConfirmation)
+            .build()
+
+        if (cryptoObject != null) {
+            biometricPrompt.authenticate(lskfPromptInfo, cryptoObject)
+        } else {
+            biometricPrompt.authenticate(lskfPromptInfo)
+        }
+    }
+}

--- a/identity/src/androidMain/res/values/strings.xml
+++ b/identity/src/androidMain/res/values/strings.xml
@@ -2,4 +2,20 @@
     <!-- NfcTagReaderModalBottomSheet -->
     <string name="nfc_tag_reader_modal_bottom_sheet_ready_to_scan">Ready to Scan</string>
 
+    <!-- showBiometricPrompt -->
+    <string name="biometric_prompt_negative_btn_lskf">Use PIN</string>
+    <string name="biometric_prompt_negative_btn_no_lskf">Cancel</string>
+
+    <!-- AndroidKeystoreSecureArea -->
+    <string name="aks_auth_default_title">Verify it\'s you</string>
+    <string name="aks_auth_default_subtitle">Authentication is required to share the document</string>
+
+    <!-- CloudSecureArea -->
+    <string name="csa_auth_default_title">Verify it\'s you</string>
+    <string name="csa_auth_default_subtitle_pin">Enter the PIN associated with the document</string>
+    <string name="csa_auth_default_subtitle_passphrase">Enter the passphrase associated with the document</string>
+    <string name="csa_auth_wrong_pin">Wrong PIN entered. Try again</string>
+    <string name="csa_auth_wrong_passphrase">Wrong passphrase entered. Try again</string>
+    <string name="csa_auth_too_many_attempts">Too many attempts. Try again later</string>
+
 </resources>

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyAttestation.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyAttestation.kt
@@ -15,7 +15,7 @@ import com.android.identity.crypto.X509CertChain
  * support attestation.
  *
  * @param publicKey the key that the attestation is for.
- * @param certChain If set, this contains  X.509 certificate chain attesting to the key.
+ * @param certChain If set, this contains a X.509 certificate chain attesting to the key.
  */
 @CborSerializable
 data class KeyAttestation(

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyInfo.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyInfo.kt
@@ -8,6 +8,7 @@ import com.android.identity.crypto.EcPublicKey
  * Concrete [SecureArea] implementations may subclass this to provide additional
  * implementation-specific information about the key.
  *
+ * @param alias the alias for the key.
  * @param publicKey the public part of the key.
  * @param keyPurposes the purposes of the key.
  * @param attestation the attestation for the key.

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyUnlockInteractive.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyUnlockInteractive.kt
@@ -1,0 +1,19 @@
+package com.android.identity.securearea
+
+/**
+ * A [KeyUnlockData] which will automatically show dialogs to interact with the user.
+ *
+ * This can be passed to [SecureArea.sign] and [SecureArea.keyAgreement] to automatically
+ * prompt the user for authentication. Depending on the Secure Area implementation this uses
+ * either platform native dialogs (for biometric unlock) or the [PassphrasePromptModel]
+ * mechanism.
+ *
+ * @property title the title to show in the authentication prompt or `null` to use default.
+ * @property subtitle the subtitle to show in the authentication prompt or `null` to use default.
+ * @property requireConfirmation if `true`, require active user confirmation if used for passive biometrics.
+ */
+class KeyUnlockInteractive(
+    val title: String? = null,
+    val subtitle: String? = null,
+    val requireConfirmation: Boolean = false,
+): KeyUnlockData

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/PassphrasePromptModel.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/PassphrasePromptModel.kt
@@ -1,0 +1,63 @@
+package com.android.identity.securearea
+
+import com.android.identity.util.Logger
+
+/**
+ * A model for requesting passphrases from the user.
+ *
+ * This bridges the low-level library with the UI layer of an application. See the
+ * [com.android.identity.appsupport.ui.passphrase.PassphrasePromptProvider] composable
+ * for an example.
+ */
+object PassphrasePromptModel {
+    private const val TAG = "PassphrasePromptModel"
+
+    // No locking needed since calls should only come from the UI thread.
+    //
+    private var currentView: PassphrasePromptView? = null
+
+    fun registerView(view: PassphrasePromptView) {
+        if (currentView != null) {
+            Logger.e(TAG, "Trying to register view, but another view which will be replaced is active: $currentView")
+        }
+        currentView = view
+    }
+
+    fun unregisterView(view: PassphrasePromptView) {
+        if (currentView != view) {
+            Logger.e(TAG, "Trying to unregister but another view is active: $currentView")
+            return
+        }
+        currentView = null
+    }
+
+    /**
+     * Requests that the UI layer should ask the user for a passphrase.
+     *
+     * If [passphraseEvaluator] is not `null`, it is called every time the user inputs a passphrase with
+     * the passphrase that was entered. It should return `null` to indicate the passphrase is correct
+     * otherwise a short message which is displayed in prompt indicating the user entered the wrong passphrase
+     * and optionally how many attempts are remaining.
+     *
+     * @param title the title for the passphrase prompt.
+     * @param subtitle the subtitle for the passphrase prompt.
+     * @param passphraseConstraints the [PassphraseConstraints] for the passphrase.
+     * @param passphraseEvaluator an optional function to evaluate the passphrase and give the user feedback.
+     * @return the passphrase entered by the user or `null` if the user dismissed the prompt.
+     * @throws PassphrasePromptViewNotAvailableException if the UI layer hasn't registered any viewer.
+     */
+    suspend fun requestPassphrase(
+        title: String,
+        subtitle: String,
+        passphraseConstraints: PassphraseConstraints,
+        passphraseEvaluator: (suspend (enteredPassphrase: String) -> String?)?
+    ): String? {
+        currentView?.let {
+            return it.requestPassphrase(title, subtitle, passphraseConstraints, passphraseEvaluator)
+        }
+        throw PassphrasePromptViewNotAvailableException(
+            "No PassphrasePromptView registered. " +
+                    "Is PassphrasePromptProvider() or similar included in the current composition?"
+        )
+    }
+}

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/PassphrasePromptView.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/PassphrasePromptView.kt
@@ -1,0 +1,27 @@
+package com.android.identity.securearea
+
+/**
+ * An interface that the UI layer can implement to display passphrase prompt dialogs.
+ *
+ * See the [com.android.identity.appsupport.ui.passphrase.PassphrasePromptProvider] composable
+ * for an example.
+ */
+interface PassphrasePromptView {
+    /**
+     * Called when the UI layer should ask the user for a passphrase.
+     *
+     * See [PassphrasePromptModel.requestPassphrase] for more details on how [passphraseEvaluator].
+     *
+     * @param title the title for the passphrase prompt.
+     * @param subtitle the subtitle for the passphrase prompt.
+     * @param passphraseConstraints the [PassphraseConstraints] for the passphrase.
+     * @param passphraseEvaluator an optional function to evaluate the passphrase and give the user feedback.
+     * @return the passphrase entered by the user or `null` if the user dismissed the prompt.
+     */
+    suspend fun requestPassphrase(
+        title: String,
+        subtitle: String,
+        passphraseConstraints: PassphraseConstraints,
+        passphraseEvaluator: (suspend (enteredPassphrase: String) -> String?)?
+    ): String?
+}

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/PassphrasePromptViewNotAvailableException.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/PassphrasePromptViewNotAvailableException.kt
@@ -1,0 +1,6 @@
+package com.android.identity.securearea
+
+/**
+ * Thrown if no [PassphrasePromptView] has registered with [PassphrasePromptModel].
+ */
+class PassphrasePromptViewNotAvailableException(message: String): Exception(message)

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/SecureArea.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/SecureArea.kt
@@ -28,8 +28,10 @@ import com.android.identity.crypto.EcSignature
  *
  * A Secure Area may require authentication before a key can be used and
  * this is modeled through the [KeyLockedException] and [KeyUnlockData]
- * types. Applications will need to use Secure-Area specific mechanisms
- * to obtain the required authentication.
+ * types. By default, [KeyUnlockInteractive] is used which handles user
+ * authentication out-of-band so the application will not have to worry
+ * about this except to ensure that their user interface can handle platform
+ * or local UI being shown to the user for authentication.
  *
  * Existing keys in a Secure Area may be invalidated and this can happen
  * on Android if e.g. the LSKF is removed or if a Cloud-based Secure Area
@@ -69,7 +71,7 @@ interface SecureArea {
      * @param createKeySettings A [CreateKeySettings] object.
      * @throws IllegalArgumentException if the underlying Secure Area Implementation
      * does not support the requested creation settings, for example the EC curve to use.
-     * @return key alias
+     * @return a [KeyInfo] with information about the key.
      */
     suspend fun createKey(alias: String?, createKeySettings: CreateKeySettings): KeyInfo
 
@@ -92,7 +94,8 @@ interface SecureArea {
      * @param alias The alias of the EC key to sign with.
      * @param signatureAlgorithm the signature algorithm to use.
      * @param dataToSign the data to sign.
-     * @param keyUnlockData data used to unlock the key or null.
+     * @param keyUnlockData data used to unlock the key, `null`, or a [KeyUnlockInteractive] to
+     *     handle user authentication automatically.
      * @return the signature.
      * @throws IllegalArgumentException if there is no key with the given alias
      * or the key wasn't created with purpose [KeyPurpose.SIGN].
@@ -104,7 +107,7 @@ interface SecureArea {
         alias: String,
         signatureAlgorithm: Algorithm,
         dataToSign: ByteArray,
-        keyUnlockData: KeyUnlockData?
+        keyUnlockData: KeyUnlockData? = KeyUnlockInteractive()
     ): EcSignature
 
     /**
@@ -116,7 +119,8 @@ interface SecureArea {
      *
      * @param alias the alias of the EC key to use.
      * @param otherKey The public EC key from the other party
-     * @param keyUnlockData data used to unlock the key or `null`.
+     * @param keyUnlockData data used to unlock the key, `null`, or a [KeyUnlockInteractive] to
+     *     handle user authentication automatically.
      * @return The shared secret.
      * @throws IllegalArgumentException if the other key isn't the same curve.
      * @throws IllegalArgumentException if there is no key with the given alias
@@ -127,7 +131,7 @@ interface SecureArea {
     suspend fun keyAgreement(
         alias: String,
         otherKey: EcPublicKey,
-        keyUnlockData: KeyUnlockData?
+        keyUnlockData: KeyUnlockData? = KeyUnlockInteractive()
     ): ByteArray
 
     /**

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/PlatformAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/PlatformAndroid.kt
@@ -3,7 +3,9 @@ package com.android.identity.testapp
 import android.os.Build
 import com.android.identity.android.securearea.AndroidKeystoreCreateKeySettings
 import com.android.identity.android.securearea.AndroidKeystoreSecureArea
+import com.android.identity.android.securearea.UserAuthenticationType
 import com.android.identity.securearea.CreateKeySettings
+import com.android.identity.securearea.KeyPurpose
 import com.android.identity.securearea.SecureArea
 import com.android.identity.util.AndroidContexts
 import com.android.identity.securearea.SecureAreaProvider
@@ -11,6 +13,7 @@ import com.android.identity.storage.Storage
 import com.android.identity.storage.android.AndroidStorage
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
 import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.io.File
 import java.net.NetworkInterface
@@ -66,8 +69,19 @@ actual fun platformSecureAreaProvider(): SecureAreaProvider<SecureArea> {
     return androidKeystoreSecureAreaProvider
 }
 
-actual fun platformKeySetting(clientId: String): CreateKeySettings {
-    return AndroidKeystoreCreateKeySettings.Builder(clientId.toByteArray()).build()
+actual fun platformCreateKeySettings(
+    challenge: ByteString,
+    keyPurposes: Set<KeyPurpose>,
+    userAuthenticationRequired: Boolean
+): CreateKeySettings {
+    return AndroidKeystoreCreateKeySettings.Builder(challenge.toByteArray())
+        .setKeyPurposes(keyPurposes)
+        .setUserAuthenticationRequired(
+            required = userAuthenticationRequired,
+            timeoutMillis = 0,
+            userAuthenticationTypes = setOf(UserAuthenticationType.LSKF, UserAuthenticationType.BIOMETRIC)
+        )
+        .build()
 }
 
 // https://stackoverflow.com/a/21505193/878126

--- a/samples/testapp/src/commonMain/composeResources/values/strings.xml
+++ b/samples/testapp/src/commonMain/composeResources/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="secure_enclave_secure_area_screen_title">Secure Enclave Secure Area</string>
     <string name="cloud_secure_area_screen_title">Cloud Secure Area</string>
     <string name="passphrase_entry_field_screen_title">PassphraseEntryField use-cases</string>
+    <string name="passphrase_prompt_screen_title">PassphrasePrompt use-cases</string>
     <string name="consent_modal_bottom_sheet_screen_title">ConsentModalBottomSheet</string>
     <string name="consent_modal_bottom_sheet_list_screen_title">ConsentModalBottomSheet use-cases</string>
     <string name="qr_codes_screen_title">QR code generation and scanning</string>

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Destinations.kt
@@ -21,6 +21,7 @@ import identitycredential.samples.testapp.generated.resources.secure_enclave_sec
 import identitycredential.samples.testapp.generated.resources.software_secure_area_screen_title
 import identitycredential.samples.testapp.generated.resources.start_screen_title
 import identitycredential.samples.testapp.generated.resources.certificate_viewer_title
+import identitycredential.samples.testapp.generated.resources.passphrase_prompt_screen_title
 import identitycredential.samples.testapp.generated.resources.settings_screen_title
 import org.jetbrains.compose.resources.StringResource
 
@@ -67,6 +68,11 @@ data object CloudSecureAreaDestination : Destination {
 data object PassphraseEntryFieldDestination : Destination {
     override val route = "passphrase_entry_field"
     override val title = Res.string.passphrase_entry_field_screen_title
+}
+
+data object PassphrasePromptDestination : Destination {
+    override val route = "passphrase_prompt"
+    override val title = Res.string.passphrase_prompt_screen_title
 }
 
 data object ProvisioningTestDestination : Destination {
@@ -145,6 +151,7 @@ val appDestinations = listOf(
     SecureEnclaveSecureAreaDestination,
     CloudSecureAreaDestination,
     PassphraseEntryFieldDestination,
+    PassphrasePromptDestination,
     ProvisioningTestDestination,
     ConsentModalBottomSheetListDestination,
     ConsentModalBottomSheetDestination,

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
@@ -1,9 +1,11 @@
 package com.android.identity.testapp
 
 import com.android.identity.securearea.CreateKeySettings
+import com.android.identity.securearea.KeyPurpose
 import com.android.identity.securearea.SecureArea
 import com.android.identity.securearea.SecureAreaProvider
 import com.android.identity.storage.Storage
+import kotlinx.io.bytestring.ByteString
 
 enum class Platform(val displayName: String) {
     ANDROID("Android"),
@@ -20,6 +22,20 @@ expect val platformIsEmulator: Boolean
 
 expect fun platformStorage(): Storage
 
+/**
+ * Gets a provider for the preferred [SecureArea] implementation for the platform.
+ */
 expect fun platformSecureAreaProvider(): SecureAreaProvider<SecureArea>
 
-expect fun platformKeySetting(clientId: String): CreateKeySettings
+/**
+ * Gets a [CreateKeySettings] object for creating auth-bound keys that works with the [SecureArea] returned
+ * returned by [platformSecureAreaProvider].
+ *
+ * @param challenge the challenge to use in the generated attestation, if the [SecureArea] supports that.
+ * @param userAuthenticationRequired set to `true` to require user authentication, `false` otherwise.
+ */
+expect fun platformCreateKeySettings(
+    challenge: ByteString,
+    keyPurposes: Set<KeyPurpose>,
+    userAuthenticationRequired: Boolean
+): CreateKeySettings

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppPresentmentSource.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppPresentmentSource.kt
@@ -63,7 +63,7 @@ private suspend fun mdocFindCredentialsForRequest(
     val result = mutableListOf<Credential>()
 
     if (preSelectedDocument != null) {
-        val credential = mdocFindCredentialInDocument(request, now, preSelectedDocument)
+        val credential = mdocFindCredentialInDocument(app, request, now, preSelectedDocument)
         if (credential != null) {
             result.add(credential)
             return result
@@ -72,7 +72,7 @@ private suspend fun mdocFindCredentialsForRequest(
 
     for (documentName in app.documentStore.listDocuments()) {
         val document = app.documentStore.lookupDocument(documentName) ?: continue
-        val credential = mdocFindCredentialInDocument(request, now, document)
+        val credential = mdocFindCredentialInDocument(app, request, now, document)
         if (credential != null) {
             result.add(credential)
         }
@@ -81,14 +81,20 @@ private suspend fun mdocFindCredentialsForRequest(
 }
 
 private fun mdocFindCredentialInDocument(
+    app: App,
     request: MdocRequest,
     now: Instant,
     document: Document,
 ): Credential? {
+    val domain = if (app.settingsModel.presentmentRequireAuthentication.value) {
+        TestAppUtils.MDOC_CREDENTIAL_DOMAIN_AUTH
+    } else {
+        TestAppUtils.MDOC_CREDENTIAL_DOMAIN_NO_AUTH
+    }
     for (credential in document.certifiedCredentials) {
         if (credential is MdocCredential && credential.docType == request.docType) {
             val credential = document.findCredential(
-                domain = TestAppUtils.MDOC_AUTH_KEY_DOMAIN,
+                domain = domain,
                 now = now
             )
             if (credential != null) {

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
@@ -8,6 +8,7 @@ import com.android.identity.storage.Storage
 import com.android.identity.storage.StorageTable
 import com.android.identity.storage.StorageTableSpec
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -80,7 +81,7 @@ class TestAppSettingsModel private constructor(
         variable.value = value
 
         if (!readOnly) {
-            CoroutineScope(currentCoroutineContext()).launch {
+            CoroutineScope(Dispatchers.Default).launch {
                 variable.asStateFlow().collect { newValue ->
                     val dataItem = when (defaultValue) {
                         is Boolean -> {
@@ -130,6 +131,7 @@ class TestAppSettingsModel private constructor(
             )
         )
         bind(presentmentShowConsentPrompt, "presentmentShowConsentPrompt", true)
+        bind(presentmentRequireAuthentication, "presentmentRequireAuthentication", true)
 
         bind(readerBleCentralClientModeEnabled, "readerBleCentralClientModeEnabled", true)
         bind(readerBlePeripheralServerModeEnabled, "readerBlePeripheralServerModeEnabled", true)
@@ -147,6 +149,7 @@ class TestAppSettingsModel private constructor(
     val presentmentAllowMultipleRequests = MutableStateFlow<Boolean>(false)
     val presentmentNegotiatedHandoverPreferredOrder = MutableStateFlow<List<String>>(listOf())
     val presentmentShowConsentPrompt = MutableStateFlow<Boolean>(false)
+    val presentmentRequireAuthentication = MutableStateFlow<Boolean>(false)
 
     val readerBleCentralClientModeEnabled = MutableStateFlow<Boolean>(false)
     val readerBlePeripheralServerModeEnabled = MutableStateFlow<Boolean>(false)

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreen.kt
@@ -3,4 +3,7 @@ package com.android.identity.testapp.ui
 import androidx.compose.runtime.Composable
 
 @Composable
-expect fun AndroidKeystoreSecureAreaScreen(showToast: (message: String) -> Unit)
+expect fun AndroidKeystoreSecureAreaScreen(
+    showToast: (message: String) -> Unit,
+    onViewCertificate: (encodedCertificateData: String) -> Unit
+)

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CertificateViewerExamplesScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CertificateViewerExamplesScreen.kt
@@ -18,7 +18,9 @@ import com.android.identity.util.fromHex
 import com.android.identity.util.toBase64Url
 
 @Composable
-fun CertificateViewerExamplesScreen(navController: NavHostController) {
+fun CertificateViewerExamplesScreen(
+    onViewCertificate: (encodedCertificateData: String) -> Unit
+) {
     val samplesData = getCertificateExamplesList()
     LazyColumn(
         modifier = Modifier
@@ -27,9 +29,7 @@ fun CertificateViewerExamplesScreen(navController: NavHostController) {
     ) {
         items(samplesData.keys.toList()) { title ->
             TextButton(
-                onClick = { navController.navigate(
-                    "${CertificateViewerDestination.route}/${samplesData[title]}")
-                },
+                onClick = { onViewCertificate(samplesData[title]!!) },
                 content = { Text(title) }
             )
         }

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
@@ -3,4 +3,7 @@ package com.android.identity.secure_area_test_app.ui
 import androidx.compose.runtime.Composable
 
 @Composable
-expect fun CloudSecureAreaScreen(showToast: (message: String) -> Unit)
+expect fun CloudSecureAreaScreen(
+    showToast: (message: String) -> Unit,
+    onViewCertificate: (encodedCertificateData: String) -> Unit
+)

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PassphraseEntryFieldScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PassphraseEntryFieldScreen.kt
@@ -77,14 +77,14 @@ fun PassphraseEntryFieldScreen(
             item {
                 TextButton(
                     onClick = { showEntry.value = Pair(PassphraseConstraints.PASSPHRASE_SIX_CHARS, checkWeakPassphrase)},
-                    content = { Text("Passphrase Six Characters (checkWeak=$checkWeakPassphrase)") }
+                    content = { Text("6-Character Passphrase (checkWeak=$checkWeakPassphrase)") }
                 )
             }
             item {
                 TextButton(
                     onClick = {
                         showEntry.value = Pair(PassphraseConstraints.PASSPHRASE_SIX_CHARS_OR_LONGER, checkWeakPassphrase)},
-                    content = { Text("Passphrase Six Characters or longer (checkWeak=$checkWeakPassphrase)") }
+                    content = { Text("6-Character Passphrase or longer (checkWeak=$checkWeakPassphrase)") }
                 )
             }
             item {

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PassphrasePromptScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/PassphrasePromptScreen.kt
@@ -1,0 +1,158 @@
+package com.android.identity.testapp.ui
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import com.android.identity.appsupport.ui.passphrase.PassphrasePromptBottomSheet
+import com.android.identity.securearea.PassphraseConstraints
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+@Composable
+fun PassphrasePromptScreen(
+    showToast: (message: String) -> Unit
+) {
+    val showPrompt = remember {
+        mutableStateOf<Pair<PassphraseConstraints, String>?>(null)
+    }
+
+    if (showPrompt.value != null) {
+        val constraints = showPrompt.value!!.first
+        val expectedPassphrase = showPrompt.value!!.second
+        val numWrongTries = remember { mutableStateOf(0) }
+        showPassphrasePrompt(
+            constraints = constraints,
+            expectedPassphrase = expectedPassphrase,
+            onDismissRequest = {
+                showPrompt.value = null
+            },
+            onPassphraseEntered = { passphrase ->
+                if (passphrase == expectedPassphrase) {
+                    showPrompt.value = null
+                    if (constraints.requireNumerical) {
+                        showToast("The expected PIN was entered")
+                    } else {
+                        showToast("The expected passphrase was entered")
+                    }
+                    null
+                } else {
+                    val numAttemptsLeft = 3 - numWrongTries.value
+                    if (numAttemptsLeft == 0) {
+                        if (constraints.requireNumerical) {
+                            showToast("Too many wrong PINs attempted")
+                        } else {
+                            showToast("Too many wrong passphrases attempted")
+                        }
+                        showPrompt.value = null
+                        null
+                    } else {
+                        numWrongTries.value = numWrongTries.value + 1
+                        val attemptsMessage = if (numAttemptsLeft == 1) {
+                            "This is your final attempt before you are locked out"
+                        } else {
+                            "$numAttemptsLeft attempts left before you are locked out"
+                        }
+                        if (constraints.requireNumerical) {
+                            "Wrong PIN entered. $attemptsMessage"
+                        } else {
+                            "Wrong passphrase entered. $attemptsMessage"
+                        }
+                    }
+                }
+            })
+    }
+    
+    LazyColumn(
+        modifier = Modifier.padding(8.dp)
+    ) {
+        item {
+            TextButton(
+                onClick = { showPrompt.value = Pair(PassphraseConstraints.PIN_FOUR_DIGITS, "1111") },
+                content = { Text("4-Digit PIN") }
+            )
+        }
+        item {
+            TextButton(
+                onClick = { showPrompt.value = Pair(PassphraseConstraints.PIN_FOUR_DIGITS_OR_LONGER, "11111") },
+                content = { Text("4-Digit PIN or longer") }
+            )
+        }
+        item {
+            TextButton(
+                onClick = { showPrompt.value = Pair(PassphraseConstraints.PIN_SIX_DIGITS, "123456") },
+                content = { Text("6-Digit PIN") }
+            )
+        }
+        item {
+            TextButton(
+                onClick = { showPrompt.value = Pair(PassphraseConstraints.PIN_SIX_DIGITS_OR_LONGER, "1234567") },
+                content = { Text("6-Digit PIN or longer") }
+            )
+        }
+        item {
+            TextButton(
+                onClick = { showPrompt.value = Pair(PassphraseConstraints.PASSPHRASE_SIX_CHARS, "abcdef") },
+                content = { Text("6-Character Passphrase") }
+            )
+        }
+        item {
+            TextButton(
+                onClick = {
+                    showPrompt.value = Pair(PassphraseConstraints.PASSPHRASE_SIX_CHARS_OR_LONGER, "axaxaxa") },
+                content = { Text("6-Character Passphrase or longer") }
+            )
+        }
+        item {
+            TextButton(
+                onClick = { showPrompt.value = Pair(PassphraseConstraints.NONE, "multipaz.org") },
+                content = { Text("No constraints") }
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+private fun showPassphrasePrompt(
+    constraints: PassphraseConstraints,
+    expectedPassphrase: String,
+    onDismissRequest: () -> Unit,
+    onPassphraseEntered: (passphrase: String) -> String?
+) {
+    // To avoid jank, we request the keyboard to be shown only when the sheet is fully expanded.
+    //
+    val showKeyboard = MutableStateFlow<Boolean>(false)
+    val sheetState = rememberModalBottomSheetState(
+        skipPartiallyExpanded = true,
+        confirmValueChange = { value ->
+            showKeyboard.value = true
+            true
+        }
+    )
+    PassphrasePromptBottomSheet(
+        sheetState = sheetState,
+        title = "Verifying Knowledge Factor",
+        subtitle = if (constraints.requireNumerical) {
+            "Enter your PIN to continue. " +
+            "It's '$expectedPassphrase' but also try entering " +
+            "something else to test see an error message"
+        } else {
+            "Enter your passphrase to continue. " +
+                    "It's '$expectedPassphrase' but also try entering " +
+                    "something else to test see an error message"
+        },
+        passphraseConstraints = constraints,
+        showKeyboard = showKeyboard.asStateFlow(),
+        onPassphraseEntered = onPassphraseEntered,
+        onDismissed = onDismissRequest,
+    )
+
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SettingsScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SettingsScreen.kt
@@ -210,6 +210,13 @@ fun SettingsScreen(
                 onCheckedChange = { app.settingsModel.presentmentShowConsentPrompt.value = !it },
             )
         }
+        item {
+            SettingToggle(
+                title = "Skip user authentication",
+                isChecked = !app.settingsModel.presentmentRequireAuthentication.collectAsState().value,
+                onCheckedChange = { app.settingsModel.presentmentRequireAuthentication.value = !it },
+            )
+        }
 
         item {
             HorizontalDivider(

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/StartScreen.kt
@@ -23,6 +23,7 @@ import identitycredential.samples.testapp.generated.resources.iso_mdoc_multi_dev
 import identitycredential.samples.testapp.generated.resources.iso_mdoc_proximity_reading_title
 import identitycredential.samples.testapp.generated.resources.iso_mdoc_proximity_sharing_title
 import identitycredential.samples.testapp.generated.resources.nfc_screen_title
+import identitycredential.samples.testapp.generated.resources.passphrase_prompt_screen_title
 import identitycredential.samples.testapp.generated.resources.provisioning_test_title
 import identitycredential.samples.testapp.generated.resources.qr_codes_screen_title
 import identitycredential.samples.testapp.generated.resources.secure_enclave_secure_area_screen_title
@@ -37,6 +38,7 @@ fun StartScreen(
     onClickCloudSecureArea: () -> Unit = {},
     onClickSecureEnclaveSecureArea: () -> Unit = {},
     onClickPassphraseEntryField: () -> Unit = {},
+    onClickPassphrasePrompt: () -> Unit = {},
     onClickIssuanceTestField: () -> Unit = {},
     onClickConsentSheetList: () -> Unit = {},
     onClickQrCodes: () -> Unit = {},
@@ -91,6 +93,12 @@ fun StartScreen(
             item {
                 TextButton(onClick = onClickPassphraseEntryField) {
                     Text(stringResource(Res.string.passphrase_entry_field_screen_title))
+                }
+            }
+
+            item {
+                TextButton(onClick = onClickPassphrasePrompt) {
+                    Text(stringResource(Res.string.passphrase_prompt_screen_title))
                 }
             }
 

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/MainViewController.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/MainViewController.kt
@@ -1,16 +1,9 @@
 package com.android.identity.testapp
 
 import androidx.compose.ui.window.ComposeUIViewController
-import kotlinx.coroutines.runBlocking
-import platform.UIKit.UIViewController
 
-private val app = App()
+private val app = App.getInstanceAndInitializeInBackground()
 
-fun MainViewController(): UIViewController {
-    runBlocking {
-        app.init()
-    }
-    return ComposeUIViewController {
-        app.Content()
-    }
+fun MainViewController() = ComposeUIViewController {
+    app.Content()
 }

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenIos.kt
@@ -3,5 +3,8 @@ package com.android.identity.testapp.ui
 import androidx.compose.runtime.Composable
 
 @Composable
-actual fun AndroidKeystoreSecureAreaScreen(showToast: (message: String) -> Unit) {
+actual fun AndroidKeystoreSecureAreaScreen(
+    showToast: (message: String) -> Unit,
+    onViewCertificate: (encodedCertificateData: String) -> Unit
+) {
 }

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreenIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreenIos.kt
@@ -4,5 +4,8 @@ import androidx.compose.runtime.Composable
 
 // This is Android-only for now.
 @Composable
-actual fun CloudSecureAreaScreen(showToast: (message: String) -> Unit) {
+actual fun CloudSecureAreaScreen(
+    showToast: (message: String) -> Unit,
+    onViewCertificate: (encodedCertificateData: String) -> Unit
+) {
 }


### PR DESCRIPTION
Introduce KeyUnlockInteractive which if passed to sign() and keyAgreement() on SecureArea will show the appropriate authentication prompts and generate the proper KeyUnlockData-derived objects. Add support for this in all four SecureArea implementations (Software, Android Keystore, iOS Secure Enclave, Cloud Secure Area) and port samples/testapp to use this both in the SecureArea specific screens and also in PresentmentModel and Presentment composable.

Also make KeyUnlockInteractive the default for SecureArea operations since it's a vastly simpler model for application programmers, compared to juggling KeyUnlockData objects and performing user authentication.

Introduce a PassphrasePromptModel mechanism for the core library to display passphrase prompt dialogs in the UI layer. This is required for the Software and Cloud Secure Area implementations of SecureArea when KeyUnlockInteractive is used.

Add PassphrasePromptBottomSheet composable (based on existing code in the wallet module) as well as a screen in samples/testapp that demoes it. Connect this implementation to the PassphrasePromptModel mechanism via the PassphrasePromptProvider composable.

Start using platform-specific Secure Areas for test documents in samples/testapp and use two domains so each document has a credential with user-authentication and one without. Add new "Skip user authentication" setting in samples/testapp and use this setting to pick the right domain in TestAppPresentmentSource.

Because of the new KeyUnlockInteractive, we now get the user authentication part for free in PresentmentModel / Presentment regardless of the Secure Area in use. In fact, a third party could create a SecureArea implementation (it's an open class and intended for this) and as long as they handle UI/UX interactions correctly things will just work without any changes.

In samples/testapp's screen for Android Keystore and Cloud Secure Areas, remove the dialogs for displaying certificate chains. Use the new Certificate Viewer screen instead.

Test: Tested on Android and iOS and all four SecureArea impl