### PR TITLE
CertificateViewer: Pretty-print Android Keystore attestation extension.

### DIFF
--- a/identity-appsupport/src/commonMain/composeResources/values/strings.xml
+++ b/identity-appsupport/src/commonMain/composeResources/values/strings.xml
@@ -32,8 +32,8 @@
     <string name="certificate_viewer_k_type">Type</string>
     <string name="certificate_viewer_k_serial_number">Serial Number</string>
     <string name="certificate_viewer_k_version">Version</string>
-    <string name="certificate_viewer_k_issued">Issued</string>
-    <string name="certificate_viewer_k_expired">Expired</string>
+    <string name="certificate_viewer_k_issued">Issued On</string>
+    <string name="certificate_viewer_k_expired">Expires On</string>
     <string name="certificate_viewer_sub_subject">Subject</string>
     <string name="certificate_viewer_sub_issuer">Issuer</string>
     <string name="certificate_viewer_k_country_name">Country Name</string>

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/certificateviewer/CertificateViewer.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/certificateviewer/CertificateViewer.kt
@@ -73,6 +73,7 @@ import kotlinx.datetime.Instant
 import org.jetbrains.compose.resources.StringResource
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
+import kotlin.math.max
 import kotlin.time.Duration.Companion.hours
 
 private val PAGER_INDICATOR_HEIGHT = 30.dp
@@ -238,10 +239,12 @@ private fun CertificateView(
                 stringResource(Res.string.certificate_viewer_k_pk_algorithm),
                 data.pkAlgorithm
             )
-            KeyValuePairLine(
-                stringResource(Res.string.certificate_viewer_k_pk_named_curve),
-                data.pkNamedCurve
-            )
+            if (data.pkNamedCurve != null) {
+                KeyValuePairLine(
+                    stringResource(Res.string.certificate_viewer_k_pk_named_curve),
+                    data.pkNamedCurve
+                )
+            }
             KeyValuePairLine(
                 stringResource(Res.string.certificate_viewer_k_pk_value),
                 data.pkValue
@@ -405,30 +408,16 @@ private fun WarningCard(text: String) {
     }
 }
 
-/**
- * Parse hierarchical output of the ASN1.print() to display it line by line with indentation of
- * 2dp (default) per space character in the original plain text indentation of each line.
- * That allows to precisely control the screen output indentation regardless of the font size/style
- * used in the app Theme, as well as preventing long lines wrapping to the start of the column.
- */
 @Composable
-private fun DisplayIndentedText(text: String, indentationStep: Dp = 12.dp) {
-    var indentationLevel = 0
-    var indentationSize = 0
+private fun DisplayIndentedText(text: String, indentationStep: Dp = 6.dp) {
     Column(Modifier.padding(start = indent[2])) {
         text.lines().forEach { line ->
-            line.takeWhile { it == ' ' }.length.let { spaceCount ->
-                when {
-                    spaceCount > indentationSize -> indentationLevel++
-                    spaceCount < indentationSize -> indentationLevel--
-                }
-                indentationSize = spaceCount
-                Text(
-                    modifier = Modifier.padding(start = indentationStep * indentationLevel),
-                    text = line.trimStart(),
-                    style = MaterialTheme.typography.bodyMedium
-                )
-            }
+            val numSpaces = max(0, line.indexOfFirst { it != ' ' })
+            Text(
+                modifier = Modifier.padding(start = indentationStep * numSpaces),
+                text = line.trimStart(),
+                style = MaterialTheme.typography.bodyMedium
+            )
         }
     }
 }


### PR DESCRIPTION
This adds support for pretty-printing the attestation extension from Android Keystore which is helpful as we may elect to provide a way to show these in the wallet app when the user elects to view detailed information about a document and its underlying ISO mdoc or IETF SD-JWT VC credentials.

Also address a couple of small things in CertificateViewer:

- Use "Issued On", "Expires On" instead of "Issued", "Expired"
- Use "X.509 Certificate" for the type, not just "X.509"
- Only sho Named Curve for EC keys
- Under Public Key Information the signature data in hex was shown instead of the actual key data. Show the ASN.1 bytes of SubjectPublicKeyInfo instead.
- Trim extension data fields to avoid spurious newlines
- Simplify DisplayIndentedText()

Test: Manually tested.
