### PR TITLE
testapp: Re-enable call to update Credman at start-up time.

### DIFF
--- a/identity-appsupport/src/androidMain/kotlin/com/android/identity/appsupport/ui/digitalcredentials/DigitalCredentials.android.kt
+++ b/identity-appsupport/src/androidMain/kotlin/com/android/identity/appsupport/ui/digitalcredentials/DigitalCredentials.android.kt
@@ -177,8 +177,7 @@ internal actual suspend fun defaultStartExportingCredentials(
         documentTypeRepository = documentTypeRepository,
         listeningJob = listeningJob,
     ))
-    // TODO: b/393388152 - new racing condition here (doc.metadata might be not initialized yet).
-    //updateCredman()
+    updateCredman()
 }
 
 internal actual suspend fun defaultStopExportingCredentials(


### PR DESCRIPTION
This is already fixed by commit 6ae69e3 ("Make Document storage table configurable in DocumentStore. (#869)") which wasn't in Alex's tree when he ran into this problem. It's safe to reeanble.

Test: Manually tested.
