### PR TITLE
Treat Warnings as Errors.

### DIFF
--- a/appverifier/build.gradle.kts
+++ b/appverifier/build.gradle.kts
@@ -7,7 +7,6 @@ plugins {
     id("kotlin-android")
     alias(libs.plugins.navigation.safe.args)
     alias(libs.plugins.parcelable)
-    alias(libs.plugins.kapt)
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -15,6 +14,10 @@ val projectVersionName: String by rootProject.extra
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
 }
 
 android {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ val projectVersionCode: Int by extra {
         commandLine("git", "rev-list", "HEAD", "--count")
         standardOutput = stdout
     }
+    @Suppress("DEPRECATION") // toString() is deprecated.
     stdout.toString().trim().toInt()
 }
 
@@ -17,6 +18,7 @@ val projectVersionName: String by extra {
         commandLine("git", "describe", "--tags", "--dirty")
         standardOutput = stdout
     }
+    @Suppress("DEPRECATION") // toString() is deprecated.
     stdout.toString().trim()
 }
 
@@ -32,6 +34,5 @@ plugins {
     alias(libs.plugins.gretty) apply false
     alias(libs.plugins.navigation.safe.args) apply false
     alias(libs.plugins.parcelable) apply false
-    alias(libs.plugins.kapt) apply false
     alias(libs.plugins.buildconfig) apply false
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -154,7 +154,6 @@ jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin"
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 gretty = { id = "org.gretty", version.ref = "gretty"}
 navigation-safe-args = { id = "androidx.navigation.safeargs.kotlin", version.ref = "navigation-plugin" }
-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 parcelable = { id = "org.jetbrains.kotlin.plugin.parcelize", version.ref = "kotlin" }
 buildconfig = { id = "com.github.gmazzo.buildconfig", version.ref = "buildconfig" }
 kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }

--- a/jpeg2k/build.gradle.kts
+++ b/jpeg2k/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
+        @Suppress("DEPRECATION") // The targetSdk option is deprecated.
         targetSdk = libs.versions.android.targetSdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/multipaz-mrtd-reader-android/build.gradle.kts
+++ b/multipaz-mrtd-reader-android/build.gradle.kts
@@ -13,6 +13,7 @@ android {
 
     defaultConfig {
         minSdk = libs.versions.android.minSdk.get().toInt()
+        @Suppress("DEPRECATION") // targetSdk is deprecated.
         targetSdk = libs.versions.android.targetSdk.get().toInt()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/multipaz/SwiftBridge/build.gradle.kts
+++ b/multipaz/SwiftBridge/build.gradle.kts
@@ -2,6 +2,7 @@ import org.jetbrains.kotlin.konan.target.HostManager
 
 if (HostManager.hostIsMac) {
     listOf("iphoneos", "iphonesimulator").forEach { sdk ->
+        @Suppress("DEPRECATION") // The capitalize() is deprecated.
         tasks.create<Exec>("build${sdk.capitalize()}") {
             group = "build"
 

--- a/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/CryptoJvm.kt
+++ b/multipaz/src/javaSharedMain/kotlin/org/multipaz/crypto/CryptoJvm.kt
@@ -859,6 +859,7 @@ actual object Crypto {
         recipientKey: EcPrivateKey
     ): JsonObject {
         val encryptedJWT = EncryptedJWT.parse(encryptedJwt.jsonPrimitive.content)
+        @Suppress("DEPRECATION") // ECKey is deprecated
         val encKey = ECKey(
             Curve.P_256,
             recipientKey.publicKey.javaPublicKey as ECPublicKey,
@@ -877,6 +878,7 @@ actual object Crypto {
         type: String?,
         x5c: X509CertChain?
     ): JsonElement {
+        @Suppress("DEPRECATION") // ECKey is deprecated
         val ecKey = ECKey(
             Curve.P_256,
             key.publicKey.javaPublicKey as ECPublicKey,

--- a/samples/age-verifier-mdl/build.gradle.kts
+++ b/samples/age-verifier-mdl/build.gradle.kts
@@ -10,6 +10,10 @@ val projectVersionName: String by rootProject.extra
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
 }
 
 android {

--- a/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
+++ b/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION") // For the deprecated PreferenceManager only.
 package org.multipaz.age_verifier_mdl
 
 import android.annotation.SuppressLint

--- a/samples/preconsent-mdl/build.gradle.kts
+++ b/samples/preconsent-mdl/build.gradle.kts
@@ -11,6 +11,10 @@ val projectVersionName: String by rootProject.extra
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
 }
 
 android {

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+@file:Suppress("DEPRECATION")  // For the deprecated PreferenceManager only.
+
 package org.multipaz.preconsent_mdl
 
 import android.annotation.SuppressLint

--- a/samples/simple-verifier/build.gradle.kts
+++ b/samples/simple-verifier/build.gradle.kts
@@ -10,6 +10,10 @@ val projectVersionName: String by rootProject.extra
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
 }
 
 android {

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -25,6 +25,7 @@ kotlin {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_17)
+            allWarningsAsErrors = true
         }
     }
     

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -9,6 +9,10 @@ plugins {
 
 kotlin {
     jvmToolchain(17)
+
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
 }
 
 java {

--- a/wallet/build.gradle.kts
+++ b/wallet/build.gradle.kts
@@ -24,6 +24,10 @@ buildConfig {
 kotlin {
     jvmToolchain(17)
 
+    compilerOptions {
+        allWarningsAsErrors = true
+    }
+
     androidTarget {
         @OptIn(ExperimentalKotlinGradlePluginApi::class)
         compilerOptions {

--- a/wallet/src/androidMain/kotlin/org/multipaz/wallet/WalletApplication.kt
+++ b/wallet/src/androidMain/kotlin/org/multipaz/wallet/WalletApplication.kt
@@ -1,3 +1,4 @@
+@file:Suppress("DEPRECATION") // For the deprecated PreferenceManager only.
 package org.multipaz_credential.wallet
 
 import android.Manifest


### PR DESCRIPTION
+ Updated all Android configurations and the server to use the allWarningsAsErrors = true at compile time.
+ Fixed deprecation errors where needed.
+ removed the KAPT dependency (deprecated in K2).

Tests are passing.