### PR TITLE
Miscellaneous fixes.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
@@ -68,10 +68,9 @@ class VerifierApp : Application() {
             resources.openRawResource(R.raw.austroad_test_event_vical_20241002).readBytes()
         )
         for (certInfo in signedVical.vical.certificateInfos) {
-            val cert = X509Cert(certInfo.certificate)
             trustManagerInstance.addTrustPoint(
                 TrustPoint(
-                    cert,
+                    certInfo.certificate,
                     null,
                     null
                 )

--- a/identity-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.kt
+++ b/identity-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.kt
@@ -31,6 +31,7 @@ import com.android.identity.crypto.EcCurve
 import com.android.identity.crypto.toEcPublicKey
 import com.android.identity.securearea.KeyPurpose
 import com.android.identity.storage.android.AndroidStorage
+import com.android.identity.util.AndroidContexts
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Test
@@ -47,7 +48,8 @@ class MigrateFromKeystoreICStoreTest {
     fun testMigrateToCredentialStore() = runBlocking {
         val context = InstrumentationRegistry.getInstrumentation().targetContext
         val storage = AndroidStorage(":memory:")
-        val aksSecureArea = AndroidKeystoreSecureArea.create(context, storage)
+        AndroidContexts.setApplicationContext(context)
+        val aksSecureArea = AndroidKeystoreSecureArea.create(storage)
         val icStore = Utility.getIdentityCredentialStore(context)
 
         val noAuthProfile =

--- a/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/document/AndroidKeystoreSecureAreaDocumentStoreTest.kt
@@ -27,6 +27,7 @@ import com.android.identity.securearea.SecureAreaRepository
 import com.android.identity.storage.Storage
 import com.android.identity.storage.android.AndroidStorage
 import com.android.identity.util.AndroidAttestationExtensionParser
+import com.android.identity.util.AndroidContexts
 import kotlinx.coroutines.runBlocking
 import org.junit.Assert
 import org.junit.Before
@@ -46,10 +47,10 @@ class AndroidKeystoreSecureAreaDocumentStoreTest {
 
     @Before
     fun setup() {
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        AndroidContexts.setApplicationContext(InstrumentationRegistry.getInstrumentation().targetContext)
         storage = AndroidStorage(":memory:")
         secureAreaRepository = SecureAreaRepository.build {
-            add(AndroidKeystoreSecureArea.create(context, storage))
+            add(AndroidKeystoreSecureArea.create(storage))
         }
         credentialLoader = CredentialLoader()
         credentialLoader.addCredentialImplementation(SecureAreaBoundCredential::class) {

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
@@ -70,6 +70,7 @@ import com.android.identity.securearea.SecureAreaRepository
 import com.android.identity.securearea.software.SoftwareCreateKeySettings
 import com.android.identity.storage.Storage
 import com.android.identity.storage.android.AndroidStorage
+import com.android.identity.util.AndroidContexts
 import com.android.identity.util.Constants
 import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock.System.now
@@ -113,14 +114,11 @@ class DeviceRetrievalHelperTest {
         Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
         Security.addProvider(BouncyCastleProvider())
 
+        AndroidContexts.setApplicationContext(InstrumentationRegistry.getInstrumentation().targetContext)
+
         storage = AndroidStorage(":memory:")
         secureAreaRepository = SecureAreaRepository.build {
-            add(
-                AndroidKeystoreSecureArea.create(
-                    InstrumentationRegistry.getInstrumentation().targetContext,
-                    storage
-                )
-            )
+            add(AndroidKeystoreSecureArea.create(storage))
         }
         val credentialLoader = CredentialLoader()
         credentialLoader.addCredentialImplementation(MdocCredential::class) { document ->

--- a/identity-csa/src/main/java/com/android/identity/securearea/cloud/CloudSecureAreaServer.kt
+++ b/identity-csa/src/main/java/com/android/identity/securearea/cloud/CloudSecureAreaServer.kt
@@ -440,7 +440,11 @@ class CloudSecureAreaServer(
                 // Check that device created the key with the requested user authentication.
                 val attestation = AndroidAttestationExtensionParser(request1.localKeyAttestation!!.certificates[0])
                 if (state.userAuthenticationRequired) {
-                    check(attestation.getUserAuthenticationType() == state.userAuthenticationTypes)
+                    val attestationExtensionUserAuthType = attestation.getUserAuthenticationType()
+                    check(attestationExtensionUserAuthType == state.userAuthenticationTypes) {
+                        "Requested userAuthType ${state.userAuthenticationTypes} for the local key but the Android " +
+                        "attestation extension contains ${attestationExtensionUserAuthType}"
+                    }
                 } else {
                     check(attestation.getUserAuthenticationType() == 0L)
                 }

--- a/identity-mdoc/src/androidMain/kotlin/com/android/identity/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/identity-mdoc/src/androidMain/kotlin/com/android/identity/mdoc/transport/BleCentralManagerAndroid.kt
@@ -138,6 +138,12 @@ internal class BleCentralManagerAndroid : BleCentralManager {
     private var characteristicIdent: BluetoothGattCharacteristic? = null
     private var characteristicL2cap: BluetoothGattCharacteristic? = null
 
+    init {
+        if (bluetoothManager.adapter == null) {
+            throw IllegalStateException("Bluetooth is not available on this device")
+        }
+    }
+
     private class ConnectionFailedException(
         message: String
     ) : Throwable(message)

--- a/identity-mdoc/src/androidMain/kotlin/com/android/identity/mdoc/transport/BlePeripheralManagerAndroid.kt
+++ b/identity-mdoc/src/androidMain/kotlin/com/android/identity/mdoc/transport/BlePeripheralManagerAndroid.kt
@@ -144,6 +144,12 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
     private var advertiser: BluetoothLeAdvertiser? = null
     private var device: BluetoothDevice? = null
 
+    init {
+        if (bluetoothManager.adapter == null) {
+            throw IllegalStateException("Bluetooth is not available on this device")
+        }
+    }
+
     private val gattServerCallback = object: BluetoothGattServerCallback() {
 
         override fun onServiceAdded(status: Int, service: BluetoothGattService?) {

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/vical/SignedVical.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/vical/SignedVical.kt
@@ -40,15 +40,13 @@ data class SignedVical(
     ): ByteArray {
         val certInfosBuilder = CborArray.builder()
         for (certInfo in vical.certificateInfos) {
-            val cert = X509Cert(certInfo.certificate)
-
             val docTypesBuilder = CborArray.builder()
             certInfo.docType.forEach { docTypesBuilder.add(it) }
 
             certInfosBuilder.addMap()
-                .put("certificate", certInfo.certificate)
-                .put("serialNumber", Tagged(2, Bstr(cert.serialNumber.value)))
-                .put("ski", cert.subjectKeyIdentifier!!)
+                .put("certificate", certInfo.certificate.encodedCertificate)
+                .put("serialNumber", Tagged(Tagged.UNSIGNED_BIGNUM, Bstr(certInfo.certificate.serialNumber.value)))
+                .put("ski", certInfo.certificate.subjectKeyIdentifier!!)
                 .put("docType", docTypesBuilder.end().build())
                 .end()
         }
@@ -135,7 +133,7 @@ data class SignedVical(
                     (it as CborArray).items.map { it.asTstr }
                 }
                 certificateInfos.add(VicalCertificateInfo(
-                    certBytes,
+                    X509Cert(certBytes),
                     docType,
                     certProfiles
                 ))

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/vical/VicalCertificateInfo.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/vical/VicalCertificateInfo.kt
@@ -1,14 +1,16 @@
 package com.android.identity.mdoc.vical
 
+import com.android.identity.crypto.X509Cert
+
 /**
  * An entry in a VICAL according to ISO/IEC 18013-5:2021.
  *
- * @property certificate the bytes of the X.509 certificate.
+ * @property certificate the X.509 certificate.
  * @property docType a list of document types for which the certificate may be used as a trust point.
  * @property certificateProfiles list of Uniform Resource Name (URN) according to RFC 8141, if available.
  */
 data class VicalCertificateInfo(
-    val certificate: ByteArray,
+    val certificate: X509Cert,
     val docType: List<String>,
     val certificateProfiles: List<String>?
 )

--- a/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/util/MdocUtilTest.kt
+++ b/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/util/MdocUtilTest.kt
@@ -327,22 +327,22 @@ class MdocUtilTest {
         )
         assertEquals(
             """
-            SEQUENCE (1 elem)
-              [6] (1 elem)
-                (29 byte) 687474703a2f2f7777772e6578616d706c652e636f6d2f697373756572
-            """.trimIndent(),
+                SEQUENCE (1 elem)
+                  [6] (1 elem)
+                    68 74 74 70 3a 2f 2f 77 77 77 2e 65 78 61 6d 70 6c 65 2e 63 6f 6d 2f 69 73 73 75 65 72 ("http://www.example.com/issuer")
+            """.trimIndent().trim(),
             ASN1.print(ASN1.decode(iacaCert.getExtensionValue(
                 OID.X509_EXTENSION_ISSUER_ALT_NAME.oid)!!)!!).trim()
         )
         assertEquals(
             """
-            SEQUENCE (1 elem)
-              SEQUENCE (1 elem)
-                [0] (1 elem)
-                  [0] (1 elem)
-                    [6] (1 elem)
-                      (33 byte) 687474703a2f2f7777772e6578616d706c652e636f6d2f6973737565722f63726c
-            """.trimIndent(),
+                SEQUENCE (1 elem)
+                  SEQUENCE (1 elem)
+                    [0] (1 elem)
+                      [0] (1 elem)
+                        [6] (1 elem)
+                          68 74 74 70 3a 2f 2f 77 77 77 2e 65 78 61 6d 70 6c 65 2e 63 6f 6d 2f 69 73 73 75 65 72 2f 63 72 6c ("http://www.example.com/issuer/crl")
+            """.trimIndent().trim(),
             ASN1.print(ASN1.decode(iacaCert.getExtensionValue(
                 OID.X509_EXTENSION_CRL_DISTRIBUTION_POINTS.oid)!!)!!).trim()
         )

--- a/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/vical/VicalGeneratorTest.kt
+++ b/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/vical/VicalGeneratorTest.kt
@@ -61,17 +61,17 @@ class VicalGeneratorTest {
                 vicalIssueID = vicalIssueID,
                 listOf(
                     VicalCertificateInfo(
-                        certificate = issuer1Cert.encodedCertificate,
+                        certificate = issuer1Cert,
                         docType = listOf("org.iso.18013.5.1.mDL"),
                         certificateProfiles = listOf("")
                     ),
                     VicalCertificateInfo(
-                        certificate = issuer2Cert.encodedCertificate,
+                        certificate = issuer2Cert,
                         docType = listOf("org.iso.18013.5.1.mDL"),
                         certificateProfiles = null
                     ),
                     VicalCertificateInfo(
-                        certificate = issuer3Cert.encodedCertificate,
+                        certificate = issuer3Cert,
                         docType = listOf("org.iso.18013.5.1.mDL", "eu.europa.ec.eudi.pid.1"),
                         certificateProfiles = null
                     ),
@@ -96,8 +96,8 @@ class VicalGeneratorTest {
         assertEquals(vicalIssueID, decodedSignedVical.vical.vicalIssueID)
         assertEquals(3, decodedSignedVical.vical.certificateInfos.size)
 
-        assertContentEquals(
-            issuer1Cert.encodedCertificate,
+        assertEquals(
+            issuer1Cert,
             decodedSignedVical.vical.certificateInfos[0].certificate
         )
         assertContentEquals(
@@ -106,8 +106,8 @@ class VicalGeneratorTest {
         )
         assertEquals(null, decodedSignedVical.vical.certificateInfos[0].certificateProfiles)
 
-        assertContentEquals(
-            issuer2Cert.encodedCertificate,
+        assertEquals(
+            issuer2Cert,
             decodedSignedVical.vical.certificateInfos[1].certificate
         )
         assertContentEquals(
@@ -116,8 +116,8 @@ class VicalGeneratorTest {
         )
         assertEquals(null, decodedSignedVical.vical.certificateInfos[1].certificateProfiles)
 
-        assertContentEquals(
-            issuer3Cert.encodedCertificate,
+        assertEquals(
+            issuer3Cert,
             decodedSignedVical.vical.certificateInfos[2].certificate
         )
         assertContentEquals(

--- a/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/vical/VicalParserTest.kt
+++ b/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/vical/VicalParserTest.kt
@@ -979,16 +979,15 @@ Mbff+DlHy77+wXISb35NiZ8FdVHgC2ut4fDQTRN4
 -----END CERTIFICATE-----
             """.trimIndent()
             ),
-            X509Cert(ci.certificate)
-        )
-        val ciCert = X509Cert(ci.certificate)
-        assertEquals(
-            "C=ZZ,CN=OWF Identity Credential TEST IACA",
-            ciCert.subject.name
+            ci.certificate
         )
         assertEquals(
             "C=ZZ,CN=OWF Identity Credential TEST IACA",
-            ciCert.issuer.name
+            ci.certificate.subject.name
+        )
+        assertEquals(
+            "C=ZZ,CN=OWF Identity Credential TEST IACA",
+            ci.certificate.issuer.name
         )
         assertEquals(
             "org.iso.18013.5.1.mDL, org.iso.23220.photoid.1, org.micov.1, org.iso.7367.1.mVRC",
@@ -1044,16 +1043,15 @@ A01EUDAKBggqhkjOPQQDAgNIADBFAiEAnX3+E4E5dQ+5G1rmStJTW79ZAiDTabyL
 -----END CERTIFICATE-----
             """.trimIndent()
             ),
-            X509Cert(ci.certificate)
-        )
-        val ciCert = X509Cert(ci.certificate)
-        assertEquals(
-            "CN=Fast Enterprises Root,O=Maryland MVA,L=Glen Burnie,C=US,ST=US-MD",
-            ciCert.subject.name
+            ci.certificate
         )
         assertEquals(
             "CN=Fast Enterprises Root,O=Maryland MVA,L=Glen Burnie,C=US,ST=US-MD",
-            ciCert.issuer.name
+            ci.certificate.subject.name
+        )
+        assertEquals(
+            "CN=Fast Enterprises Root,O=Maryland MVA,L=Glen Burnie,C=US,ST=US-MD",
+            ci.certificate.issuer.name
         )
         assertEquals(
             "org.iso.18013.5.1.mDL",

--- a/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/AndroidKeystoreSecureAreaTest.kt
+++ b/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/AndroidKeystoreSecureAreaTest.kt
@@ -35,6 +35,7 @@ import com.android.identity.securearea.KeyPurpose
 import com.android.identity.securearea.SecureAreaProvider
 import com.android.identity.storage.android.AndroidStorage
 import com.android.identity.util.AndroidAttestationExtensionParser
+import com.android.identity.util.AndroidContexts
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
 import org.bouncycastle.jce.provider.BouncyCastleProvider
@@ -66,11 +67,10 @@ class AndroidKeystoreSecureAreaTest {
         Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
         Security.addProvider(BouncyCastleProvider())
 
-
-        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        AndroidContexts.setApplicationContext(InstrumentationRegistry.getInstrumentation().targetContext)
         val storage = AndroidStorage(databasePath = null, clock = Clock.System)
         secureAreaProvider = SecureAreaProvider {
-            AndroidKeystoreSecureArea.create(context, storage)
+            AndroidKeystoreSecureArea.create(storage)
         }
     }
 

--- a/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/cloud/CloudSecureAreaTest.kt
+++ b/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/cloud/CloudSecureAreaTest.kt
@@ -163,9 +163,7 @@ class CloudSecureAreaTest {
     @Test
     fun testAttestationCorrectness() = runTest {
         // This test only works if a Device Lock is setup.
-        val aksCapabilities = AndroidKeystoreSecureArea.Capabilities(
-            AndroidContexts.applicationContext,
-        )
+        val aksCapabilities = AndroidKeystoreSecureArea.Capabilities()
         assumeTrue(aksCapabilities.secureLockScreenSetup)
 
         val csa = LoopbackCloudSecureArea(EphemeralStorage().getTable(tableSpec), null)

--- a/identity/src/androidMain/kotlin/com/android/identity/nfc/scanNfcTag.android.kt
+++ b/identity/src/androidMain/kotlin/com/android/identity/nfc/scanNfcTag.android.kt
@@ -74,7 +74,7 @@ private class NfcTagReader<T> {
         }
     }
 
-    private val adapter = NfcAdapter.getDefaultAdapter(AndroidContexts.applicationContext)
+    private val adapter: NfcAdapter? = NfcAdapter.getDefaultAdapter(AndroidContexts.applicationContext)
 
     private var continuation: CancellableContinuation<T>? = null
 
@@ -109,6 +109,9 @@ private class NfcTagReader<T> {
             updateMessage: (message: String) -> Unit
         ) -> T?,
     ): T? {
+        if (adapter == null) {
+            throw IllegalStateException("NFC is not supported on this device")
+        }
 
         if (disableReaderModeJob != null) {
             disableReaderModeJob!!.cancel()

--- a/identity/src/androidMain/kotlin/com/android/identity/securearea/cloud/CloudSecureArea.android.kt
+++ b/identity/src/androidMain/kotlin/com/android/identity/securearea/cloud/CloudSecureArea.android.kt
@@ -21,14 +21,14 @@ private val androidStorage: AndroidStorage by lazy {
 }
 
 private val androidKeystoreSecureAreaProvider = SecureAreaProvider {
-    AndroidKeystoreSecureArea.create(AndroidContexts.applicationContext, androidStorage)
+    AndroidKeystoreSecureArea.create(androidStorage)
 }
 
 internal actual suspend fun cloudSecureAreaGetPlatformSecureArea(
     storage: Storage,
     partitionId: String,
 ): SecureArea {
-    return AndroidKeystoreSecureArea.create(AndroidContexts.applicationContext, androidStorage)
+    return AndroidKeystoreSecureArea.create(androidStorage)
 }
 
 internal actual fun cloudSecureAreaGetPlatformSecureAreaCreateKeySettings(

--- a/identity/src/commonMain/kotlin/com/android/identity/asn1/ASN1.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/asn1/ASN1.kt
@@ -226,7 +226,7 @@ object ASN1 {
                 try {
                     sb.append("$label ${obj.toLong()}\n")
                 } catch (e: IllegalStateException) {
-                    sb.append("$label ${obj.value.toHex()}\n")
+                    sb.append("$label ${obj.value.toHex(byteDivider = " ")}\n")
                 }
             }
             is ASN1Null -> {
@@ -238,7 +238,8 @@ object ASN1 {
                 sb.append("\n")
             }
             is ASN1OctetString -> {
-                sb.append("OCTET STRING (${obj.value.size} byte) ${obj.value.toHex()}\n")
+                sb.append("OCTET STRING (${obj.value.size} byte) " +
+                        "${obj.value.toHex(byteDivider = " ", decodeAsString = true)}\n")
             }
             is ASN1BitString -> {
                 sb.append("BIT STRING (${obj.value.size*8 - obj.numUnusedBits} bit) ${obj.renderBitString()}\n")
@@ -305,12 +306,12 @@ object ASN1 {
                     for (n in IntRange(1, indent + 2)) {
                         sb.append(" ")
                     }
-                    sb.append("(${obj.content.size} byte) ${obj.content.toHex()}\n")
+                    sb.append(obj.content.toHex(byteDivider = " ", decodeAsString = true) + "\n")
                 }
             }
             is ASN1RawObject -> {
                 sb.append("UNSUPPORTED TAG class=${obj.cls} encoding=${obj.enc} ")
-                sb.append("tag=${obj.tag} value=${obj.content.toHex()}")
+                sb.append("tag=${obj.tag} value=${obj.content.toHex(byteDivider = " ", decodeAsString = true)}")
             }
             is ASN1PrimitiveValue -> {
                 //throw IllegalStateException()

--- a/identity/src/commonMain/kotlin/com/android/identity/asn1/OID.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/asn1/OID.kt
@@ -37,7 +37,7 @@ enum class OID(
     LOCALITY_NAME("2.5.4.7", "localityName (X.520 DN component)"),
     STATE_OR_PROVINCE_NAME("2.5.4.8", "stateOrProvinceName (X.520 DN component)"),
     ORGANIZATION_NAME("2.5.4.10", "organizationName (X.520 DN component)"),
-    ORGANIZATIONAL_UNIT_NAME("organizationalUnitName (X.520 DN component)", ""),
+    ORGANIZATIONAL_UNIT_NAME("2.5.4.11", "organizationalUnitName (X.520 DN component)"),
 
     X509_EXTENSION_KEY_USAGE("2.5.29.15", "keyUsage (X.509 extension)"),
     X509_EXTENSION_EXTENDED_KEY_USAGE("2.5.29.37", "extKeyUsage (X.509 extension)"),
@@ -47,6 +47,7 @@ enum class OID(
     X509_EXTENSION_ISSUER_ALT_NAME("2.5.29.18", "issuerAltName (X.509 extension)"),
     X509_EXTENSION_CRL_DISTRIBUTION_POINTS("2.5.29.31", "cRLDistributionPoints (X.509 extension)"),
     X509_EXTENSION_ANDROID_KEYSTORE_ATTESTATION("1.3.6.1.4.1.11129.2.1.17", "Android Keystore Key Attestation (X.509 extension)"),
+    X509_EXTENSION_ANDROID_KEYSTORE_PROVISIONING_INFORMATION("1.3.6.1.4.1.11129.2.1.30", "Android Keystore Provisioning Information (X.509 extension)"),
     X509_EXTENSION_MULTIPAZ_KEY_ATTESTATION("1.3.6.1.4.1.11129.2.1.49", "Multipaz Key Attestation (X.509 extension)"),
 
     ISO_18013_5_MDL_DS("1.0.18013.5.1.2", "Mobile Driving Licence (mDL) Document Signer (DS)"),
@@ -58,6 +59,33 @@ enum class OID(
             OID.entries.associateBy({it.oid}, {it})
         }
 
+        /**
+         * Checks if a given string is exists in the [OID] enumeration.
+         *
+         * @param oid the OID as a string in dotted-decimal notation.
+         * @return the entry in the [OID] enumeration or `null` if not found.
+         */
         fun lookupByOid(oid: String): OID? = stringToOid[oid]
+
+        /**
+         * Checks if a given string is encoded as an OID.
+         *
+         * @param `true` if encoded as a valid OID, `false` otherwise.
+         */
+        fun isOid(str: String): Boolean {
+            val components = str.split(".")
+            for (component in components) {
+                try {
+                    component.toLong(10)
+                } catch (_: Throwable) {
+                    return false
+                }
+            }
+            // First component must be 0, 1, or 2
+            return when (components[0]) {
+                "0", "1", "2" -> true
+                else -> false
+            }
+        }
     }
 }

--- a/identity/src/commonMain/kotlin/com/android/identity/cbor/Tagged.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/cbor/Tagged.kt
@@ -64,6 +64,22 @@ class Tagged(val tagNumber: Long, val taggedItem: DataItem) : DataItem(MajorType
          */
         const val DATE_TIME_NUMBER = 1L
 
+        /**
+         * Unsigned bignum.
+         *
+         * Bignums are encoded as a byte string data item, which is interpreted as an unsigned
+         * integer n in network byte order. Contained items of other types are invalid. For tag
+         * number 2, the value of the bignum is n.
+         */
+        const val UNSIGNED_BIGNUM = 2L
+
+        /**
+         * Negative bignum.
+         *
+         * For tag number 3, the value of the bignum is -1 - n. The preferred serialization of
+         * the byte string is to leave out any leading zeroes.
+         */
+        const val NEGATIVE_BIGNUM = 3L
 
         /**
          * Encoded CBOR data item.

--- a/identity/src/commonMain/kotlin/com/android/identity/crypto/X509Cert.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/crypto/X509Cert.kt
@@ -325,7 +325,6 @@ class X509Cert(
     val keyUsage: Set<X509KeyUsage>
         get() {
             val extVal = getExtensionValue(OID.X509_EXTENSION_KEY_USAGE.oid) ?: return emptySet()
-            check(criticalExtensionOIDs.contains(OID.X509_EXTENSION_KEY_USAGE.oid))
             return X509KeyUsage.decodeSet(ASN1.decode(extVal) as ASN1BitString)
         }
 

--- a/identity/src/commonMain/kotlin/com/android/identity/datetime/dateTimeUtils.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/datetime/dateTimeUtils.kt
@@ -1,0 +1,48 @@
+package com.android.identity.datetime
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+
+/**
+ * Styles used when formatting time or dates.
+ *
+ * Note that the style is a function of the platform the app is running on and
+ * might vary slightly from one platform to another or even on the same platform
+ * from one release to another. An app should not make any assumptions about the
+ * format.
+ */
+enum class FormatStyle {
+    /** Short style, typically numeric. */
+    SHORT,
+
+    /** Medium style with some detail. */
+    MEDIUM,
+
+    /** Long style with a lot of detail. */
+    LONG,
+
+    /** Full style with the most detail. */
+    FULL,
+}
+
+/**
+ * Formats a localized string representing a [LocalDate].
+ *
+ * @param dateStyle the amount of detail to include for the date.
+ * @return the localized string.
+ */
+expect fun LocalDate.formatLocalized(
+    dateStyle: FormatStyle = FormatStyle.MEDIUM,
+): String
+
+/**
+ * Formats a localized string representing a [LocalDateTime].
+ *
+ * @param dateStyle the amount of detail to include for the date component.
+ * @param timeStyle the amount of detail to include for the time component.
+ * @return the localized string.
+ */
+expect fun LocalDateTime.formatLocalized(
+    dateStyle: FormatStyle = FormatStyle.MEDIUM,
+    timeStyle: FormatStyle = FormatStyle.MEDIUM,
+): String

--- a/identity/src/commonMain/kotlin/com/android/identity/util/AndroidAttestationExtensionParser.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/util/AndroidAttestationExtensionParser.kt
@@ -350,15 +350,23 @@ class AndroidAttestationExtensionParser(cert: X509Cert) {
         )
         sb.append("\n\n")
         sb.append("Software Enforced Authorizations:\n")
-        for (tag in softwareEnforcedAuthorizationTags) {
-            val obj = getSoftwareAuthorizationValue(tag)
-            sb.append(renderAndroidKeystoreAuthorization(tag, obj))
+        if (softwareEnforcedAuthorizationTags.isEmpty()) {
+            sb.append("  <empty>")
+        } else {
+            for (tag in softwareEnforcedAuthorizationTags) {
+                val obj = getSoftwareAuthorizationValue(tag)
+                sb.append(renderAndroidKeystoreAuthorization(tag, obj))
+            }
         }
         sb.append("\n")
         sb.append("Hardware Enforced Authorizations:\n")
-        for (tag in teeEnforcedAuthorizationTags) {
-            val obj = getTeeAuthorizationValue(tag)
-            sb.append(renderAndroidKeystoreAuthorization(tag, obj))
+        if (teeEnforcedAuthorizationTags.isEmpty()) {
+            sb.append("  <empty>")
+        } else {
+            for (tag in teeEnforcedAuthorizationTags) {
+                val obj = getTeeAuthorizationValue(tag)
+                sb.append(renderAndroidKeystoreAuthorization(tag, obj))
+            }
         }
         return sb.toString()
     }

--- a/identity/src/commonMain/kotlin/com/android/identity/util/HexUtil.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/util/HexUtil.kt
@@ -12,16 +12,35 @@ object HexUtil {
      * @param bytes the byte array to encode.
      * @param upperCase if `true`, will use upper-case characters, otherwise lower-case is used.
      * @param byteDivider a string to separate bytes (hex pairs).
+     * @param decodeAsString if `true`, will include the value decoded as a string with only
+     *   printable characters.
      * @return a string with hexadecimal numbers optionally separated by [byteDivider].
      */
-    fun toHex(bytes: ByteArray, upperCase: Boolean = false, byteDivider: String = ""): String {
+    fun toHex(
+        bytes: ByteArray,
+        upperCase: Boolean = false,
+        byteDivider: String = "",
+        decodeAsString: Boolean = false
+    ): String {
         val sb = StringBuilder(bytes.size * 2)
         for (n in 0 until bytes.size) {
             val b = bytes[n]
             val digits = if (upperCase) HEX_DIGITS_UPPER else HEX_DIGITS_LOWER
+            if (n != 0) {
+                sb.append(byteDivider)
+            }
             sb.append(digits[b.toInt().and(0xff) shr 4])
             sb.append(digits[b.toInt().and(0x0f)])
-            sb.append(byteDivider)
+        }
+        if (decodeAsString) {
+            val str = bytes.decodeToString().map { char ->
+                if (char.isISOControl() || char.isWhitespace()) {
+                    '.'
+                } else {
+                    char
+                }
+            }.joinToString("")
+            sb.append(" (\"${str}\")")
         }
         return sb.toString()
     }
@@ -50,8 +69,8 @@ object HexUtil {
 /**
  * Extension to encode a [ByteArray] to a string with hexadecimal numbers.
  */
-fun ByteArray.toHex(upperCase: Boolean = false, byteDivider: String = ""): String =
-    HexUtil.toHex(this, upperCase = upperCase, byteDivider = byteDivider)
+fun ByteArray.toHex(upperCase: Boolean = false, byteDivider: String = "", decodeAsString: Boolean = false): String =
+    HexUtil.toHex(this, upperCase = upperCase, byteDivider = byteDivider, decodeAsString = decodeAsString)
 
 /**
  * Extension to decode a [ByteArray] from a string with hexadecimal numbers.

--- a/identity/src/commonTest/kotlin/com/android/identity/asn1/ASN1Tests.kt
+++ b/identity/src/commonTest/kotlin/com/android/identity/asn1/ASN1Tests.kt
@@ -480,13 +480,13 @@ class ASN1Tests {
 
         assertEquals(
             """
-            SEQUENCE (6 elem)
-              OCTET STRING (1 byte) e0
-              OCTET STRING (1 byte) c0
-              OCTET STRING (1 byte) f8
-              OCTET STRING (1 byte) ff
-              OCTET STRING (2 byte) ff00
-              OCTET STRING (3 byte) ff0080
+                SEQUENCE (6 elem)
+                  OCTET STRING (1 byte) e0 ("�")
+                  OCTET STRING (1 byte) c0 ("�")
+                  OCTET STRING (1 byte) f8 ("�")
+                  OCTET STRING (1 byte) ff ("�")
+                  OCTET STRING (2 byte) ff 00 ("�.")
+                  OCTET STRING (3 byte) ff 00 80 ("�.�")
             """.trimIndent(),
             ASN1.print(ASN1Sequence(listOf(
                 ASN1OctetString("e0".fromHex()),
@@ -518,8 +518,8 @@ class ASN1Tests {
 
         assertEquals(
             """
-            SEQUENCE (1 elem)
-              UNSUPPORTED TAG class=UNIVERSAL encoding=PRIMITIVE tag=9 value=1011
+                SEQUENCE (1 elem)
+                  UNSUPPORTED TAG class=UNIVERSAL encoding=PRIMITIVE tag=9 value=10 11 ("..")
             """.trimIndent(),
             ASN1.print(ASN1Sequence(listOf(
                 ASN1RawObject(ASN1TagClass.UNIVERSAL, ASN1Encoding.PRIMITIVE, 0x09, byteArrayOf(16, 17))
@@ -564,89 +564,90 @@ A01EUDAKBggqhkjOPQQDAgNIADBFAiEAnX3+E4E5dQ+5G1rmStJTW79ZAiDTabyL
     @Test
     fun testPrettyPrint() {
         val certificate = ASN1.decode(exampleX509Cert.encodedCertificate)
-        assertEquals("""            
-            SEQUENCE (3 elem)
-              SEQUENCE (8 elem)
-                [0] (1 elem)
-                  INTEGER 2
-                INTEGER 26457b125f0ad75217a98ee6cfdea7fc486221
-                SEQUENCE (1 elem)
-                  OBJECT IDENTIFIER 1.2.840.10045.4.3.2 ECDSA coupled with SHA-256
-                SEQUENCE (5 elem)
-                  SET (1 elem)
+        assertEquals(
+            """
+                SEQUENCE (3 elem)
+                  SEQUENCE (8 elem)
+                    [0] (1 elem)
+                      INTEGER 2
+                    INTEGER 26 45 7b 12 5f 0a d7 52 17 a9 8e e6 cf de a7 fc 48 62 21
+                    SEQUENCE (1 elem)
+                      OBJECT IDENTIFIER 1.2.840.10045.4.3.2 ECDSA coupled with SHA-256
+                    SEQUENCE (5 elem)
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.8 stateOrProvinceName (X.520 DN component)
+                          PrintableString US-MD
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.6 countryName (X.520 DN component)
+                          PrintableString US
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.7 localityName (X.520 DN component)
+                          PrintableString Glen Burnie
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.10 organizationName (X.520 DN component)
+                          PrintableString Maryland MVA
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.3 commonName (X.520 DN component)
+                          PrintableString Fast Enterprises Root
                     SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.8 stateOrProvinceName (X.520 DN component)
-                      PrintableString US-MD
-                  SET (1 elem)
+                      UTCTime 2024-01-05T05:00:00Z
+                      UTCTime 2029-01-04T05:00:00Z
+                    SEQUENCE (5 elem)
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.8 stateOrProvinceName (X.520 DN component)
+                          PrintableString US-MD
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.6 countryName (X.520 DN component)
+                          PrintableString US
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.7 localityName (X.520 DN component)
+                          PrintableString Glen Burnie
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.10 organizationName (X.520 DN component)
+                          PrintableString Maryland MVA
+                      SET (1 elem)
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.4.3 commonName (X.520 DN component)
+                          PrintableString Fast Enterprises Root
                     SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.6 countryName (X.520 DN component)
-                      PrintableString US
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.7 localityName (X.520 DN component)
-                      PrintableString Glen Burnie
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.10 organizationName (X.520 DN component)
-                      PrintableString Maryland MVA
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.3 commonName (X.520 DN component)
-                      PrintableString Fast Enterprises Root
-                SEQUENCE (2 elem)
-                  UTCTime 2024-01-05T05:00:00Z
-                  UTCTime 2029-01-04T05:00:00Z
-                SEQUENCE (5 elem)
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.8 stateOrProvinceName (X.520 DN component)
-                      PrintableString US-MD
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.6 countryName (X.520 DN component)
-                      PrintableString US
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.7 localityName (X.520 DN component)
-                      PrintableString Glen Burnie
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.10 organizationName (X.520 DN component)
-                      PrintableString Maryland MVA
-                  SET (1 elem)
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.4.3 commonName (X.520 DN component)
-                      PrintableString Fast Enterprises Root
-                SEQUENCE (2 elem)
-                  SEQUENCE (2 elem)
-                    OBJECT IDENTIFIER 1.2.840.10045.2.1 Elliptic curve public key cryptography
-                    OBJECT IDENTIFIER 1.2.840.10045.3.1.7 NIST Curve P-256
-                  BIT STRING (520 bit) 0000010001101001011001110000101000100010101010010100000001011001101110100001010111110111011101000100000001101011100101101001110111010000101100100100000110011111110001011011010011111111001001100011000010110100111011001001010010010111000110111001001111000110100010100011100001001000111110010010100010101100101010011000111011001111011100010010000101001110000100001011111001010011100001011001000110101110110111010111011101101001001010011100001010110000100110110100101011111011000001101000000100010110000010000101011110111011
-                [3] (1 elem)
-                  SEQUENCE (6 elem)
-                    SEQUENCE (3 elem)
-                      OBJECT IDENTIFIER 2.5.29.15 keyUsage (X.509 extension)
-                      BOOLEAN true
-                      OCTET STRING (4 byte) 03020106
-                    SEQUENCE (3 elem)
-                      OBJECT IDENTIFIER 2.5.29.19 basicConstraints (X.509 extension)
-                      BOOLEAN true
-                      OCTET STRING (8 byte) 30060101ff020100
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.29.14 subjectKeyIdentifier (X.509 extension)
-                      OCTET STRING (22 byte) 04144e9ad1cda14127548b8c9b0ed35b652c2438605d
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.29.18 issuerAltName (X.509 extension)
-                      OCTET STRING (53 byte) 303381166d76616373406d646f742e73746174652e6d642e7573861968747470733a2f2f6d76612e6d6172796c616e642e676f762f
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 2.5.29.31 cRLDistributionPoints (X.509 extension)
-                      OCTET STRING (81 byte) 304f304da04ba049864768747470733a2f2f6d796d76612e6d6172796c616e642e676f763a353434332f4d44502f57656253657276696365732f43524c2f6d444c2f7265766f636174696f6e732e63726c
-                    SEQUENCE (2 elem)
-                      OBJECT IDENTIFIER 1.3.6.1.4.1.58017.1
-                      OCTET STRING (3 byte) 4d4450
-              SEQUENCE (1 elem)
-                OBJECT IDENTIFIER 1.2.840.10045.4.3.2 ECDSA coupled with SHA-256
-              BIT STRING (568 bit) 0011000001000101000000100010000100000000100111010111110111111110000100111000000100111001011101010000111110111001000110110101101011100110010010101101001001010011010110111011111101011001000000100010000011010011011010011011110010001011111100100101001001101110011000001011111111100111000011110001001100000010001000000111000111100100000000110010001000001001011100010000100101010000100110001010000011010100010101100100000001101011110111100001011110010100011101111001001101111101011000111100000110010110011101011011010110100111011011000111101110110000011110111011001110100110
+                      SEQUENCE (2 elem)
+                        OBJECT IDENTIFIER 1.2.840.10045.2.1 Elliptic curve public key cryptography
+                        OBJECT IDENTIFIER 1.2.840.10045.3.1.7 NIST Curve P-256
+                      BIT STRING (520 bit) 0000010001101001011001110000101000100010101010010100000001011001101110100001010111110111011101000100000001101011100101101001110111010000101100100100000110011111110001011011010011111111001001100011000010110100111011001001010010010111000110111001001111000110100010100011100001001000111110010010100010101100101010011000111011001111011100010010000101001110000100001011111001010011100001011001000110101110110111010111011101101001001010011100001010110000100110110100101011111011000001101000000100010110000010000101011110111011
+                    [3] (1 elem)
+                      SEQUENCE (6 elem)
+                        SEQUENCE (3 elem)
+                          OBJECT IDENTIFIER 2.5.29.15 keyUsage (X.509 extension)
+                          BOOLEAN true
+                          OCTET STRING (4 byte) 03 02 01 06 ("....")
+                        SEQUENCE (3 elem)
+                          OBJECT IDENTIFIER 2.5.29.19 basicConstraints (X.509 extension)
+                          BOOLEAN true
+                          OCTET STRING (8 byte) 30 06 01 01 ff 02 01 00 ("0...�...")
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.29.14 subjectKeyIdentifier (X.509 extension)
+                          OCTET STRING (22 byte) 04 14 4e 9a d1 cd a1 41 27 54 8b 8c 9b 0e d3 5b 65 2c 24 38 60 5d ("..N��͡A'T���.�[e,${'$'}8`]")
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.29.18 issuerAltName (X.509 extension)
+                          OCTET STRING (53 byte) 30 33 81 16 6d 76 61 63 73 40 6d 64 6f 74 2e 73 74 61 74 65 2e 6d 64 2e 75 73 86 19 68 74 74 70 73 3a 2f 2f 6d 76 61 2e 6d 61 72 79 6c 61 6e 64 2e 67 6f 76 2f ("03�.mvacs@mdot.state.md.us�.https://mva.maryland.gov/")
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 2.5.29.31 cRLDistributionPoints (X.509 extension)
+                          OCTET STRING (81 byte) 30 4f 30 4d a0 4b a0 49 86 47 68 74 74 70 73 3a 2f 2f 6d 79 6d 76 61 2e 6d 61 72 79 6c 61 6e 64 2e 67 6f 76 3a 35 34 34 33 2f 4d 44 50 2f 57 65 62 53 65 72 76 69 63 65 73 2f 43 52 4c 2f 6d 44 4c 2f 72 65 76 6f 63 61 74 69 6f 6e 73 2e 63 72 6c ("0O0M�K�I�Ghttps://mymva.maryland.gov:5443/MDP/WebServices/CRL/mDL/revocations.crl")
+                        SEQUENCE (2 elem)
+                          OBJECT IDENTIFIER 1.3.6.1.4.1.58017.1
+                          OCTET STRING (3 byte) 4d 44 50 ("MDP")
+                  SEQUENCE (1 elem)
+                    OBJECT IDENTIFIER 1.2.840.10045.4.3.2 ECDSA coupled with SHA-256
+                  BIT STRING (568 bit) 0011000001000101000000100010000100000000100111010111110111111110000100111000000100111001011101010000111110111001000110110101101011100110010010101101001001010011010110111011111101011001000000100010000011010011011010011011110010001011111100100101001001101110011000001011111111100111000011110001001100000010001000000111000111100100000000110010001000001001011100010000100101010000100110001010000011010100010101100100000001101011110111100001011110010100011101111001001101111101011000111100000110010110011101011011010110100111011011000111101110110000011110111011001110100110
             """.trimIndent(),
             ASN1.print(certificate!!).trim()
         )

--- a/identity/src/commonTest/kotlin/com/android/identity/crypto/X509CertTests.kt
+++ b/identity/src/commonTest/kotlin/com/android/identity/crypto/X509CertTests.kt
@@ -176,15 +176,15 @@ class X509CertTests {
         assertEquals(expectedSubjectKeyIdentifier.toHex(), cert.subjectKeyIdentifier!!.toHex())
         assertEquals(expectedSubjectKeyIdentifier.toHex(), cert.authorityKeyIdentifier!!.toHex())
         assertEquals(
-            "OCTET STRING (20 byte) ${expectedSubjectKeyIdentifier.toHex()}",
+            "OCTET STRING (20 byte) ${expectedSubjectKeyIdentifier.toHex(byteDivider = " ", decodeAsString = true)}",
             ASN1.print(ASN1.decode(cert.getExtensionValue(OID.X509_EXTENSION_SUBJECT_KEY_IDENTIFIER.oid)!!)!!).trim()
         )
         assertEquals(
             """
                 SEQUENCE (1 elem)
                   [0] (1 elem)
-                    (20 byte) ${expectedSubjectKeyIdentifier.toHex()}
-            """.trimIndent(),
+                    ${expectedSubjectKeyIdentifier.toHex(byteDivider = " ", decodeAsString = true)}
+            """.trimIndent().trim(),
             ASN1.print(ASN1.decode(cert.getExtensionValue(OID.X509_EXTENSION_AUTHORITY_KEY_IDENTIFIER.oid)!!)!!).trim()
         )
     }

--- a/identity/src/commonTest/kotlin/com/android/identity/util/HexUtilTest.kt
+++ b/identity/src/commonTest/kotlin/com/android/identity/util/HexUtilTest.kt
@@ -18,6 +18,26 @@ class HexUtilTest {
     }
 
     @Test
+    fun toHexDecodeAsString() {
+        assertEquals(
+            " (\"\")",
+            HexUtil.toHex(
+                byteArrayOf(),
+                byteDivider = " ",
+                decodeAsString = true
+            )
+        )
+        assertEquals(
+            "00 ff 13 ab 0b 41 42 43 (\".�.�.ABC\")",
+            HexUtil.toHex(
+                byteArrayOf(0x00, 0xff.toByte(), 0x13, 0xab.toByte(), 0x0b, 0x41, 0x42, 0x43),
+                byteDivider = " ",
+                decodeAsString = true
+            )
+        )
+    }
+
+    @Test
     fun fromHex() {
         assertContentEquals(ByteArray(0), HexUtil.fromHex(""))
         assertContentEquals(

--- a/identity/src/iosMain/kotlin/com/android/identity/datetime/dateTimeUtils.ios.kt
+++ b/identity/src/iosMain/kotlin/com/android/identity/datetime/dateTimeUtils.ios.kt
@@ -1,0 +1,53 @@
+package com.android.identity.datetime
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toNSDateComponents
+import platform.Foundation.NSCalendar
+import platform.Foundation.NSDateFormatter
+import platform.Foundation.NSDateFormatterFullStyle
+import platform.Foundation.NSDateFormatterLongStyle
+import platform.Foundation.NSDateFormatterMediumStyle
+import platform.Foundation.NSDateFormatterNoStyle
+import platform.Foundation.NSDateFormatterShortStyle
+import platform.Foundation.NSDateFormatterStyle
+import platform.Foundation.NSLocale
+import platform.Foundation.NSTimeZone
+import platform.Foundation.currentLocale
+import platform.Foundation.localTimeZone
+
+actual fun LocalDate.formatLocalized(
+    dateStyle: FormatStyle,
+): String {
+    val dateFormatter = NSDateFormatter()
+    dateFormatter.dateStyle = dateStyle.toNSDateFormatterStyle()
+    dateFormatter.timeStyle = NSDateFormatterNoStyle
+    dateFormatter.locale = NSLocale.currentLocale
+    dateFormatter.timeZone = NSTimeZone.localTimeZone
+    val components = this.toNSDateComponents()
+    components.calendar = NSCalendar.currentCalendar
+    return dateFormatter.stringFromDate(components.date!!)
+}
+
+actual fun LocalDateTime.formatLocalized(
+    dateStyle: FormatStyle,
+    timeStyle: FormatStyle
+): String {
+    val dateFormatter = NSDateFormatter()
+    dateFormatter.dateStyle = dateStyle.toNSDateFormatterStyle()
+    dateFormatter.timeStyle = timeStyle.toNSDateFormatterStyle()
+    dateFormatter.locale = NSLocale.currentLocale
+    dateFormatter.timeZone = NSTimeZone.localTimeZone
+    val components = this.toNSDateComponents()
+    components.calendar = NSCalendar.currentCalendar
+    return dateFormatter.stringFromDate(components.date!!)
+}
+
+private fun FormatStyle.toNSDateFormatterStyle(): NSDateFormatterStyle {
+    return when (this) {
+        FormatStyle.SHORT -> NSDateFormatterShortStyle
+        FormatStyle.MEDIUM -> NSDateFormatterMediumStyle
+        FormatStyle.LONG -> NSDateFormatterLongStyle
+        FormatStyle.FULL -> NSDateFormatterFullStyle
+    }
+}

--- a/identity/src/javaSharedMain/kotlin/com/android/identity/datetime/dateTimeUtils.jvm.kt
+++ b/identity/src/javaSharedMain/kotlin/com/android/identity/datetime/dateTimeUtils.jvm.kt
@@ -1,0 +1,40 @@
+package com.android.identity.datetime
+
+import kotlinx.datetime.LocalDate
+import kotlinx.datetime.LocalDateTime
+import kotlinx.datetime.toJavaLocalDate
+import kotlinx.datetime.toJavaLocalDateTime
+import java.time.ZoneId
+import java.time.ZoneOffset
+import java.time.format.DateTimeFormatter
+import java.time.format.FormatStyle
+import com.android.identity.datetime.FormatStyle as MultipazFormsatStyle
+
+actual fun LocalDate.formatLocalized(
+    dateStyle: MultipazFormsatStyle
+): String {
+    val formatter = DateTimeFormatter.ofLocalizedDate(dateStyle.toJavaFormatStyle())
+    return this.toJavaLocalDate().format(formatter)
+}
+
+actual fun LocalDateTime.formatLocalized(
+    dateStyle: MultipazFormsatStyle,
+    timeStyle: MultipazFormsatStyle
+): String {
+    val formatter = DateTimeFormatter.ofLocalizedDateTime(
+        dateStyle.toJavaFormatStyle(),
+        timeStyle.toJavaFormatStyle()
+    )
+    return this.toJavaLocalDateTime()
+        .atZone(ZoneId.systemDefault())
+        .format(formatter)
+}
+
+private fun MultipazFormsatStyle.toJavaFormatStyle(): FormatStyle {
+    return when (this) {
+        MultipazFormsatStyle.SHORT -> FormatStyle.SHORT
+        MultipazFormsatStyle.MEDIUM -> FormatStyle.MEDIUM
+        MultipazFormsatStyle.LONG -> FormatStyle.LONG
+        MultipazFormsatStyle.FULL -> FormatStyle.FULL
+    }
+}

--- a/multipaz-compose/build.gradle.kts
+++ b/multipaz-compose/build.gradle.kts
@@ -1,6 +1,8 @@
 import org.gradle.kotlin.dsl.implementation
+import org.jetbrains.compose.ExperimentalComposeLibrary
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSetTree
 
 plugins {
     alias(libs.plugins.kotlinMultiplatform)
@@ -13,6 +15,9 @@ kotlin {
     jvmToolchain(17)
 
     androidTarget {
+        @OptIn(ExperimentalKotlinGradlePluginApi::class)
+        instrumentedTestVariant.sourceSetTree.set(KotlinSourceSetTree.test)
+
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
@@ -59,6 +64,14 @@ kotlin {
                 implementation(libs.kotlinx.io.core)
             }
         }
+        val commonTest by getting {
+            dependencies {
+                implementation(libs.kotlin.test)
+                implementation(libs.kotlinx.coroutine.test)
+                @OptIn(ExperimentalComposeLibrary::class)
+                implementation(compose.uiTest)
+            }
+        }
         val androidMain by getting {
             dependencies {
                 implementation(libs.accompanist.permissions)
@@ -85,7 +98,8 @@ android {
     dependencies {
         debugImplementation(compose.uiTooling)
         debugImplementation(libs.androidx.ui.tooling.preview)
-        implementation(libs.kotlinx.datetime)
+        androidTestImplementation(libs.compose.junit4)
+        debugImplementation(libs.compose.test.manifest)
     }
 
     packaging {

--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/BluetoothPermissionState.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/BluetoothPermissionState.android.kt
@@ -1,6 +1,7 @@
 package org.multipaz.compose.permissions
 
 import android.Manifest
+import android.os.Build
 import androidx.compose.runtime.Composable
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.MultiplePermissionsState
@@ -24,11 +25,15 @@ private class AccompanistBluetoothPermissionState(
 actual fun rememberBluetoothPermissionState(): BluetoothPermissionState {
     return AccompanistBluetoothPermissionState(
         rememberMultiplePermissionsState(
-            listOf(
-                Manifest.permission.BLUETOOTH_SCAN,
-                Manifest.permission.BLUETOOTH_CONNECT,
-                Manifest.permission.BLUETOOTH_ADVERTISE,
-            )
+            if (Build.VERSION.SDK_INT >= 31) {
+                listOf(
+                    Manifest.permission.BLUETOOTH_ADVERTISE,
+                    Manifest.permission.BLUETOOTH_SCAN,
+                    Manifest.permission.BLUETOOTH_CONNECT
+                )
+            } else {
+                listOf(Manifest.permission.ACCESS_FINE_LOCATION)
+            }
         )
     )
 }

--- a/multipaz-compose/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-compose/src/commonMain/composeResources/values/strings.xml
@@ -24,16 +24,11 @@
     <string name="show_qr_code_dialog_qr_content_description">QR code image</string>
 
     <!-- CertificateViewer -->
-    <string name="certificate_viewer_no_certificates_in_chain">No certificates in the chain.</string>
-    <string name="certificate_viewer_no_cert_data_warning">No certificate data provided.</string>
-    <string name="certificate_viewer_accessibility_info_icon">An info icon</string>
-    <string name="certificate_viewer_accessibility_error_icon">An error icon</string>
     <string name="certificate_viewer_sub_basic_info">Basic Information</string>
     <string name="certificate_viewer_k_type">Type</string>
     <string name="certificate_viewer_k_serial_number">Serial Number</string>
-    <string name="certificate_viewer_k_version">Version</string>
-    <string name="certificate_viewer_k_issued">Issued On</string>
-    <string name="certificate_viewer_k_expired">Expires On</string>
+    <string name="certificate_viewer_k_valid_from">Valid From</string>
+    <string name="certificate_viewer_k_valid_until">Valid Until</string>
     <string name="certificate_viewer_sub_subject">Subject</string>
     <string name="certificate_viewer_sub_issuer">Issuer</string>
     <string name="certificate_viewer_k_country_name">Country Name</string>
@@ -42,7 +37,7 @@
     <string name="certificate_viewer_k_org_unit_name">Organizational Unit</string>
     <string name="certificate_viewer_k_locality_name">Locality</string>
     <string name="certificate_viewer_k_state_name">State or Province</string>
-    <string name="certificate_viewer_k_other_name">&lt;Other Name&gt;</string>
+    <string name="certificate_viewer_k_other_name">Other Name (OID %1$s)</string>
     <string name="certificate_viewer_sub_public_key_info">Public Key Information</string>
     <string name="certificate_viewer_k_pk_algorithm">Algorithm</string>
     <string name="certificate_viewer_k_pk_named_curve">Named Curve</string>
@@ -54,6 +49,9 @@
     <string name="certificate_viewer_critical_ext">Critical Extension</string>
     <string name="certificate_viewer_non_critical_ext">Non-Critical Extension</string>
     <string name="certificate_viewer_value_digital_signature">Digital Signature</string>
+    <string name="certificate_viewer_validity_in_the_past">This certificate is no longer valid, it expired %1$s</string>
+    <string name="certificate_viewer_validity_in_the_future">This certificate is not yet valid, it will be valid %1$s</string>
+    <string name="certificate_viewer_valid_now">Currently valid, will expire %1$s</string>
 
     <!-- Presentment -->
     <string name="presentment_connecting_to_reader">Connecting to reader</string>
@@ -72,5 +70,42 @@
     <string name="passphrase_pin_screen_cancel">Cancel</string>
     <string name="passphrase_pin_screen_done">Done</string>
     <string name="passphrase_prompt_bottom_sheet_cancel">Cancel</string>
+
+    <!-- durationFromNowText -->
+    <string name="duration_just_now">just now</string>
+    <string name="duration_in_a_few_moments">in a few moments</string>
+    <string name="duration_less_than_a_minute">less than a minute</string>
+    <string name="duration_years_and_months">%1$s and %2$s</string>
+    <string name="duration_months_and_days">%1$s and %2$s</string>
+    <string name="duration_weeks_and_days">%1$s and %2$s</string>
+    <string name="duration_days_and_hours">%1$s and %2$s</string>
+    <string name="duration_hours_and_minutes">%1$s and %2$s</string>
+    <string name="duration_time_ago">%1$s ago</string>
+    <string name="duration_time_from_now">%1$s from now</string>
+    <!-- TODO: figure out if we have to have separate string for past and future durations -->
+    <plurals name="duration_year">
+        <item quantity="one">%1$d year</item>
+        <item quantity="other">%1$d years</item>
+    </plurals>
+    <plurals name="duration_month">
+        <item quantity="one">%1$d month</item>
+        <item quantity="other">%1$d months</item>
+    </plurals>
+    <plurals name="duration_day">
+        <item quantity="one">%1$d day</item>
+        <item quantity="other">%1$d days</item>
+    </plurals>
+    <plurals name="duration_week">
+        <item quantity="one">%1$d week</item>
+        <item quantity="other">%1$d weeks</item>
+    </plurals>
+    <plurals name="duration_hour">
+        <item quantity="one">%1$d hour</item>
+        <item quantity="other">%1$d hours</item>
+    </plurals>
+    <plurals name="duration_minute">
+        <item quantity="one">%1$d minute</item>
+        <item quantity="other">%1$d minutes</item>
+    </plurals>
 
 </resources>

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/InfoCard.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/InfoCard.kt
@@ -1,0 +1,55 @@
+package org.multipaz.compose.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Info
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+/**
+ * A composable which shows a card with information.
+ *
+ * @param content the content.
+ */
+@Composable
+fun InfoCard(
+    content: @Composable (() -> Unit)
+) {
+    Column(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+            .clip(shape = RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.primaryContainer),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier.padding(8.dp),
+        ) {
+            Icon(
+                modifier = Modifier.padding(end = 12.dp),
+                imageVector = Icons.Filled.Info,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.onPrimaryContainer
+            )
+
+            CompositionLocalProvider(
+                LocalContentColor provides MaterialTheme.colorScheme.onPrimaryContainer
+            ) {
+                content()
+            }
+        }
+    }
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/WarningCard.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/cards/WarningCard.kt
@@ -1,0 +1,55 @@
+package org.multipaz.compose.cards
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Warning
+import androidx.compose.material3.Icon
+import androidx.compose.material3.LocalContentColor
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.dp
+
+/**
+ * A composable which shows a card with a warning.
+ *
+ * @param content the content.
+ */
+@Composable
+fun WarningCard(
+    content: @Composable (() -> Unit)
+) {
+    Column(
+        modifier = Modifier
+            .padding(8.dp)
+            .fillMaxWidth()
+            .clip(shape = RoundedCornerShape(8.dp))
+            .background(MaterialTheme.colorScheme.errorContainer),
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Row(
+            modifier = Modifier.padding(8.dp),
+        ) {
+            Icon(
+                modifier = Modifier.padding(end = 12.dp),
+                imageVector = Icons.Filled.Warning,
+                contentDescription = "An error icon",
+                tint = MaterialTheme.colorScheme.onErrorContainer
+            )
+
+            CompositionLocalProvider(
+                LocalContentColor provides MaterialTheme.colorScheme.onErrorContainer
+            ) {
+                content()
+            }
+        }
+    }
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/datetime/formattedDate.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/datetime/formattedDate.kt
@@ -1,0 +1,43 @@
+package org.multipaz.compose.datetime
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import com.android.identity.datetime.FormatStyle
+import com.android.identity.datetime.formatLocalized
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Formats a string to display a point in time as a date.
+ *
+ * @param instant the point in time to display.
+ * @param timeZone the timezone to use for displaying the point in time.
+ * @param dateStyle the amount of data to include in the date component.
+ * @param includeDurationFromNow if `true`, will include a textual representation of how
+ *   far in the past or future the point in time is relative to the current time.
+ * @param durationFromNowColor the color to use for the duration from now component.
+ */
+@Composable
+fun formattedDate(
+    instant: Instant,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    dateStyle: FormatStyle = FormatStyle.MEDIUM,
+    includeDurationFromNow: Boolean = false,
+    durationFromNowColor: Color = MaterialTheme.colorScheme.secondary
+): AnnotatedString {
+    return buildAnnotatedString {
+        append(instant.toLocalDateTime(timeZone).date.formatLocalized(dateStyle))
+        if (includeDurationFromNow) {
+            withStyle(style = SpanStyle(color = durationFromNowColor)) {
+                append(" — ")
+                append(durationFromNowText(instant))
+            }
+        }
+    }
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/datetime/formattedDateTime.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/datetime/formattedDateTime.kt
@@ -1,0 +1,45 @@
+package org.multipaz.compose.datetime
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.withStyle
+import com.android.identity.datetime.FormatStyle
+import com.android.identity.datetime.formatLocalized
+import kotlinx.datetime.Instant
+import kotlinx.datetime.TimeZone
+import kotlinx.datetime.toLocalDateTime
+
+/**
+ * Formats a string to display a point in time as a date and time string.
+ *
+ * @param instant the point in time to display.
+ * @param timeZone the timezone to use for displaying the point in time.
+ * @param dateStyle the amount of data to include in the date component.
+ * @param timeStyle the amount of date to include in the time component.
+ * @param includeDurationFromNow if `true`, will include a textual representation of how
+ *   far in the past or future the point in time is relative to the current time.
+ * @param durationFromNowColor the color to use for the duration from now component.
+ */
+@Composable
+fun formattedDateTime(
+    instant: Instant,
+    timeZone: TimeZone = TimeZone.currentSystemDefault(),
+    dateStyle: FormatStyle = FormatStyle.MEDIUM,
+    timeStyle: FormatStyle = FormatStyle.MEDIUM,
+    includeDurationFromNow: Boolean = false,
+    durationFromNowColor: Color = MaterialTheme.colorScheme.secondary
+ ): AnnotatedString {
+    return buildAnnotatedString {
+        append(instant.toLocalDateTime(timeZone).formatLocalized(dateStyle, timeStyle))
+        if (includeDurationFromNow) {
+            withStyle(style = SpanStyle(color = durationFromNowColor)) {
+                append(" — ")
+                append(durationFromNowText(instant))
+            }
+        }
+    }
+}

--- a/multipaz-compose/src/commonTest/kotlin/org/multipaz/compose/datetime/DurationFromNowTextTest.kt
+++ b/multipaz-compose/src/commonTest/kotlin/org/multipaz/compose/datetime/DurationFromNowTextTest.kt
@@ -1,263 +1,259 @@
-package com.android.identity_credential.wallet.ui
+package org.multipaz.compose.datetime
 
-import androidx.compose.ui.test.junit4.createComposeRule
-import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
 import kotlinx.datetime.Instant
-import org.junit.Assert
-import org.junit.Rule
-import org.junit.Test
-import org.junit.runner.RunWith
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
-@RunWith(AndroidJUnit4::class)
+@OptIn(ExperimentalTestApi::class)
 class DurationFromNowTextTest {
-    @get:Rule
-    val composeTestRule = createComposeRule()
 
     @Test
-    fun past_seconds() {
+    fun past_seconds() = runComposeUiTest {
         // setContent here and below is only needed to be able to call @Composable functions.
-        composeTestRule.setContent {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00.2Z")
             val now = Instant.parse("2021-11-25T15:20:04.4Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("just now", text)
+            assertEquals("just now", text)
         }
     }
 
     @Test
-    fun past_tens_of_seconds() {
-        composeTestRule.setContent {
+    fun past_tens_of_seconds() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2021-11-25T15:20:22Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("less than a minute ago", text)
+            assertEquals("less than a minute ago", text)
         }
     }
 
     @Test
-    fun past_minutes() {
-        composeTestRule.setContent {
+    fun past_minutes() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2021-11-25T15:21:01Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("1 minute ago", text)
+            assertEquals("1 minute ago", text)
         }
     }
 
     @Test
-    fun past_hours_only() {
-        composeTestRule.setContent {
+    fun past_hours_only() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2021-11-25T17:20:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("2 hours ago", text)
+            assertEquals("2 hours ago", text)
         }
     }
 
     @Test
-    fun past_hours_and_minutes() {
-        composeTestRule.setContent {
+    fun past_hours_and_minutes() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2021-11-25T17:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("2 hours and 8 minutes ago", text)
+            assertEquals("2 hours and 8 minutes ago", text)
         }
     }
 
     @Test
-    fun past_days_only() {
-        composeTestRule.setContent {
+    fun past_days_only() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2021-11-28T15:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("3 days ago", text)
+            assertEquals("3 days ago", text)
         }
     }
 
     @Test
-    fun past_days_and_hours() {
-        composeTestRule.setContent {
+    fun past_days_and_hours() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2021-11-28T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("3 days and 5 hours ago", text)
+            assertEquals("3 days and 5 hours ago", text)
         }
     }
 
     @Test
-    fun past_weeks_only() {
-        composeTestRule.setContent {
+    fun past_weeks_only() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2024-02-25T15:20:00Z")
             val now = Instant.parse("2024-03-04T12:20:00Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("1 week ago", text)
+            assertEquals("1 week ago", text)
         }
     }
 
     @Test
-    fun past_weeks_and_days() {
-        composeTestRule.setContent {
+    fun past_weeks_and_days() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-12-02T15:20:00Z")
             val now = Instant.parse("2022-01-01T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("4 weeks and 2 days ago", text)
+            assertEquals("4 weeks and 2 days ago", text)
         }
     }
 
     @Test
-    fun past_months_only() {
-        composeTestRule.setContent {
+    fun past_months_only() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2021-12-25T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("1 month ago", text)
+            assertEquals("1 month ago", text)
         }
     }
 
     @Test
-    fun past_months_and_days() {
-        composeTestRule.setContent {
+    fun past_months_and_days() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-02-25T15:20:00Z")
             val now = Instant.parse("2021-04-26T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("2 months and 1 day ago", text)
+            assertEquals("2 months and 1 day ago", text)
         }
     }
 
     @Test
-    fun past_weeks_or_month() {
+    fun past_weeks_or_month() = runComposeUiTest {
         // corner case of 4 weeks == 1 month
-        composeTestRule.setContent {
+        setContent {
             val instant = Instant.parse("2023-02-25T15:20:00Z")
             val now = Instant.parse("2023-03-25T16:20:00Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("1 month ago", text)
+            assertEquals("1 month ago", text)
         }
     }
 
     @Test
-    fun past_months_and_days_month_length() {
-        composeTestRule.setContent {
+    fun past_months_and_days_month_length() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-02-28T15:20:00Z")
             val now = Instant.parse("2021-04-30T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("2 months ago", text)
+            assertEquals("2 months ago", text)
         }
     }
 
     @Test
-    fun past_months_and_days_leap() {
-        composeTestRule.setContent {
+    fun past_months_and_days_leap() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2024-02-25T15:20:00Z")
             val now = Instant.parse("2024-04-28T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("2 months and 3 days ago", text)
+            assertEquals("2 months and 3 days ago", text)
         }
     }
 
     @Test
-    fun past_years_only() {
-        composeTestRule.setContent {
+    fun past_years_only() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00Z")
             val now = Instant.parse("2023-11-26T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("2 years ago", text)
+            assertEquals("2 years ago", text)
         }
     }
 
     @Test
-    fun past_years_and_months() {
-        composeTestRule.setContent {
+    fun past_years_and_months() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("1910-11-25T15:20:00Z")
             val now = Instant.parse("2023-12-26T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("113 years and 1 month ago", text)
+            assertEquals("113 years and 1 month ago", text)
         }
     }
 
     @Test
-    fun future_seconds() {
-        composeTestRule.setContent {
+    fun future_seconds() = runComposeUiTest {
+        setContent {
             val now = Instant.parse("2021-11-25T15:20:00.2Z")
             val instant = Instant.parse("2021-11-25T15:20:00.4Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("in a few moments", text)
+            assertEquals("in a few moments", text)
         }
     }
 
     @Test
-    fun future_months_and_days_month_length() {
-        composeTestRule.setContent {
+    fun future_months_and_days_month_length() = runComposeUiTest {
+        setContent {
             val now = Instant.parse("2021-02-28T15:20:00Z")
             val instant = Instant.parse("2021-04-30T20:28:59Z")
             val text = durationFromNowTextCore(instant = instant, now = now).first
-            Assert.assertEquals("2 months and 2 days from now", text)
+            assertEquals("2 months and 2 days from now", text)
         }
     }
 
     @Test
-    fun past_update_time_seconds() {
-        composeTestRule.setContent {
+    fun past_update_time_seconds() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00.2Z")
             val now = Instant.parse("2021-11-25T15:20:00.4Z")
 
             val (_, updateAt) = durationFromNowTextCore(instant, now)
-            Assert.assertEquals(Instant.parse("2021-11-25T15:20:10.2Z"), updateAt)
+            assertEquals(Instant.parse("2021-11-25T15:20:10.2Z"), updateAt)
         }
     }
 
     @Test
-    fun past_update_time_minutes() {
-        composeTestRule.setContent {
+    fun past_update_time_minutes() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00.5Z")
             val now = Instant.parse("2021-11-25T15:24:50Z")
 
             val (_, updateAt) = durationFromNowTextCore(instant, now)
-            Assert.assertEquals(Instant.parse("2021-11-25T15:25:00.5Z"), updateAt)
+            assertEquals(Instant.parse("2021-11-25T15:25:00.5Z"), updateAt)
         }
     }
 
     @Test
-    fun past_update_time_hours_and_minutes() {
-        composeTestRule.setContent {
+    fun past_update_time_hours_and_minutes() = runComposeUiTest {
+        setContent {
             val instant = Instant.parse("2021-11-25T15:20:00.5Z")
             val now = Instant.parse("2021-11-25T19:24:50Z")
 
             val (_, updateAt) = durationFromNowTextCore(instant, now)
-            Assert.assertEquals(Instant.parse("2021-11-25T19:25:00.5Z"), updateAt)
+            assertEquals(Instant.parse("2021-11-25T19:25:00.5Z"), updateAt)
         }
     }
 
     @Test
-    fun future_update_time_seconds() {
-        composeTestRule.setContent {
+    fun future_update_time_seconds() = runComposeUiTest {
+        setContent {
             val now = Instant.parse("2021-11-25T15:20:00Z")
             val instant = Instant.parse("2021-11-25T15:20:09Z")
 
             val (_, updateAt) = durationFromNowTextCore(instant, now)
-            Assert.assertEquals(instant, updateAt)
+            assertEquals(instant, updateAt)
         }
     }
 
     @Test
-    fun future_update_time_tens_of_seconds() {
-        composeTestRule.setContent {
+    fun future_update_time_tens_of_seconds() = runComposeUiTest {
+        setContent {
             val now = Instant.parse("2021-11-25T15:20:00Z")
             val instant = Instant.parse("2021-11-25T15:20:49Z")
 
             val (_, updateAt) = durationFromNowTextCore(instant, now)
-            Assert.assertEquals(Instant.parse("2021-11-25T15:20:39Z"), updateAt)
+            assertEquals(Instant.parse("2021-11-25T15:20:39Z"), updateAt)
         }
     }
 
     @Test
-    fun future_update_time_weeks_and_days() {
-        composeTestRule.setContent {
+    fun future_update_time_weeks_and_days() = runComposeUiTest {
+        setContent {
             val now = Instant.parse("1990-11-03T15:20:00Z")
             val instant = Instant.parse("1990-11-25T15:34:50Z")
 
             val (_, updateAt) = durationFromNowTextCore(instant, now)
-            Assert.assertEquals(Instant.parse("1990-11-03T15:34:50Z"), updateAt)
+            assertEquals(Instant.parse("1990-11-03T15:34:50Z"), updateAt)
         }
     }
 }

--- a/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
+++ b/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
@@ -206,7 +206,7 @@ class TransferHelper private constructor(
         val storageFile = File(context.noBackupFilesDir.path, "identity.db")
         storage = AndroidStorage(storageFile.absolutePath)
         androidKeystoreSecureAreaProvider = SecureAreaProvider {
-            AndroidKeystoreSecureArea.create(context, storage)
+            AndroidKeystoreSecureArea.create(storage)
         }
         state.value = State.IDLE
 

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
@@ -104,7 +104,7 @@ class TransferHelper private constructor(private val context: Context) {
         sharedPreferences = PreferenceManager.getDefaultSharedPreferences(context)
         storage = AndroidStorage(storagePath)
         secureAreaRepository = SecureAreaRepository.build {
-            add(AndroidKeystoreSecureArea.create(context, storage))
+            add(AndroidKeystoreSecureArea.create(storage))
         }
         credentialLoader = CredentialLoader()
         credentialLoader.addCredentialImplementation(MdocCredential::class) {

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -18,6 +18,15 @@
         tools:targetApi="s" />
     <uses-permission android:name="android.permission.BLUETOOTH_ADVERTISE" />
     <uses-permission android:name="android.permission.BLUETOOTH_CONNECT" />
+    <!-- Request legacy Bluetooth permissions on older devices. -->
+    <uses-permission android:name="android.permission.BLUETOOTH"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.BLUETOOTH_ADMIN"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION"
+        android:maxSdkVersion="30" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"
+        android:maxSdkVersion="30" />
 
     <!-- For NFC engagement -->
     <uses-feature

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/PlatformAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/PlatformAndroid.kt
@@ -62,7 +62,7 @@ actual fun platformStorage(): Storage {
 }
 
 private val androidKeystoreSecureAreaProvider = SecureAreaProvider {
-    AndroidKeystoreSecureArea.create(AndroidContexts.applicationContext, androidStorage)
+    AndroidKeystoreSecureArea.create(androidStorage)
 }
 
 actual fun platformSecureAreaProvider(): SecureAreaProvider<SecureArea> {

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -70,7 +70,7 @@ import kotlin.time.Duration.Companion.days
 private const val TAG = "AndroidKeystoreSecureAreaScreen"
 
 private val androidKeystoreCapabilities: AndroidKeystoreSecureArea.Capabilities by lazy {
-    AndroidKeystoreSecureArea.Capabilities(AndroidContexts.applicationContext)
+    AndroidKeystoreSecureArea.Capabilities()
 }
 
 private val keymintVersionTee: Int by lazy {
@@ -118,10 +118,15 @@ actual fun AndroidKeystoreSecureAreaScreen(
         item {
             TextButton(onClick = {
                 coroutineScope.launch {
-                    val attestation = aksAttestation(false)
-                    Logger.d(TAG, "attestation: " + attestation)
-                    withContext(Dispatchers.Main) {
-                        onViewCertificate(Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url())
+                    try {
+                        val attestation = aksAttestation(false)
+                        Logger.d(TAG, "attestation: " + attestation)
+                        withContext(Dispatchers.Main) {
+                            onViewCertificate(Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url())
+                        }
+                    } catch (e: Throwable) {
+                        e.printStackTrace();
+                        showToast("${e.message}")
                     }
                 }
             })
@@ -136,10 +141,17 @@ actual fun AndroidKeystoreSecureAreaScreen(
         item {
             TextButton(onClick = {
                 coroutineScope.launch {
-                    val attestation = aksAttestation(true)
-                    Logger.d(TAG, "attestation: " + attestation)
-                    withContext(Dispatchers.Main) {
-                        onViewCertificate(Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url())
+                    try {
+                        val attestation = aksAttestation(true)
+                        Logger.d(TAG, "attestation: " + attestation)
+                        withContext(Dispatchers.Main) {
+                            onViewCertificate(
+                                Cbor.encode(attestation.certChain!!.toDataItem()).toBase64Url()
+                            )
+                        }
+                    } catch (e: Throwable) {
+                        e.printStackTrace();
+                        showToast("${e.message}")
                     }
                 }
             })

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppUtils.kt
@@ -207,7 +207,7 @@ object TestAppUtils {
                 docType = documentType.mdocDocumentType!!.docType,
                 createKeySettings = platformCreateKeySettings(
                     challenge = "Challenge".encodeToByteString(),
-                    keyPurposes = setOf(KeyPurpose.AGREE_KEY, KeyPurpose.SIGN),
+                    keyPurposes = setOf(KeyPurpose.SIGN),
                     userAuthenticationRequired = userAuthenticationRequired
                 )
             )

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
@@ -131,16 +131,21 @@ fun IsoMdocProximitySharingScreen(
                                 if (connectionMethods.isEmpty()) {
                                     showToast("No connection methods selected")
                                 } else {
-                                    doHolderFlow(
-                                        connectionMethods = connectionMethods,
-                                        handover = Simple.NULL,
-                                        options = options,
-                                        allowMultipleRequests = settingsModel.presentmentAllowMultipleRequests.value,
-                                        showToast = showToast,
-                                        presentmentModel = presentmentModel,
-                                        showQrCode = showQrCode,
-                                        onNavigateToPresentationScreen = onNavigateToPresentmentScreen,
-                                    )
+                                    try {
+                                        doHolderFlow(
+                                            connectionMethods = connectionMethods,
+                                            handover = Simple.NULL,
+                                            options = options,
+                                            allowMultipleRequests = settingsModel.presentmentAllowMultipleRequests.value,
+                                            showToast = showToast,
+                                            presentmentModel = presentmentModel,
+                                            showQrCode = showQrCode,
+                                            onNavigateToPresentationScreen = onNavigateToPresentmentScreen,
+                                        )
+                                    } catch (e: Throwable) {
+                                        e.printStackTrace()
+                                        showToast("Error: $e")
+                                    }
                                 }
                             }
                         },

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,21 @@
 rootProject.name = "IdentityCredential"
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")
 
+// As per https://www.jetbrains.com/help/kotlin-multiplatform-dev/compose-test.html#-o0tm8i_54
+// "Currently, you cannot run common Compose Multiplatform tests using android (local) test
+// configurations, so gutter icons in Android Studio, for example, won't be helpful."
+//
+// This is not a problem because the tests will get run as part of the multipaz-compose:connectedCheck
+// tasks.
+//
+// When this starts working again, we can remove the lines below.
+//
+startParameter.excludedTaskNames +=
+    listOf(
+        ":multipaz-compose:testDebugUnitTest",
+        ":multipaz-compose:testReleaseUnitTest"
+    )
+
 pluginManagement {
     repositories {
         google {

--- a/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/WalletApplication.kt
@@ -165,7 +165,7 @@ class WalletApplication : Application() {
 
         // init AndroidKeyStoreSecureArea
         secureAreaProvider = SecureAreaProvider {
-            AndroidKeystoreSecureArea.create(applicationContext, storage)
+            AndroidKeystoreSecureArea.create(storage)
         }
 
         // init SecureAreaRepository
@@ -268,10 +268,9 @@ class WalletApplication : Application() {
             resources.openRawResource(R.raw.austroad_test_event_vical_20241002).readBytes()
         )
         for (certInfo in signedVical.vical.certificateInfos) {
-            val cert = X509Cert(certInfo.certificate)
             issuerTrustManager.addTrustPoint(
                 TrustPoint(
-                    cert,
+                    certInfo.certificate,
                     null,
                     null
                 )
@@ -451,7 +450,7 @@ class WalletApplication : Application() {
     private fun getWalletApplicationInformation(): WalletApplicationCapabilities {
         val now = Clock.System.now()
 
-        val keystoreCapabilities = AndroidKeystoreSecureArea.Capabilities(applicationContext)
+        val keystoreCapabilities = AndroidKeystoreSecureArea.Capabilities()
 
         return WalletApplicationCapabilities(
             generatedAt = now,

--- a/wallet/src/main/java/com/android/identity_credential/wallet/dynamicregistration/AidRegistrationUtil.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/dynamicregistration/AidRegistrationUtil.kt
@@ -35,6 +35,9 @@ object AidRegistrationUtil {
 
     fun routeAidsToHost(context: Context) {
         val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+        if (nfcAdapter == null) {
+            return
+        }
         val cardEmulation = CardEmulation.getInstance(nfcAdapter!!)
         val nfcEngagementHandlerComponent =
             ComponentName(context, NFC_ENGAGEMENT_HANDLER)
@@ -59,6 +62,9 @@ object AidRegistrationUtil {
 
     fun routeAidsToSe(context: Context) {
         val nfcAdapter = NfcAdapter.getDefaultAdapter(context)
+        if (nfcAdapter == null) {
+            return
+        }
         val cardEmulation = CardEmulation.getInstance(nfcAdapter)
         val offHostNfcPresentationHandlerComponent =
             ComponentName(context, OFF_HOST_NFC_PRESENTATION_HANDLER)
@@ -77,9 +83,7 @@ object AidRegistrationUtil {
                 listOf(AID_TYPE_4_TAG_NDEF_APPLICATION, AID_MDL_DATA_TRANSFER)
             )
         ) {
-            Logger.d(
-                TAG, "Failed to dynamically register offHostNfcDataTransferHandlerComponent"
-            )
+            Logger.d(TAG, "Failed to dynamically register offHostNfcDataTransferHandlerComponent")
         }
     }
 }

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/document/DocumentInfoScreen.kt
@@ -49,10 +49,10 @@ import com.android.identity_credential.wallet.SettingsModel
 import com.android.identity_credential.wallet.navigation.WalletDestination
 import com.android.identity_credential.wallet.ui.KeyValuePairText
 import com.android.identity_credential.wallet.ui.ScreenWithAppBarAndBackButton
-import com.android.identity_credential.wallet.ui.durationFromNowText
 import com.android.identity_credential.wallet.util.asFormattedDateTimeInCurrentTimezone
 import kotlinx.coroutines.launch
 import kotlinx.datetime.Instant
+import org.multipaz.compose.datetime.durationFromNowText
 import java.util.*
 
 

--- a/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/main/MainScreen.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/ui/destination/main/MainScreen.kt
@@ -381,7 +381,7 @@ fun MainScreenContent(
             ) {
                 OutlinedButton(
                     onClick = {
-                        if (!AndroidKeystoreSecureArea.Capabilities(context).secureLockScreenSetup) {
+                        if (!AndroidKeystoreSecureArea.Capabilities().secureLockScreenSetup) {
                             showDeviceLockNotSetupWarning = true
                         } else if (!hasProximityPresentationPermissions.allPermissionsGranted) {
                             showProximityPresentationPermissionsMissing = true
@@ -477,7 +477,7 @@ fun MainScreenNoDocumentsAvailable(
             modifier = Modifier.padding(16.dp),
             shape = RoundedCornerShape(16.dp),
             onClick = {
-            if (!AndroidKeystoreSecureArea.Capabilities(context).secureLockScreenSetup) {
+            if (!AndroidKeystoreSecureArea.Capabilities().secureLockScreenSetup) {
                 showDeviceLockNotSetupWarning = true
             } else {
                 onNavigate(WalletDestination.AddToWallet.route)


### PR DESCRIPTION
Remove Context parameter from AndroidKeystoreSecureArea.create() and AndroidKeystoreSecureArea.Capabilities since it's available via the AndroidContexts object.

Add new dateTimeUtils.kt to core library with formatLocalized() extensions to LocalDate and LocalDateTime implemented using the underlying platform's routines. Both platforms (JVM and Darwin) happens to both support the same formatting styles (short, medium, long, full) so pipe this through our APIs.

Move durationFromNowText() and its unit tests from wallet to multipaz-compose library.

Add formattedDate() and formattedDateTime() functions (using formatLocalized() and durationFromNowText()) to multipaz-compose so our library code can use these, for consistency.

Add WarningCard()/InfoCard() composables to multipaz-compose library.

Multiple CertificateViewer enhancements/fixes:
- Change "Issued On" to "Valid From"  since the former is factually incorrect.
- Change "Expires On" to "Valid Until" to match "Valid From"
- Use formattedDateTime() for validFrom / validUntil instead of rolling our own routines (which coincidentally got the timezone wrong).
- Add new "Validity Info" subsection which conveys the amount of time before a certificate expires (if it's currently valid), if it's already expired and so how long ago, or if it's not valid yet. For the cases where the certificate is not valid, use MaterialTheme.colorScheme.error to highlight this.
- Remove warning/infos since it's not used and it's expected that users will arrange these separately.
- Make all values selectable so users can copy-paste.
- Add an easter-egg-ish feature to copy the PEM-encoded version of the certificate to the clipboard when tapping the "Basic Information" text label. This is going to be useful at test events when debugging.

Add new X509_EXTENSION_ANDROID_KEYSTORE_PROVISIONING_INFORMATION extension to OID along with support in CertificateViewer.

In BleCentralManagerAndroid and BlePeripheralManagerAndroid throw early if Bluetooth is not available (the case for emulators for old Android devices).

In scanNfcTag() throw early if NFC is not available on the device (the case for all Android emulators).

Change VicalCertificateInfo to hold the X509Cert instead of a ByteArray with the encoded certificate.

Add support to toHex() for also including a decoded string with only printable characters. Use this in ASN1.print() and also change insert a space between hex bytes. This makes CertificateViewer more useful for X.509 extensions that we don't directly support insofar that strings in the OCTET STRING in the ASN.1 are properly shown.

Add BLE permissions to samples/testapp so it works on devices with an Android version earlier than API 30.

Catch exceptions in various places in samples/testapp to prevent crashes. Don't require KeyPurposes.AGREE_KEY for keys because this is not available on older Android versions. These fixes are needed when running on Pixel 3a API 28 emulator.

Test: ./gradlew check && ./gradlew connectedCheck
Test: Manually tested samples/testapp and wallet and appverifier
