### PR TITLE
Port MobileSecurityObjectGenerator to take Algorithm instead of string.

### DIFF
--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
@@ -161,7 +161,7 @@ class DeviceRetrievalHelperTest {
 
         // Generate an MSO and issuer-signed data for this credential.
         val msoGenerator = MobileSecurityObjectGenerator(
-            "SHA-256",
+            Algorithm.SHA256,
             MDL_DOCTYPE,
             mdocCredential.getAttestation().publicKey
         )

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Util.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Util.kt
@@ -94,7 +94,6 @@ import javax.crypto.Mac
 import javax.crypto.SecretKey
 import javax.crypto.spec.SecretKeySpec
 
-// TODO: b/393388152 - Multiple unused methods.
 /**
  * Utility functions.
  */

--- a/multipaz-android-legacy/src/test/java/com/android/identity/android/legacy/UtilTest.java
+++ b/multipaz-android-legacy/src/test/java/com/android/identity/android/legacy/UtilTest.java
@@ -29,6 +29,7 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import org.multipaz.crypto.Algorithm;
 import org.multipaz.crypto.EcCurve;
 import org.multipaz.crypto.EcPublicKeyJvmKt;
 import org.multipaz.mdoc.mso.MobileSecurityObjectGenerator;
@@ -191,7 +192,7 @@ public class UtilTest {
 
             MobileSecurityObjectGenerator msoGenerator =
                     new MobileSecurityObjectGenerator(
-                            "SHA-256",
+                            Algorithm.SHA256,
                             docType,
                             EcPublicKeyJvmKt.toEcPublicKey(authKey, EcCurve.P256))
                             .setValidityInfo(

--- a/multipaz-provisioning/src/main/java/org/multipaz/issuance/hardcoded/IssuingAuthorityState.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/issuance/hardcoded/IssuingAuthorityState.kt
@@ -487,7 +487,7 @@ class IssuingAuthorityState(
             else -> throw IllegalArgumentException("Unknown type $type")
         }
         val msoGenerator = MobileSecurityObjectGenerator(
-            "SHA-256",
+            Algorithm.SHA256,
             docType,
             authenticationKey
         )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
@@ -156,11 +156,8 @@ class DeviceResponseParser(
             }
 
             /* don't care about version for now */
-            val digestAlgorithm = when (parsedMso.digestAlgorithm) {
-                "SHA-256" -> Algorithm.SHA256
-                "SHA-384" -> Algorithm.SHA384
-                "SHA-512" -> Algorithm.SHA512
-                else -> throw IllegalStateException("Unexpected digest algorithm ${parsedMso.digestAlgorithm}")
+            check(parsedMso.digestAlgorithm in listOf(Algorithm.SHA256, Algorithm.SHA384, Algorithm.SHA512)) {
+                "Unexpected digest algorithm ${parsedMso.digestAlgorithm}"
             }
             val msoDocType = parsedMso.docType
             require(msoDocType == expectedDocType) {
@@ -192,7 +189,7 @@ class DeviceResponseParser(
                         // We need the encoded representation with the tag.
                         val encodedIssuerSignedItemBytes = Cbor.encode(elem)
                         val expectedDigest =
-                            Crypto.digest(digestAlgorithm, encodedIssuerSignedItemBytes)
+                            Crypto.digest(parsedMso.digestAlgorithm, encodedIssuerSignedItemBytes)
                         val issuerSignedItem = Cbor.decode(elem.asTagged.asBstr)
                         val elementName = issuerSignedItem["elementIdentifier"].asTstr
                         val elementValue = issuerSignedItem["elementValue"]

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectGeneratorTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectGeneratorTest.kt
@@ -42,118 +42,114 @@ class MobileSecurityObjectGeneratorTest {
             else -> throw AssertionError()
         }
     }
-    
-    private fun generateISODigest(digestAlgorithm: String): Map<Long, ByteArray> {
-        val alg = getDigestAlg(digestAlgorithm)
+
+    private fun generateISODigest(digestAlgorithm: Algorithm): Map<Long, ByteArray> {
         val isoDigestIDs = mutableMapOf<Long, ByteArray>()
-        isoDigestIDs[0L] = Crypto.digest(alg, "aardvark".encodeToByteArray())
-        isoDigestIDs[1L] = Crypto.digest(alg, "alligator".encodeToByteArray())
-        isoDigestIDs[2L] = Crypto.digest(alg, "baboon".encodeToByteArray())
-        isoDigestIDs[3L] = Crypto.digest(alg, "butterfly".encodeToByteArray())
-        isoDigestIDs[4L] = Crypto.digest(alg, "cat".encodeToByteArray())
-        isoDigestIDs[5L] = Crypto.digest(alg, "cricket".encodeToByteArray())
-        isoDigestIDs[6L] = Crypto.digest(alg, "dog".encodeToByteArray())
-        isoDigestIDs[7L] = Crypto.digest(alg, "elephant".encodeToByteArray())
-        isoDigestIDs[8L] = Crypto.digest(alg, "firefly".encodeToByteArray())
-        isoDigestIDs[9L] = Crypto.digest(alg, "frog".encodeToByteArray())
-        isoDigestIDs[10L] = Crypto.digest(alg, "gecko".encodeToByteArray())
-        isoDigestIDs[11L] = Crypto.digest(alg, "hippo".encodeToByteArray())
-        isoDigestIDs[12L] = Crypto.digest(alg, "iguana".encodeToByteArray())
+        isoDigestIDs[0L] = Crypto.digest(digestAlgorithm, "aardvark".encodeToByteArray())
+        isoDigestIDs[1L] = Crypto.digest(digestAlgorithm, "alligator".encodeToByteArray())
+        isoDigestIDs[2L] = Crypto.digest(digestAlgorithm, "baboon".encodeToByteArray())
+        isoDigestIDs[3L] = Crypto.digest(digestAlgorithm, "butterfly".encodeToByteArray())
+        isoDigestIDs[4L] = Crypto.digest(digestAlgorithm, "cat".encodeToByteArray())
+        isoDigestIDs[5L] = Crypto.digest(digestAlgorithm, "cricket".encodeToByteArray())
+        isoDigestIDs[6L] = Crypto.digest(digestAlgorithm, "dog".encodeToByteArray())
+        isoDigestIDs[7L] = Crypto.digest(digestAlgorithm, "elephant".encodeToByteArray())
+        isoDigestIDs[8L] = Crypto.digest(digestAlgorithm, "firefly".encodeToByteArray())
+        isoDigestIDs[9L] = Crypto.digest(digestAlgorithm, "frog".encodeToByteArray())
+        isoDigestIDs[10L] = Crypto.digest(digestAlgorithm, "gecko".encodeToByteArray())
+        isoDigestIDs[11L] = Crypto.digest(digestAlgorithm, "hippo".encodeToByteArray())
+        isoDigestIDs[12L] = Crypto.digest(digestAlgorithm, "iguana".encodeToByteArray())
         return isoDigestIDs
     }
 
-    private fun generateISOUSDigest(digestAlgorithm: String): Map<Long, ByteArray> {
-        val alg = getDigestAlg(digestAlgorithm)
+    private fun generateISOUSDigest(digestAlgorithm: Algorithm): Map<Long, ByteArray> {
         val isoUSDigestIDs: MutableMap<Long, ByteArray> = HashMap()
-        isoUSDigestIDs[0L] = Crypto.digest(alg, "jaguar".encodeToByteArray())
-        isoUSDigestIDs[1L] = Crypto.digest(alg, "jellyfish".encodeToByteArray())
-        isoUSDigestIDs[2L] = Crypto.digest(alg, "koala".encodeToByteArray())
-        isoUSDigestIDs[3L] = Crypto.digest(alg, "lemur".encodeToByteArray())
+        isoUSDigestIDs[0L] = Crypto.digest(digestAlgorithm, "jaguar".encodeToByteArray())
+        isoUSDigestIDs[1L] = Crypto.digest(digestAlgorithm, "jellyfish".encodeToByteArray())
+        isoUSDigestIDs[2L] = Crypto.digest(digestAlgorithm, "koala".encodeToByteArray())
+        isoUSDigestIDs[3L] = Crypto.digest(digestAlgorithm, "lemur".encodeToByteArray())
         return isoUSDigestIDs
     }
 
-    private fun checkISODigest(isoDigestIDs: Map<Long, ByteArray>?, digestAlgorithm: String) {
-        val alg = getDigestAlg(digestAlgorithm)
+    private fun checkISODigest(isoDigestIDs: Map<Long, ByteArray>?, digestAlgorithm: Algorithm) {
         assertEquals(
             setOf(0L, 1L, 2L, 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L),
             isoDigestIDs!!.keys
         )
         assertContentEquals(
-            Crypto.digest(alg, "aardvark".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "aardvark".encodeToByteArray()),
             isoDigestIDs[0L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "alligator".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "alligator".encodeToByteArray()),
             isoDigestIDs[1L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "baboon".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "baboon".encodeToByteArray()),
             isoDigestIDs[2L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "butterfly".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "butterfly".encodeToByteArray()),
             isoDigestIDs[3L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "cat".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "cat".encodeToByteArray()),
             isoDigestIDs[4L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "cricket".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "cricket".encodeToByteArray()),
             isoDigestIDs[5L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "dog".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "dog".encodeToByteArray()),
             isoDigestIDs[6L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "elephant".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "elephant".encodeToByteArray()),
             isoDigestIDs[7L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "firefly".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "firefly".encodeToByteArray()),
             isoDigestIDs[8L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "frog".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "frog".encodeToByteArray()),
             isoDigestIDs[9L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "gecko".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "gecko".encodeToByteArray()),
             isoDigestIDs[10L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "hippo".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "hippo".encodeToByteArray()),
             isoDigestIDs[11L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "iguana".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "iguana".encodeToByteArray()),
             isoDigestIDs[12L]
         )
     }
 
-    private fun checkISOUSDigest(isoUSDigestIDs: Map<Long, ByteArray>?, digestAlgorithm: String) {
-        val alg = getDigestAlg(digestAlgorithm)
+    private fun checkISOUSDigest(isoUSDigestIDs: Map<Long, ByteArray>?, digestAlgorithm: Algorithm) {
         assertEquals(setOf(0L, 1L, 2L, 3L), isoUSDigestIDs!!.keys)
         assertContentEquals(
-            Crypto.digest(alg, "jaguar".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "jaguar".encodeToByteArray()),
             isoUSDigestIDs[0L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "jellyfish".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "jellyfish".encodeToByteArray()),
             isoUSDigestIDs[1L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "koala".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "koala".encodeToByteArray()),
             isoUSDigestIDs[2L]
         )
         assertContentEquals(
-            Crypto.digest(alg, "lemur".encodeToByteArray()),
+            Crypto.digest(digestAlgorithm, "lemur".encodeToByteArray()),
             isoUSDigestIDs[3L]
         )
     }
 
-    fun testFullMSO(digestAlgorithm: String) {
+    private fun testFullMSO(digestAlgorithm: Algorithm) {
         val deviceKeyFromVector = EcPublicKeyDoubleCoordinate(
             EcCurve.P256,
             TestVectors.ISO_18013_5_ANNEX_D_STATIC_DEVICE_KEY_X.fromHex(),
@@ -221,7 +217,7 @@ class MobileSecurityObjectGeneratorTest {
         val signedTimestamp = Instant.fromEpochMilliseconds(1601559002000L)
         val validFromTimestamp = Instant.fromEpochMilliseconds(1601559002000L)
         val validUntilTimestamp = Instant.fromEpochMilliseconds(1633095002000L)
-        val digestAlgorithm = "SHA-256"
+        val digestAlgorithm = Algorithm.SHA256
         val encodedMSO = MobileSecurityObjectGenerator(
             digestAlgorithm,
             "org.iso.18013.5.1.mDL", deviceKeyFromVector
@@ -253,17 +249,17 @@ class MobileSecurityObjectGeneratorTest {
 
     @Test
     fun testFullMSO_Sha256() {
-        testFullMSO("SHA-256")
+        testFullMSO(Algorithm.SHA256)
     }
 
     @Test
     fun testFullMSO_Sha384() {
-        testFullMSO("SHA-384")
+        testFullMSO(Algorithm.SHA384)
     }
 
     @Test
     fun testFullMSO_Sha512() {
-        testFullMSO("SHA-512")
+        testFullMSO(Algorithm.SHA512)
     }
 
     @Test
@@ -276,11 +272,11 @@ class MobileSecurityObjectGeneratorTest {
         assertFailsWith<IllegalArgumentException>(
             "expect exception for illegal digestAlgorithm") {
             MobileSecurityObjectGenerator(
-                "SHA-257",
+                Algorithm.UNSET,
                 "org.iso.18013.5.1.mDL", deviceKeyFromVector
             )
         }
-        val digestAlgorithm = "SHA-256"
+        val digestAlgorithm = Algorithm.SHA256
         val msoGenerator = MobileSecurityObjectGenerator(
             digestAlgorithm,
             "org.iso.18013.5.1.mDL", deviceKeyFromVector
@@ -378,11 +374,11 @@ class MobileSecurityObjectGeneratorTest {
         val expectedUpdateTimestampWholeSeconds = Instant.fromEpochSeconds(7100, 0)
 
         val encodedMSO = MobileSecurityObjectGenerator(
-            "SHA-256",
+            Algorithm.SHA256,
             "org.iso.18013.5.1.mDL", deviceKeyFromVector
         )
             .setValidityInfo(signedTimestamp, validFromTimestamp, validUntilTimestamp, expectedUpdateTimestamp)
-            .addDigestIdsForNamespace("org.iso.18013.5.1", generateISODigest("SHA-256"))
+            .addDigestIdsForNamespace("org.iso.18013.5.1", generateISODigest(Algorithm.SHA256))
             .generate()
         val mso = MobileSecurityObjectParser(encodedMSO).parse()
         assertEquals(signedTimestampWholeSeconds, mso.signed)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectParserTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/mso/MobileSecurityObjectParserTest.kt
@@ -22,6 +22,7 @@ import org.multipaz.mdoc.TestVectors
 import org.multipaz.util.fromHex
 import org.multipaz.util.toHex
 import kotlinx.datetime.Instant
+import org.multipaz.crypto.Algorithm
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
@@ -42,7 +43,7 @@ class MobileSecurityObjectParserTest {
         // response - the goal is to check that the parser returns the expected values
         val mso = MobileSecurityObjectParser(encodedMobileSecurityObject).parse()
         assertEquals("1.0", mso.version)
-        assertEquals("SHA-256", mso.digestAlgorithm)
+        assertEquals(Algorithm.SHA256, mso.digestAlgorithm)
         assertEquals("org.iso.18013.5.1.mDL", mso.docType)
         assertEquals(
             setOf("org.iso.18013.5.1", "org.iso.18013.5.1.US"),

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/response/DeviceResponseGeneratorTest.kt
@@ -161,7 +161,7 @@ class DeviceResponseGeneratorTest {
         ).build()
         for (mdocCredential in listOf(mdocCredentialSign, mdocCredentialMac)) {
             val msoGenerator = MobileSecurityObjectGenerator(
-                "SHA-256",
+                Algorithm.SHA256,
                 DOC_TYPE,
                 mdocCredential.getAttestation().publicKey
             )

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/MainActivity.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/MainActivity.kt
@@ -167,7 +167,7 @@ class MainActivity : ComponentActivity() {
 
             // Generate an MSO and issuer-signed data for this credentials.
             val msoGenerator = MobileSecurityObjectGenerator(
-                "SHA-256",
+                Algorithm.SHA256,
                 MDL_DOCTYPE,
                 pendingCredential.getAttestation().publicKey
             )

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppUtils.kt
@@ -380,7 +380,7 @@ object TestAppUtils {
 
                 // Generate an MSO and issuer-signed data for this authentication key.
                 val msoGenerator = MobileSecurityObjectGenerator(
-                    "SHA-256",
+                    Algorithm.SHA256,
                     documentType.mdocDocumentType!!.docType,
                     mdocCredential.getAttestation().publicKey
                 )

--- a/server/src/main/java/com/android/identity/server/openid4vci/CredentialFactoryMdl.kt
+++ b/server/src/main/java/com/android/identity/server/openid4vci/CredentialFactoryMdl.kt
@@ -72,7 +72,7 @@ internal class CredentialFactoryMdl : CredentialFactory {
         // Generate an MSO and issuer-signed data for this authentication key.
         val docType = DrivingLicense.MDL_DOCTYPE
         val msoGenerator = MobileSecurityObjectGenerator(
-            "SHA-256",
+            Algorithm.SHA256,
             docType,
             authenticationKey!!
         )

--- a/server/src/main/java/com/android/identity/server/openid4vci/CredentialServlet.kt
+++ b/server/src/main/java/com/android/identity/server/openid4vci/CredentialServlet.kt
@@ -258,7 +258,7 @@ class CredentialServlet : BaseServlet() {
         // Generate an MSO and issuer-signed data for this authentication key.
         val docType = EUPersonalID.EUPID_DOCTYPE
         val msoGenerator = MobileSecurityObjectGenerator(
-            "SHA-256",
+            Algorithm.SHA256,
             docType,
             authenticationKey
         )

--- a/wallet/src/androidMain/kotlin/org/multipaz/wallet/DocumentModel.kt
+++ b/wallet/src/androidMain/kotlin/org/multipaz/wallet/DocumentModel.kt
@@ -428,7 +428,7 @@ class DocumentModel(
         val kvPairs = mutableMapOf<String, String>()
         kvPairs.put("Document Type", mso.docType)
         kvPairs.put("MSO Version", mso.version)
-        kvPairs.put("Issuer Data Digest Algorithm", mso.digestAlgorithm)
+        kvPairs.put("Issuer Data Digest Algorithm", mso.digestAlgorithm.description)
 
         if (mdocCredential is MdocCredential) {
             addSecureAreaBoundCredentialInfo(mdocCredential, kvPairs)


### PR DESCRIPTION
Refactor String for Algorithm enum use.

Test: Unit tests amended too and are passing.