### PR TITLE
SecureArea APIs: specify signing algorithm parameter at key creation.

### DIFF
--- a/identity-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.kt
+++ b/identity-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.kt
@@ -160,7 +160,6 @@ class MigrateFromKeystoreICStoreTest {
         val dataToSign = byteArrayOf(1, 2, 3)
         val ecSignature = aksSecureArea.sign(
             credentialKeyAlias,
-            Algorithm.ES256,
             dataToSign,
             null
         )

--- a/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
+++ b/identity-android/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
@@ -206,13 +206,13 @@ class DeviceRetrievalHelperTest {
         //
         // MobileSecurityObjectBytes = #6.24(bstr .cbor MobileSecurityObject)
         //
-        val protectedHeaders = java.util.Map.of<CoseLabel, DataItem>(
-            CoseNumberLabel(Cose.COSE_LABEL_ALG),
-            Algorithm.ES256.coseAlgorithmIdentifier.toDataItem()
+        val protectedHeaders = mapOf<CoseLabel, DataItem>(
+            CoseNumberLabel(Cose.COSE_LABEL_ALG) to
+                    Algorithm.ES256.coseAlgorithmIdentifier.toDataItem()
         )
-        val unprotectedHeaders = java.util.Map.of<CoseLabel, DataItem>(
-            CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
-            X509CertChain(listOf(documentSignerCert)).toDataItem()
+        val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
+            CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN) to
+                    X509CertChain(listOf(documentSignerCert)).toDataItem()
         )
         val encodedIssuerAuth = encode(
             coseSign1Sign(
@@ -415,8 +415,7 @@ class DeviceRetrievalHelperTest {
                                 deviceSignedData,
                                 mdocCredential.secureArea,
                                 mdocCredential.alias,
-                                null,
-                                Algorithm.ES256
+                                null
                             )
                             .generate()
                     )

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/digitalCredentialsPresentment.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/digitalCredentialsPresentment.kt
@@ -736,7 +736,6 @@ private suspend fun calcDocument(
         credential.secureArea,
         credential.alias,
         KeyUnlockInteractive(),
-        keyInfo.publicKey.curve.defaultSigningAlgorithm,
     )
     return documentGenerator.generate()
 }

--- a/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/mdocPresentment.kt
+++ b/identity-appsupport/src/commonMain/kotlin/com/android/identity/appsupport/ui/presentment/mdocPresentment.kt
@@ -209,13 +209,11 @@ private suspend fun calcDocument(
     )
     documentGenerator.setIssuerNamespaces(mergedIssuerNamespaces)
 
-    val keyInfo = credential.secureArea.getKeyInfo(credential.alias)
     documentGenerator.setDeviceNamespacesSignature(
         NameSpacedData.Builder().build(),
         credential.secureArea,
         credential.alias,
         KeyUnlockInteractive(),
-        keyInfo.publicKey.curve.defaultSigningAlgorithm,
     )
     return documentGenerator.generate()
 }

--- a/identity-csa/src/main/java/com/android/identity/securearea/cloud/CloudSecureAreaServer.kt
+++ b/identity-csa/src/main/java/com/android/identity/securearea/cloud/CloudSecureAreaServer.kt
@@ -373,6 +373,7 @@ class CloudSecureAreaServer(
         var cloudChallenge: ByteArray? = null,
         var purposes: Set<KeyPurpose> = emptySet(),
         var curve: EcCurve = EcCurve.P256,
+        var signingAlgorithm: Int? = null,
         var validFromMillis: Long = 0,
         var validUntilMillis: Long = 0,
         var passphraseRequired: Boolean = false,
@@ -402,6 +403,7 @@ class CloudSecureAreaServer(
         state.cloudChallenge = Random.Default.nextBytes(32)
         state.purposes = request0.purposes
         state.curve = request0.curve
+        state.signingAlgorithm = request0.signingAlgorithm
         state.validFromMillis = request0.validFromMillis
         state.validUntilMillis = request0.validUntilMillis
         state.passphraseRequired = request0.passphraseRequired
@@ -610,7 +612,6 @@ class CloudSecureAreaServer(
             val secureArea = SoftwareSecureArea.create(storage)
             val signature = secureArea.sign(
                 "CloudKey",
-                Algorithm.ES256,
                 state.dataToSign!!,
                 null
             )

--- a/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
+++ b/identity-issuance/src/main/java/com/android/identity/issuance/funke/FunkeUtil.kt
@@ -48,7 +48,7 @@ internal object FunkeUtil {
     suspend fun communicationSign(env: FlowEnvironment, clientId: String, message: ByteArray): ByteArray {
         val secureArea = env.getInterface(SecureAreaProvider::class)!!.get()
         val alias = "FunkeComm_" + clientId
-        val sig = secureArea.sign(alias, Algorithm.ES256, message, null)
+        val sig = secureArea.sign(alias, message, null)
         return sig.toCoseEncoded()
     }
 

--- a/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/response/DocumentGenerator.kt
+++ b/identity-mdoc/src/commonMain/kotlin/com/android/identity/mdoc/response/DocumentGenerator.kt
@@ -83,7 +83,7 @@ class DocumentGenerator
         secureArea: SecureArea,
         keyAlias: String,
         keyUnlockData: KeyUnlockData?,
-        signatureAlgorithm: Algorithm,
+        useMac: Boolean,
         eReaderKey: EcPublicKey?
     ) = apply {
         val mapBuilder = CborMap.builder()
@@ -110,20 +110,14 @@ class DocumentGenerator
         val deviceAuthenticationBytes = Cbor.encode(Tagged(24, Bstr(deviceAuthentication)))
         var encodedDeviceSignature: ByteArray? = null
         var encodedDeviceMac: ByteArray? = null
-        if (signatureAlgorithm !== Algorithm.UNSET) {
+        if (!useMac) {
             encodedDeviceSignature = Cbor.encode(
                 Cose.coseSign1Sign(
                     secureArea,
                     keyAlias,
                     deviceAuthenticationBytes,
                     false,
-                    signatureAlgorithm,
-                    mapOf(
-                        Pair(
-                            CoseNumberLabel(Cose.COSE_LABEL_ALG),
-                            signatureAlgorithm.coseAlgorithmIdentifier.toDataItem()
-                        )
-                    ),
+                    mapOf(),
                     mapOf(),
                     keyUnlockData
                 ).toDataItem()
@@ -190,16 +184,15 @@ class DocumentGenerator
         dataElements: NameSpacedData,
         secureArea: SecureArea,
         keyAlias: String,
-        keyUnlockData: KeyUnlockData?,
-        signatureAlgorithm: Algorithm
+        keyUnlockData: KeyUnlockData?
     ) = apply {
         setDeviceNamespaces(
             dataElements,
             secureArea,
             keyAlias,
             keyUnlockData,
-            signatureAlgorithm,
-            null
+            useMac = false,
+            eReaderKey = null
         )
     }
 
@@ -229,8 +222,8 @@ class DocumentGenerator
             secureArea,
             keyAlias,
             keyUnlockData,
-            Algorithm.UNSET,
-            eReaderKey
+            useMac = true,
+            eReaderKey = eReaderKey
         )
     }
 

--- a/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.kt
+++ b/identity-mdoc/src/commonTest/kotlin/com/android/identity/mdoc/response/DeviceResponseGeneratorTest.kt
@@ -245,7 +245,6 @@ class DeviceResponseGeneratorTest {
                     mdocCredential.secureArea,
                     mdocCredential.alias,
                     null,
-                    Algorithm.ES256
                 )
                 .generate()
         )
@@ -384,8 +383,7 @@ class DeviceResponseGeneratorTest {
                     deviceSignedData,
                     mdocCredential.secureArea,
                     mdocCredential.alias,
-                    null,
-                    Algorithm.ES256
+                    null
                 )
                 .generate()
         )
@@ -448,8 +446,7 @@ class DeviceResponseGeneratorTest {
                     deviceSignedData,
                     mdocCredential.secureArea,
                     mdocCredential.alias,
-                    null,
-                    Algorithm.ES256
+                    null
                 )
                 .generate()
         )
@@ -513,8 +510,7 @@ class DeviceResponseGeneratorTest {
                     NameSpacedData.Builder().build(),
                     mdocCredential.secureArea,
                     mdocCredential.alias,
-                    null,
-                    Algorithm.ES256
+                    null
                 )
                 .generate()
         )

--- a/identity-sdjwt/src/main/java/com/android/identity/sdjwt/SdJwtVerifiableCredential.kt
+++ b/identity-sdjwt/src/main/java/com/android/identity/sdjwt/SdJwtVerifiableCredential.kt
@@ -133,18 +133,18 @@ class SdJwtVerifiableCredential(
     suspend fun createPresentation(secureArea: SecureArea?,
                            alias: String?,
                            keyUnlockData: KeyUnlockData?,
-                           alg: Algorithm,
                            nonce: String,
                            audience: String,
                            creationTime: Instant = Clock.System.now()): SdJwtVerifiablePresentation {
         val (keyBindingHeaderStr, keyBindingBodyStr, signatureStr) =
             if (secureArea != null && alias != null) {
-                val keyBindingHeaderStr = KeyBindingHeader(alg).toString()
+                val keyInfo = secureArea.getKeyInfo(alias)
+                val keyBindingHeaderStr = KeyBindingHeader(keyInfo.signingAlgorithm).toString()
                 val sdHash = Crypto.digest(this.sdHashAlg, toString().toByteArray()).toBase64Url()
                 val keyBindingBodyStr = KeyBindingBody(nonce, audience, creationTime, sdHash).toString()
 
                 val toBeSigned = "$keyBindingHeaderStr.$keyBindingBodyStr".toByteArray(Charsets.US_ASCII)
-                val signature = secureArea.sign(alias, alg, toBeSigned, keyUnlockData)
+                val signature = secureArea.sign(alias, toBeSigned, keyUnlockData)
                 val signatureStr = signature.toCoseEncoded().toBase64Url()
                 listOf(keyBindingHeaderStr, keyBindingBodyStr, signatureStr)
             } else {

--- a/identity-sdjwt/src/test/java/com/android/identity/sdjwt/SdJwtVcTest.kt
+++ b/identity-sdjwt/src/test/java/com/android/identity/sdjwt/SdJwtVcTest.kt
@@ -195,7 +195,6 @@ class SdJwtVcTest {
             credential.secureArea,
             credential.alias,
             null,
-            Algorithm.ES256,
             nonceStr,
             "https://example-verifier.com"
         ).toString()

--- a/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/AndroidKeystoreSecureAreaTest.kt
+++ b/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/AndroidKeystoreSecureAreaTest.kt
@@ -88,7 +88,7 @@ class AndroidKeystoreSecureAreaTest {
 
         // Now that we know the key doesn't exist, check that ecKeySign() throws
         try {
-            ks.sign("testKey", Algorithm.ES256, byteArrayOf(1, 2), null)
+            ks.sign("testKey", byteArrayOf(1, 2), null)
             Assert.fail()
         } catch (e: IllegalArgumentException) {
             // Expected path.
@@ -133,7 +133,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertNull(keyInfo.validUntil)
         val dataToSign = byteArrayOf(4, 5, 6)
         val signature = try {
-            ks.sign("testKey", Algorithm.ES256, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
@@ -191,7 +191,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertNull(keyInfo.validUntil)
         val dataToSign = byteArrayOf(4, 5, 6)
         try {
-            ks.sign("testKey", Algorithm.ES256, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
             Assert.fail("Should not be reached")
         } catch (e: KeyLockedException) {
             /* expected path */
@@ -224,7 +224,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertNull(keyInfo.validUntil)
         val dataToSign = byteArrayOf(4, 5, 6)
         try {
-            ks.sign("testKey", Algorithm.ES256, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
             Assert.fail("Should not be reached")
         } catch (e: KeyLockedException) {
             /* expected path */
@@ -248,6 +248,7 @@ class AndroidKeystoreSecureAreaTest {
         val keyInfo = ks.getKeyInfo("testKey")
         Assert.assertEquals(setOf(KeyPurpose.SIGN), keyInfo.keyPurposes)
         Assert.assertEquals(EcCurve.P256, keyInfo.publicKey.curve)
+        Assert.assertEquals(Algorithm.ES256, keyInfo.signingAlgorithm)
         Assert.assertFalse(keyInfo.isStrongBoxBacked)
         Assert.assertTrue(keyInfo.isUserAuthenticationRequired)
         Assert.assertEquals(42, keyInfo.userAuthenticationTimeoutMillis)
@@ -257,7 +258,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertNull(keyInfo.validUntil)
         val dataToSign = byteArrayOf(4, 5, 6)
         try {
-            ks.sign("testKey", Algorithm.ES256, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
             Assert.fail("Should not be reached")
         } catch (e: KeyLockedException) {
             /* expected path */
@@ -296,11 +297,11 @@ class AndroidKeystoreSecureAreaTest {
         val settings = AndroidKeystoreCreateKeySettings.Builder(challenge)
             .setEcCurve(EcCurve.ED25519)
             .build()
-        ks.createKey("testKey", settings)
-        val keyInfo = ks.getKeyInfo("testKey")
+        val keyInfo = ks.createKey("testKey", settings)
         Assert.assertTrue(keyInfo.attestation.certChain!!.certificates.size >= 1)
         Assert.assertEquals(setOf(KeyPurpose.SIGN), keyInfo.keyPurposes)
         Assert.assertEquals(EcCurve.ED25519, keyInfo.publicKey.curve)
+        Assert.assertEquals(Algorithm.EDDSA, keyInfo.signingAlgorithm)
         Assert.assertFalse(keyInfo.isStrongBoxBacked)
         Assert.assertFalse(keyInfo.isUserAuthenticationRequired)
         Assert.assertEquals(0, keyInfo.userAuthenticationTimeoutMillis)
@@ -310,7 +311,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertNull(keyInfo.validUntil)
         val dataToSign = byteArrayOf(4, 5, 6)
         val signature = try {
-            ks.sign("testKey", Algorithm.EDDSA, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
@@ -345,7 +346,7 @@ class AndroidKeystoreSecureAreaTest {
         )
         val dataToSign = byteArrayOf(4, 5, 6)
         try {
-            ks.sign("testKey", Algorithm.ES256, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
             Assert.fail("Signing shouldn't work with a key w/o KEY_PURPOSE_SIGN")
         } catch (e: IllegalArgumentException) {
             // Expected path.
@@ -527,7 +528,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertArrayEquals(theirSharedSecret, ourSharedSecret)
         val dataToSign = byteArrayOf(4, 5, 6)
         val signature = try {
-            ks.sign("testKey", Algorithm.ES256, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
@@ -588,7 +589,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertTrue(keyInfo.attestation.certChain!!.certificates.size >= 1)
         val dataToSign = byteArrayOf(4, 5, 6)
         val signature = try {
-            ks.sign("testKey", Algorithm.ES256, dataToSign, null)
+            ks.sign("testKey", dataToSign, null)
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
@@ -795,6 +796,7 @@ class AndroidKeystoreSecureAreaTest {
         Assert.assertNotNull(keyInfo)
         Assert.assertEquals(setOf(KeyPurpose.SIGN), keyInfo.keyPurposes)
         Assert.assertEquals(EcCurve.P256, keyInfo.publicKey.curve)
+        Assert.assertEquals(Algorithm.ES256, keyInfo.signingAlgorithm)
         val parser = AndroidAttestationExtensionParser(
             keyInfo.attestation.certChain!!.certificates[0]
         )

--- a/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/cloud/CloudSecureAreaTest.kt
+++ b/identity/src/androidInstrumentedTest/kotlin/com/android/identity/securearea/cloud/CloudSecureAreaTest.kt
@@ -328,7 +328,7 @@ class CloudSecureAreaTest {
         Assert.assertNull(keyInfo.validUntil)
         val dataToSign = byteArrayOf(4, 5, 6)
         val signature = try {
-            csa.sign("testKey", Algorithm.ES256, dataToSign, null)
+            csa.sign("testKey", dataToSign, null)
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
@@ -472,7 +472,7 @@ class CloudSecureAreaTest {
     fun testWrongPassphraseDelay_signing() = runTest {
         testWrongPassphraseDelayHelper(
             useKey = { alias, csa, unlockData ->
-                csa.sign(alias, Algorithm.ES256, byteArrayOf(1, 2, 3), unlockData)
+                csa.sign(alias, byteArrayOf(1, 2, 3), unlockData)
         })
     }
 

--- a/identity/src/androidMain/kotlin/com/android/identity/device/DeviceCheck.android.kt
+++ b/identity/src/androidMain/kotlin/com/android/identity/device/DeviceCheck.android.kt
@@ -32,7 +32,6 @@ actual object DeviceCheck {
         val assertionData = assertion.toCbor()
         val signature = secureArea.sign(
             alias = deviceAttestationId,
-            signatureAlgorithm = Algorithm.ES256,
             dataToSign = assertionData,
             keyUnlockData = null
         )

--- a/identity/src/androidMain/kotlin/com/android/identity/securearea/AndroidKeystoreKeyInfo.kt
+++ b/identity/src/androidMain/kotlin/com/android/identity/securearea/AndroidKeystoreKeyInfo.kt
@@ -1,5 +1,6 @@
 package com.android.identity.securearea
 
+import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.EcPublicKey
 import com.android.identity.securearea.KeyAttestation
 import com.android.identity.securearea.KeyInfo
@@ -14,6 +15,7 @@ class AndroidKeystoreKeyInfo internal constructor(
     publicKey: EcPublicKey,
     attestation: KeyAttestation,
     keyPurposes: Set<KeyPurpose>,
+    signingAlgorithm: Algorithm,
 
     /**
      * The attest key alias for the key, if any.
@@ -53,4 +55,4 @@ class AndroidKeystoreKeyInfo internal constructor(
      * The point in time after which the key is not valid, if set.
      */
     val validUntil: Instant?
-) : KeyInfo(alias, publicKey, keyPurposes, attestation)
+) : KeyInfo(alias, publicKey, keyPurposes, signingAlgorithm, attestation)

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/CreateKeySettings.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/CreateKeySettings.kt
@@ -1,5 +1,6 @@
 package com.android.identity.securearea
 
+import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.EcCurve
 
 /**
@@ -12,8 +13,27 @@ import com.android.identity.crypto.EcCurve
  *
  * @param keyPurposes the key purposes.
  * @param ecCurve the curve used.
+ * @param signingAlgorithm algorithm to utilize when this key is used for signing,
+ *    only meaningful when [keyPurposes] contains [KeyPurpose.SIGN].
  */
 open class CreateKeySettings(
     val keyPurposes: Set<KeyPurpose> = setOf(KeyPurpose.SIGN),
-    val ecCurve: EcCurve = EcCurve.P256
-)
+    val ecCurve: EcCurve = EcCurve.P256,
+    val signingAlgorithm: Algorithm = defaultSigningAlgorithm(keyPurposes, ecCurve)
+) {
+    companion object {
+        /**
+         * Returns the most appropriate value for [signingAlgorithm] given specified
+         * [keyPurposes] and [ecCurve].
+         * 
+         * See also [EcCurve.defaultSigningAlgorithm].
+         */
+        fun defaultSigningAlgorithm(keyPurposes: Set<KeyPurpose>, ecCurve: EcCurve): Algorithm {
+            return if (keyPurposes.contains(KeyPurpose.SIGN)) {
+                ecCurve.defaultSigningAlgorithm
+            } else {
+                Algorithm.UNSET
+            }
+        }
+    }
+}

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyInfo.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/KeyInfo.kt
@@ -1,5 +1,6 @@
 package com.android.identity.securearea
 
+import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.EcPublicKey
 
 /**
@@ -11,11 +12,14 @@ import com.android.identity.crypto.EcPublicKey
  * @param alias the alias for the key.
  * @param publicKey the public part of the key.
  * @param keyPurposes the purposes of the key.
+ * @param signingAlgorithm algorithm to utilize when this key is used for signing,
+ *     only meaningful when [keyPurposes] contains [KeyPurpose.SIGN]
  * @param attestation the attestation for the key.
  */
 open class KeyInfo protected constructor(
     val alias: String,
     val publicKey: EcPublicKey,
     val keyPurposes: Set<KeyPurpose>,
+    val signingAlgorithm: Algorithm,
     val attestation: KeyAttestation
 )

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/SecureArea.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/SecureArea.kt
@@ -15,7 +15,6 @@
  */
 package com.android.identity.securearea
 
-import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.EcPublicKey
 import com.android.identity.crypto.EcSignature
 
@@ -89,10 +88,10 @@ interface SecureArea {
      *
      * If the key needs unlocking before use (for example user authentication
      * in any shape or form) and `keyUnlockData` isn't set or doesn't contain
-     * what's needed, [KeyLockedException] is thrown.
+     * what's needed, [KeyLockedException] is thrown. Signature algorithm must be specified at key
+     * creation time using [CreateKeySettings.signingAlgorithm].
      *
      * @param alias The alias of the EC key to sign with.
-     * @param signatureAlgorithm the signature algorithm to use.
      * @param dataToSign the data to sign.
      * @param keyUnlockData data used to unlock the key, `null`, or a [KeyUnlockInteractive] to
      *     handle user authentication automatically.
@@ -105,7 +104,6 @@ interface SecureArea {
      */
     suspend fun sign(
         alias: String,
-        signatureAlgorithm: Algorithm,
         dataToSign: ByteArray,
         keyUnlockData: KeyUnlockData? = KeyUnlockInteractive()
     ): EcSignature

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/cloud/CloudKeyInfo.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/cloud/CloudKeyInfo.kt
@@ -1,5 +1,6 @@
 package com.android.identity.securearea.cloud
 
+import com.android.identity.crypto.Algorithm
 import com.android.identity.securearea.KeyAttestation
 import com.android.identity.securearea.KeyInfo
 import com.android.identity.securearea.KeyPurpose
@@ -12,6 +13,7 @@ class CloudKeyInfo internal constructor(
     alias: String,
     attestation: KeyAttestation,
     keyPurposes: Set<KeyPurpose>,
+    signingAlgorithm: Algorithm,
 
     /**
      * Whether user authentication is required to use the key.
@@ -37,6 +39,5 @@ class CloudKeyInfo internal constructor(
      * Whether the key is passphrase protected.
      */
     val isPassphraseRequired: Boolean,
-
-    ) : KeyInfo(alias, attestation.publicKey, keyPurposes, attestation)
+) : KeyInfo(alias, attestation.publicKey, keyPurposes, signingAlgorithm, attestation)
 

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/cloud/CloudSecureAreaProtocol.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/cloud/CloudSecureAreaProtocol.kt
@@ -353,6 +353,7 @@ object CloudSecureAreaProtocol {
     data class CreateKeyRequest0(
         val purposes: Set<KeyPurpose>,
         val curve: EcCurve,
+        val signingAlgorithm: Int?,
         val validFromMillis: Long,
         val validUntilMillis: Long,
         val passphraseRequired: Boolean,
@@ -378,7 +379,6 @@ object CloudSecureAreaProtocol {
     ) : Command()
 
     data class SignRequest0(
-        val signatureAlgorithm: Int,
         val dataToSign: ByteArray,
         val keyContext: ByteArray
     ) : Command()

--- a/identity/src/commonMain/kotlin/com/android/identity/securearea/software/SoftwareKeyInfo.kt
+++ b/identity/src/commonMain/kotlin/com/android/identity/securearea/software/SoftwareKeyInfo.kt
@@ -1,5 +1,6 @@
 package com.android.identity.securearea.software
 
+import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.EcPublicKey
 import com.android.identity.securearea.KeyAttestation
 import com.android.identity.securearea.KeyInfo
@@ -17,11 +18,13 @@ class SoftwareKeyInfo internal constructor(
     publicKey: EcPublicKey,
     attestation: KeyAttestation,
     keyPurposes: Set<KeyPurpose>,
+    signingAlgorithm: Algorithm,
     val isPassphraseProtected: Boolean,
     val passphraseConstraints: PassphraseConstraints?
 ): KeyInfo(
     alias,
     publicKey,
     keyPurposes,
+    signingAlgorithm,
     attestation
 )

--- a/identity/src/iosMain/kotlin/com/android/identity/securearea/SecureEnclaveKeyInfo.kt
+++ b/identity/src/iosMain/kotlin/com/android/identity/securearea/SecureEnclaveKeyInfo.kt
@@ -1,5 +1,6 @@
 package com.android.identity.securearea
 
+import com.android.identity.crypto.Algorithm
 import com.android.identity.crypto.EcPublicKey
 import com.android.identity.securearea.KeyInfo
 import com.android.identity.securearea.KeyPurpose
@@ -12,6 +13,7 @@ class SecureEnclaveKeyInfo internal constructor(
     alias: String,
     publicKey: EcPublicKey,
     keyPurposes: Set<KeyPurpose>,
+    signingAlgorithm: Algorithm,
 
     /**
      * Whether the user authentication is required to use the key.
@@ -23,4 +25,4 @@ class SecureEnclaveKeyInfo internal constructor(
      */
     val userAuthenticationTypes: Set<SecureEnclaveUserAuthType>
 
-): KeyInfo(alias, publicKey, keyPurposes, KeyAttestation(publicKey, null))
+): KeyInfo(alias, publicKey, keyPurposes, signingAlgorithm, KeyAttestation(publicKey, null))

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/PresentationActivity.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/PresentationActivity.kt
@@ -289,8 +289,7 @@ class PresentationActivity : ComponentActivity() {
                     NameSpacedData.Builder().build(),
                     credential.secureArea,
                     credential.alias,
-                    null,
-                    Algorithm.ES256
+                    null
                 )
                 .generate()
         )

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -541,12 +541,10 @@ private suspend fun aksTestUnguarded(
     )
 
     if (keyPurpose == KeyPurpose.SIGN) {
-        val signingAlgorithm = curve.defaultSigningAlgorithm
         val dataToSign = "data".toByteArray()
         val t0 = System.currentTimeMillis()
         val signature = androidKeystoreSecureArea.sign(
             "testKey",
-            signingAlgorithm,
             dataToSign,
             KeyUnlockInteractive(requireConfirmation = biometricConfirmationRequired))
         val t1 = System.currentTimeMillis()

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
@@ -445,11 +445,9 @@ private suspend fun csaTestUnguarded(
     cloudSecureArea!!.createKey("testKey", builder.build())
 
     if (keyPurpose == KeyPurpose.SIGN) {
-        val signingAlgorithm = curve.defaultSigningAlgorithm
         val t0 = Clock.System.now()
         val signature = cloudSecureArea!!.sign(
             "testKey",
-            signingAlgorithm,
             "data".encodeToByteArray(),
             KeyUnlockInteractive())
         val t1 = Clock.System.now()

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SoftwareSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SoftwareSecureAreaScreen.kt
@@ -151,12 +151,10 @@ private suspend fun swTestUnguarded(
     )
 
     if (keyPurpose == KeyPurpose.SIGN) {
-        val signingAlgorithm = curve.defaultSigningAlgorithm
         try {
             val t0 = Clock.System.now()
             val signature = softwareSecureArea.sign(
                 "testKey",
-                signingAlgorithm,
                 "data".encodeToByteArray(),
                 interactiveUnlock,
             )

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/ui/SecureEnclaveSecureAreaScreenIos.kt
@@ -146,12 +146,10 @@ private suspend fun seTestUnguarded(
     val keyUnlockData = SecureEnclaveKeyUnlockData(laContext)
 
     if (keyPurpose == KeyPurpose.SIGN) {
-        val signingAlgorithm = Algorithm.ES256
         val dataToSign = "data".encodeToByteArray()
         val t0 = Clock.System.now()
         val signature = secureEnclaveSecureArea.sign(
             "testKey",
-            signingAlgorithm,
             dataToSign,
             keyUnlockData
         )

--- a/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/DocumentModel.kt
@@ -992,7 +992,6 @@ class DocumentModel(
                             subtitle = activity.resources.getString(R.string.issuance_biometric_prompt_subtitle),
                             secureArea = credential.secureArea,
                             alias = credential.alias,
-                            algorithm = Algorithm.ES256,
                             messageToSign = challenge.messageToSign
                         )
                         possessionProofs.add(KeyPossessionProof(signature))
@@ -1034,7 +1033,6 @@ suspend fun signWithUnlock(
     subtitle: String,
     secureArea: SecureArea,
     alias: String,
-    algorithm: Algorithm,
     messageToSign: ByteString
 ): ByteString {
     // initially null and updated when catching a KeyLockedException in the while-loop below
@@ -1044,7 +1042,6 @@ suspend fun signWithUnlock(
         try {
             val signature = secureArea.sign(
                 alias,
-                algorithm,
                 messageToSign.toByteArray(),
                 keyUnlockData = keyUnlockData
             )
@@ -1054,8 +1051,8 @@ suspend fun signWithUnlock(
             when (secureArea) {
                 // show Biometric prompt
                 is AndroidKeystoreSecureArea -> {
-                    val unlockData = AndroidKeystoreKeyUnlockData(alias)
-                    val cryptoObject = unlockData.getCryptoObjectForSigning(algorithm)
+                    val unlockData = AndroidKeystoreKeyUnlockData(secureArea, alias)
+                    val cryptoObject = unlockData.getCryptoObjectForSigning()
 
                     // update KeyUnlockData to be used on the next loop iteration
                     keyUnlockData = unlockData

--- a/wallet/src/main/java/com/android/identity_credential/wallet/presentation/PresentmentFlow.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/presentation/PresentmentFlow.kt
@@ -78,13 +78,12 @@ private suspend fun showPresentmentFlowImpl(
             // The only way we should get a KeyLockedException is if this is a secure area bound
             // credential.
             val secureAreaBoundCredential = credential as SecureAreaBoundCredential
-            when (secureAreaBoundCredential.secureArea) {
+            when (val secureArea = secureAreaBoundCredential.secureArea) {
                 // show Biometric prompt
                 is AndroidKeystoreSecureArea -> {
                     val unlockData =
-                        AndroidKeystoreKeyUnlockData(secureAreaBoundCredential.alias)
-                    val cryptoObject =
-                        unlockData.getCryptoObjectForSigning(Algorithm.ES256)
+                        AndroidKeystoreKeyUnlockData(secureArea, secureAreaBoundCredential.alias)
+                    val cryptoObject = unlockData.getCryptoObjectForSigning()
 
                     // update KeyUnlockData to be used on the next loop iteration
                     keyUnlockData = unlockData
@@ -259,9 +258,8 @@ suspend fun showSdJwtPresentmentFlow(
             secureAreaBoundCredential?.secureArea,
             secureAreaBoundCredential?.alias,
             keyUnlockData,
-            Algorithm.ES256,
-            nonce!!,
-            clientId!!
+            nonce,
+            clientId
         ).toString().toByteArray(Charsets.US_ASCII)
     }
 }
@@ -285,8 +283,7 @@ private suspend fun mdocSignAndGenerate(
         NameSpacedData.Builder().build(),
         credential.secureArea,
         credential.alias,
-        keyUnlockData,
-        Algorithm.ES256
+        keyUnlockData
     )
     // increment the credential's usage count since it just finished signing the data successfully
     credential.increaseUsageCount()

--- a/wallet/src/main/java/com/android/identity_credential/wallet/presentation/TransferHelper.kt
+++ b/wallet/src/main/java/com/android/identity_credential/wallet/presentation/TransferHelper.kt
@@ -226,8 +226,7 @@ class TransferHelper(
                         NameSpacedData.Builder().build(),
                         credential.secureArea,
                         credential.alias,
-                        keyUnlockData,
-                        Algorithm.ES256
+                        keyUnlockData
                     )
                     .generate()
             )


### PR DESCRIPTION
Fixes #865

This PR changes `SecureArea` APIs, so that signing algorithm is specified at key creation time and converts the existing code to the new usage. Signing algorithm is also now exposed on the `KeyInfo` object.

Additionally, harmonize all `SecureArea` implementations so that non-implementation specific `CreateKeySettings` are honored in all implementations.

Updated tests.

Testing: unit tests + TestApp SA pages + manually tested provisioning and presentation in the TestApp and Wallet apps.