### PR TITLE
identity-sdjwt: Fix unit tests.

### DIFF
--- a/identity-sdjwt/src/commonTest/kotlin/com/android/identity/sdjwt/DisclosureTest.kt
+++ b/identity-sdjwt/src/commonTest/kotlin/com/android/identity/sdjwt/DisclosureTest.kt
@@ -4,9 +4,9 @@ import com.android.identity.crypto.Algorithm
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlinx.serialization.json.put
-import org.junit.Assert.assertEquals
-import org.junit.Test
 import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertEquals
 
 class DisclosureTest {
 

--- a/identity-sdjwt/src/commonTest/kotlin/com/android/identity/sdjwt/util/JsonWebKeyTest.kt
+++ b/identity-sdjwt/src/commonTest/kotlin/com/android/identity/sdjwt/util/JsonWebKeyTest.kt
@@ -4,19 +4,11 @@ import com.android.identity.crypto.Crypto
 import com.android.identity.crypto.EcCurve
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.junit.Before
-import org.junit.Test
-import java.security.Security
+import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class JsonWebKeyTest {
-
-    @Before
-    fun setup() {
-        Security.insertProviderAt(BouncyCastleProvider(), 1)
-    }
 
     @Test
     fun testP256() {
@@ -74,6 +66,12 @@ class JsonWebKeyTest {
     }
 
     private fun parseAndEncode(curve: EcCurve) {
+        // TODO: use assumeTrue() when available in kotlin-test
+        if (!Crypto.supportedCurves.contains(curve)) {
+            println("Curve $curve not supported on platform")
+            return
+        }
+
         val pubKey = Crypto.createEcPrivateKey(curve).publicKey
         val jwk = JsonWebKey(pubKey).asJwk
         assertTrue("jwk" in jwk.keys)


### PR DESCRIPTION
The previous commit to port identity-sdjwt to KMP didn't port the unit tests. This went under the radar because both the author and the CI wasn't using a Mac. This commit makes the unit test compile and pass on KMP.

Test: ./gradlew identity-sdjwt:check
