### PR TITLE
Fixed an issue where an NFC scan would cause following QR scans to fail.

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/UiProviderAndroid.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/UiProviderAndroid.kt
@@ -72,7 +72,7 @@ actual fun UiProvider(lifecycleOwner: LifecycleOwner) {
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) {
+            if (event == Lifecycle.Event.ON_START || event == Lifecycle.Event.ON_RESUME) {
                 UiModelAndroid.registerView(provider)
             } else if (event == Lifecycle.Event.ON_STOP) {
                 UiModelAndroid.unregisterView(provider)

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/UiProvider.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/UiProvider.kt
@@ -69,7 +69,7 @@ fun UiProviderCommon(lifecycleOwner: LifecycleOwner) {
 
     DisposableEffect(lifecycleOwner) {
         val observer = LifecycleEventObserver { _, event ->
-            if (event == Lifecycle.Event.ON_START) {
+            if (event == Lifecycle.Event.ON_START || event == Lifecycle.Event.ON_RESUME) {
                 UiModel.registerView(provider)
             } else if (event == Lifecycle.Event.ON_STOP) {
                 UiModel.unregisterView(provider)


### PR DESCRIPTION
We were getting a UiViewNotAvailableException, because UiModel.unregisterView() was being called when the NFC screen was removed, but UiModel.registerView() wasn't being called when the underlying screen came back. We were only handling the ON_START lifecycle event, not the ON_RESUME one, so a Stop/Resume cycle would leave the UI provider unregistered.

Tested by:
- Manual testing in testapp, where the bug occurred before.
