### PR TITLE
Minor fix for coroutine scopes in CloudSecureArea screen in test app.

### DIFF
--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
@@ -150,7 +150,7 @@ fun CloudSecureAreaScreen(
 
         item {
             TextButton(onClick = {
-                CoroutineScope(Dispatchers.IO).launch {
+                coroutineScope.launch {
                     try {
                         val attestation = csaAttestation(showToast)
                         if (attestation != null) {
@@ -233,7 +233,7 @@ fun CloudSecureAreaScreen(
 
                         item {
                             TextButton(onClick = {
-                                CoroutineScope(Dispatchers.IO).launch {
+                                coroutineScope.launch {
                                     csaTest(
                                         keyPurpose = keyPurpose,
                                         curve = curve,


### PR DESCRIPTION
Make sure that we run in the scope that has `PromptModel`.