### PR TITLE
SecureArea: Add new batchCreateKey() method.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/BatchCreateKeyResult.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/BatchCreateKeyResult.kt
@@ -1,0 +1,16 @@
+package org.multipaz.securearea
+
+import kotlinx.serialization.json.JsonObject
+
+/**
+ * Result of a [SecureArea.batchCreateKey] call.
+ *
+ * @property keyInfos a list [KeyInfo], one for each of the created keys.
+ * @property openid4vciKeyAttestation an attestation over all the keys according to
+ *   [OpenID4VCI Key Attestation](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html#name-key-attestation-in-jwt-form)
+ *   or `null` if the implementation doesn't provide such an attestation or wasn't requested.
+ */
+data class BatchCreateKeyResult(
+    val keyInfos: List<KeyInfo>,
+    val openid4vciKeyAttestation: JsonObject?,
+)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureArea.kt
@@ -83,6 +83,29 @@ interface SecureArea {
     suspend fun createKey(alias: String?, createKeySettings: CreateKeySettings): KeyInfo
 
     /**
+     * Creates a batch of new keys.
+     *
+     * An [OpenID4VCI Key Attestation](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html#name-key-attestation-in-jwt-form)
+     * over all the keys may be returned. By default this doesn't happen but
+     * can be requested by specific implementations through specializations of the [CreateKeySettings] class.
+     *
+     * The default implementation just calls [createKey] in sequence without generating an OpenID4VCI attestation.
+     *
+     * @param numKeys number of keys to create.
+     * @param createKeySettings the settings for the keys to create.
+     */
+    suspend fun batchCreateKey(numKeys: Int, createKeySettings: CreateKeySettings): BatchCreateKeyResult {
+        val keyInfos = mutableListOf<KeyInfo>()
+        for (n in 1..numKeys) {
+            keyInfos.add(createKey(null, createKeySettings))
+        }
+        return BatchCreateKeyResult(
+            keyInfos = keyInfos,
+            openid4vciKeyAttestation = null
+        )
+    }
+
+    /**
      * Deletes a previously created key.
      *
      * If the key to delete doesn't exist, this is a no-op.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -863,6 +863,8 @@ open class CloudSecureArea protected constructor(
         return "${identifier}_alias_${alias}"
     }
 
+    // TODO: override batchCreateKey and implement server-side command to avoid roundtrips.
+
     companion object {
         const val IDENTIFIER_PREFIX = "CloudSecureArea"
 


### PR DESCRIPTION
This adds a new batchCreateKey() method to create many keys with the same algorithm in one shot. The default implementation simply calls createKey() in sequence but implementations may override this. For example, a Cloud Secure Area implementation can use this to minimize the amount of network roundtrips. This also adds the possibility to return an OpenID4VCI key attestation JWT.

Fixes Issue #851 and fixes Issue #852.

Test: New unit test and all unit tests pass.
