### PR TITLE
Crypto: change checkSignature() to throw if signature verification fails.

### DIFF
--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/legacy/MigrateFromKeystoreICStoreTest.kt
@@ -163,13 +163,11 @@ class MigrateFromKeystoreICStoreTest {
             null
         )
         val ecCredentialKeyPublic = credentialKeyPublic.toEcPublicKey(EcCurve.P256)
-        Assert.assertTrue(
-            checkSignature(
-                ecCredentialKeyPublic,
-                dataToSign,
-                Algorithm.ES256,
-                ecSignature
-            )
+        checkSignature(
+            ecCredentialKeyPublic,
+            dataToSign,
+            Algorithm.ES256,
+            ecSignature
         )
     }
 

--- a/multipaz-csa/src/main/java/org/multipaz/securearea/cloud/CloudSecureAreaServer.kt
+++ b/multipaz-csa/src/main/java/org/multipaz/securearea/cloud/CloudSecureAreaServer.kt
@@ -271,12 +271,12 @@ class CloudSecureAreaServer(
                 .end()
                 .build()
         )
-        check(Crypto.checkSignature(
+        Crypto.checkSignature(
             state.context!!.deviceBindingKey!!.ecPublicKey,
             dataThatWasSigned,
             Algorithm.ES256,
             request1.signature
-        )) { "Error verifying signature" }
+        )
 
         state.context!!.deviceAttestation!!.validateAssertion(request1.deviceAssertion)
 
@@ -557,11 +557,11 @@ class CloudSecureAreaServer(
                     .end()
                     .build()
             )
-            check(Crypto.checkSignature(
+            Crypto.checkSignature(
                 state.keyContext!!.localKey!!.ecPublicKey,
                 dataThatWasSignedLocally,
                 Algorithm.ES256,
-                request1.signature)) { "Error verifying signature" }
+                request1.signature)
 
             if (state.keyContext!!.passphraseRequired) {
                 val lockedOutDuration =
@@ -699,12 +699,12 @@ class CloudSecureAreaServer(
                     .end()
                     .build()
             )
-            check(Crypto.checkSignature(
+            Crypto.checkSignature(
                 state.keyContext!!.localKey!!.ecPublicKey,
                 dataThatWasSignedLocally,
                 Algorithm.ES256,
                 request1.signature
-            )) { "Error verifying signature" }
+            )
 
             if (state.keyContext!!.passphraseRequired) {
                 val lockedOutDuration =

--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/AndroidKeystoreSecureAreaTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/AndroidKeystoreSecureAreaTest.kt
@@ -133,13 +133,11 @@ class AndroidKeystoreSecureAreaTest {
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
-        Assert.assertTrue(
-            Crypto.checkSignature(
-                keyInfo.publicKey,
-                dataToSign,
-                Algorithm.ES256,
-                signature
-            )
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.ES256,
+            signature
         )
     }
 
@@ -309,13 +307,11 @@ class AndroidKeystoreSecureAreaTest {
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
-        Assert.assertTrue(
-            Crypto.checkSignature(
-                keyInfo.publicKey,
-                dataToSign,
-                Algorithm.EDDSA,
-                signature
-            )
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.EDDSA,
+            signature
         )
     }
 
@@ -512,13 +508,11 @@ class AndroidKeystoreSecureAreaTest {
         )
 
         // Check new key is used to sign.
-        Assert.assertTrue(
-            Crypto.checkSignature(
-                keyInfo.publicKey,
-                dataToSign,
-                Algorithm.ES256,
-                signature
-            )
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.ES256,
+            signature
         )
     }
 

--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
@@ -324,10 +324,8 @@ class CloudSecureAreaTest {
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
-        Assert.assertTrue(
-            Crypto.checkSignature(
-                keyInfo.publicKey, dataToSign, Algorithm.ES256, signature
-            )
+        Crypto.checkSignature(
+            keyInfo.publicKey, dataToSign, Algorithm.ES256, signature
         )
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/cose/Cose.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cose/Cose.kt
@@ -10,6 +10,7 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.EcSignature
+import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.securearea.KeyUnlockData
 import org.multipaz.securearea.SecureArea
 
@@ -122,17 +123,15 @@ object Cose {
      * @param detachedData detached data, if any.
      * @param signature the COSE_Sign1 object.
      * @param signatureAlgorithm the signature algorithm to use.
-     * @throws IllegalArgumentException if not exactly one of `detachedData` and
-     * `signature.payload` are non-`null`.
-     * @return whether the signature is valid and was made with the private key corresponding to the
-     * given public key.
+     * @throws IllegalArgumentException if not exactly one of `detachedData` and `signature.payload` are non-`null`.
+     * @throws SignatureVerificationException if the signature check fails.
      */
     fun coseSign1Check(
         publicKey: EcPublicKey,
         detachedData: ByteArray?,
         signature: CoseSign1,
         signatureAlgorithm: Algorithm
-    ): Boolean {
+    ) {
         require(
             (detachedData != null && signature.payload == null) ||
                     (detachedData == null && signature.payload != null)
@@ -149,8 +148,7 @@ object Cose {
             encodedProtectedHeaders = encodedProtectedHeaders,
             dataToBeSigned = detachedData ?: signature.payload!!
         )
-
-        return Crypto.checkSignature(
+        Crypto.checkSignature(
             publicKey,
             toBeSigned,
             signatureAlgorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
@@ -3,7 +3,6 @@
 package org.multipaz.crypto
 
 import org.multipaz.util.UUID
-import kotlinx.io.bytestring.ByteString
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 
@@ -113,13 +112,15 @@ expect object Crypto {
      * @param message the data that was signed.
      * @param algorithm the signature algorithm to use.
      * @param signature the signature.
+     * @throws SignatureVerificationException if the signature check fails.
+     * @throws IllegalStateException if an error occurred during the check, for example if data is malformed.
      */
     fun checkSignature(
         publicKey: EcPublicKey,
         message: ByteArray,
         algorithm: Algorithm,
         signature: EcSignature
-    ): Boolean
+    )
 
     /**
      * Creates an EC private key.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/SecurityException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/SecurityException.kt
@@ -1,0 +1,12 @@
+package org.multipaz.crypto
+
+/**
+ * Base class for all security exceptions.
+ *
+ * @param message a textual message
+ * @param cause the cause or `null`.
+ */
+sealed class SecurityException(
+    message: String,
+    cause: Throwable? = null
+): Exception(message, cause)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/SignatureVerificationException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/SignatureVerificationException.kt
@@ -1,0 +1,12 @@
+package org.multipaz.crypto
+
+/**
+ * Exception thrown when a cryptographic signature fails to validate.
+ *
+ * @param message a textual message
+ * @param cause the cause or `null`.
+ */
+class SignatureVerificationException(
+    message: String,
+    cause: Throwable? = null
+): SecurityException(message, cause)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509Cert.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509Cert.kt
@@ -59,9 +59,9 @@ class X509Cert(
      * Checks if the certificate was signed with a given key.
      *
      * @param publicKey the key to check the signature with.
-     * @return `true` if the certificate was signed with the given key, `false` otherwise.
+     * @throws SignatureVerificationException if the signature check fails.
      */
-    fun verify(publicKey: EcPublicKey): Boolean {
+    fun verify(publicKey: EcPublicKey) {
         val ecSignature = when (signatureAlgorithm) {
             Algorithm.ES256, Algorithm.ESP256, Algorithm.ESB256,
             Algorithm.ES384, Algorithm.ESP384, Algorithm.ESB384, Algorithm.ESB320,
@@ -76,7 +76,7 @@ class X509Cert(
             }
             else -> throw IllegalArgumentException("Unsupported algorithm $signatureAlgorithm")
         }
-        return Crypto.checkSignature(
+        Crypto.checkSignature(
             publicKey,
             tbsCertificate,
             signatureAlgorithm,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAttestationAndroid.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAttestationAndroid.kt
@@ -5,7 +5,7 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcSignature
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.util.validateAndroidKeyAttestation
-import kotlinx.io.bytestring.encodeToByteString
+import org.multipaz.crypto.SignatureVerificationException
 
 /**
  * On Android we create a private key in secure area and use its key attestation as the
@@ -31,14 +31,15 @@ data class DeviceAttestationAndroid(
     override fun validateAssertion(assertion: DeviceAssertion) {
         val signature =
             EcSignature.fromCoseEncoded(assertion.platformAssertion.toByteArray())
-        if (!Crypto.checkSignature(
+        try {
+            Crypto.checkSignature(
                 publicKey = certificateChain.certificates.first().ecPublicKey,
                 message = assertion.assertionData.toByteArray(),
                 algorithm = Algorithm.ES256,
                 signature = signature
             )
-        ) {
-            throw DeviceAssertionException("DeviceAssertion signature validation failed")
+        } catch (e: SignatureVerificationException) {
+            throw DeviceAssertionException("DeviceAssertion signature validation failed", e)
         }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/request/DeviceRequestParser.kt
@@ -143,12 +143,17 @@ class DeviceRequestParser(
                         )
                         val readerAuthenticationBytes =
                             Cbor.encode(Tagged(24, Bstr(encodedReaderAuthentication)))
-                        readerAuthenticated = Cose.coseSign1Check(
-                            readerKey,
-                            readerAuthenticationBytes,
-                            readerAuthCoseSign1,
-                            signatureAlgorithm
-                        )
+                        readerAuthenticated = try {
+                            Cose.coseSign1Check(
+                                readerKey,
+                                readerAuthenticationBytes,
+                                readerAuthCoseSign1,
+                                signatureAlgorithm
+                            )
+                            true
+                        } catch (_: Throwable) {
+                            false
+                        }
                     }
                     val requestInfo: MutableMap<String, ByteArray> = HashMap()
                     itemsRequest.getOrNull("requestInfo")?.let { requestInfoDataItem ->

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseParser.kt
@@ -34,6 +34,7 @@ import org.multipaz.util.Constants
 import org.multipaz.util.Logger
 import org.multipaz.util.toHex
 import kotlinx.datetime.Instant
+import org.multipaz.crypto.SignatureVerificationException
 
 /**
  * Helper class for parsing the bytes of `DeviceResponse`
@@ -134,12 +135,17 @@ class DeviceResponseParser(
                 ]!!.asNumber.toInt()
             )
             val documentSigningKey = issuerAuthorityCertChain.certificates[0].ecPublicKey
-            val issuerSignedAuthenticated = Cose.coseSign1Check(
-                documentSigningKey,
-                null,
-                issuerAuth,
-                signatureAlgorithm
-            )
+            val issuerSignedAuthenticated = try {
+                Cose.coseSign1Check(
+                    documentSigningKey,
+                    null,
+                    issuerAuth,
+                    signatureAlgorithm
+                )
+                true
+            } catch (_: Throwable) {
+                false
+            }
             val encodedMobileSecurityObject = Cbor.decode(issuerAuth.payload!!).asTagged.asBstr
             val parsedMso = MobileSecurityObjectParser(encodedMobileSecurityObject).parse()
 
@@ -247,12 +253,17 @@ class DeviceResponseParser(
                         CoseNumberLabel(Cose.COSE_LABEL_ALG)
                     ]!!.asNumber.toInt()
                 )
-                deviceSignedAuthenticated = Cose.coseSign1Check(
-                    deviceKey,
-                    deviceAuthenticationBytes,
-                    deviceSignatureCoseSign1,
-                    signatureAlgorithm
-                )
+                deviceSignedAuthenticated = try {
+                    Cose.coseSign1Check(
+                        deviceKey,
+                        deviceAuthenticationBytes,
+                        deviceSignatureCoseSign1,
+                        signatureAlgorithm
+                    )
+                    true
+                } catch (_: SignatureVerificationException) {
+                    false
+                }
                 builder.setDeviceSignedAuthenticatedViaSignature(true)
             } else {
                 val deviceMacDataItem = deviceAuth.getOrNull("deviceMac")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/vical/SignedVical.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/vical/SignedVical.kt
@@ -4,7 +4,6 @@ import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.CborMap
-import org.multipaz.cbor.DiagnosticOption
 import org.multipaz.cbor.Tagged
 import org.multipaz.cbor.toDataItem
 import org.multipaz.cbor.toDataItemDateTimeString
@@ -13,6 +12,7 @@ import org.multipaz.cose.CoseNumberLabel
 import org.multipaz.cose.CoseSign1
 import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
 
@@ -92,8 +92,8 @@ data class SignedVical(
          *
          * @param encodedSignedVical the encoded CBOR with the COSE_Sign1 described above.
          * @return a `SignedVical` instance.
-         * @throws IllegalArgumentException if the passed in signed VICAL is malformed or signature
-         * verification failed.
+         * @throws IllegalArgumentException if the passed in signed VICAL is malformed
+         * @throws SignatureVerificationException if signature verification failed.
          */
         fun parse(encodedSignedVical: ByteArray): SignedVical {
             val signature = CoseSign1.fromDataItem(Cbor.decode(encodedSignedVical))
@@ -108,14 +108,12 @@ data class SignedVical(
                 ?.let { Algorithm.fromCoseAlgorithmIdentifier(it) }
                 ?: throw IllegalArgumentException("Signature Algorithm not set")
 
-            if (!Cose.coseSign1Check(
+            Cose.coseSign1Check(
                 certChain.certificates.first().ecPublicKey,
                 null,
                 signature,
                 signatureAlgorithm
-            )) {
-                throw IllegalArgumentException("Signature check failed")
-            }
+            )
 
             val vicalMap = Cbor.decode(vicalPayload)
             val version = vicalMap["version"].asTstr

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtVerifiableCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtVerifiableCredential.kt
@@ -103,18 +103,16 @@ class SdJwtVerifiableCredential(
      *        @param body: JwtBody the body of the JWT
      *        @param toBeVerified ByteArray the ByteArray over which the signature was generated
      *        @param signature ByteArray the signature that needs to be checked
-     *        The lambda must return true if the signature verifies, and false otherwise.
+     *        The lambda returns if the signature verifies, throws [SignatureVerificationException] otherwise.
      */
-    fun verifyIssuerSignature(verify: (JwtHeader, JwtBody, ByteArray, EcSignature) -> Boolean) {
+    fun verifyIssuerSignature(verify: (JwtHeader, JwtBody, ByteArray, EcSignature) -> Unit) {
         val headerObj = JwtHeader.fromString(header)
         val bodyObj = JwtBody.fromString(body)
 
         val toBeVerified = "$header.$body".encodeToByteArray()
         val signature = EcSignature.fromCoseEncoded(signature.fromBase64Url())
 
-        if(!verify(headerObj, bodyObj, toBeVerified, signature)) {
-            throw IllegalStateException("Signature verification failed")
-        }
+        verify(headerObj, bodyObj, toBeVerified, signature)
     }
 
     /**
@@ -122,7 +120,7 @@ class SdJwtVerifiableCredential(
      * registered crypto provider will be used to check the signature on the SD-JWT.
      * The caller passes in a public key (which presumably was obtained after inspecting
      * the SD-JWT for the 'iss' claim), and the implementation uses the 'alg' parameter
-     * in the SD-JWT header to determing the signature algorithm to use.
+     * in the SD-JWT header to determine the signature algorithm to use.
      */
     fun verifyIssuerSignature(key: EcPublicKey) {
         verifyIssuerSignature { header, _, toBeVerified, signature ->

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/presentation/SdJwtVerifiablePresentation.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/presentation/SdJwtVerifiablePresentation.kt
@@ -46,9 +46,7 @@ class SdJwtVerifiablePresentation(
         val toBeVerified = "$keyBindingHeader.$keyBindingBody".encodeToByteArray()
         val signature = EcSignature.fromCoseEncoded(keyBindingSignature.fromBase64Url())
 
-        if (!Crypto.checkSignature(key, toBeVerified, keyBindingHeaderObj.algorithm, signature)) {
-            throw IllegalStateException("Signature verification failed")
-        }
+        Crypto.checkSignature(key, toBeVerified, keyBindingHeaderObj.algorithm, signature)
 
         return keyBindingBodyObj
     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/cloud/CloudSecureArea.kt
@@ -65,10 +65,10 @@ import kotlinx.coroutines.delay
 import kotlinx.datetime.Instant
 import kotlinx.io.Buffer
 import kotlinx.io.bytestring.ByteString
-import kotlinx.io.bytestring.buildByteString
 import kotlinx.io.bytestring.decodeToString
 import kotlinx.io.bytestring.encodeToByteString
 import kotlinx.io.readByteArray
+import org.multipaz.crypto.SignatureVerificationException
 import kotlin.random.Random
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.milliseconds
@@ -388,14 +388,15 @@ open class CloudSecureArea protected constructor(
                     .end()
                     .build()
             )
-            if (!Crypto.checkSignature(
+            try {
+                Crypto.checkSignature(
                     cloudBindingKey!!,
                     dataSignedByTheCloud,
                     Algorithm.ES256,
                     response1.signature
                 )
-            ) {
-                throw CloudException("Error verifying signature")
+            } catch(e: SignatureVerificationException) {
+                throw CloudException("Error verifying signature", e)
             }
 
             // Now we can derive SKDevice and SKCloud

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cose/CoseTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cose/CoseTests.kt
@@ -65,15 +65,12 @@ class CoseTests {
             emptyMap(),
         )
 
-        assertTrue(
-            Cose.coseSign1Check(
-                key.publicKey,
-                null,
-                coseSignature,
-                Algorithm.ES256
-            )
+        Cose.coseSign1Check(
+            key.publicKey,
+            null,
+            coseSignature,
+            Algorithm.ES256
         )
-
     }
 
     @Test
@@ -108,13 +105,11 @@ class CoseTests {
             "This is the content.".encodeToByteArray()
         )
 
-        assertTrue(
-            Cose.coseSign1Check(
-                coseKey.ecPublicKey,
-                null,
-                coseSign1,
-                Algorithm.ES256
-            )
+        Cose.coseSign1Check(
+            coseKey.ecPublicKey,
+            null,
+            coseSign1,
+            Algorithm.ES256
         )
     }
 
@@ -143,13 +138,11 @@ class CoseTests {
             mapOf()
         )
 
-        assertTrue(
-            Cose.coseSign1Check(
-                privateKey.publicKey,
-                null,
-                coseSignature,
-                signatureAlgorithm
-            )
+        Cose.coseSign1Check(
+            privateKey.publicKey,
+            null,
+            coseSignature,
+            signatureAlgorithm
         )
     }
 
@@ -189,13 +182,11 @@ class CoseTests {
             unprotectedHeaders = mapOf(),
             keyUnlockData = null
         )
-        assertTrue(
-            Cose.coseSign1Check(
-                sa.getKeyInfo("testKey").publicKey,
-                null,
-                coseSignNoExplicitHeaderSet,
-                algorithm
-            )
+        Cose.coseSign1Check(
+            sa.getKeyInfo("testKey").publicKey,
+            null,
+            coseSignNoExplicitHeaderSet,
+            algorithm
         )
         assertEquals(
             algorithm.curve!!.defaultSigningAlgorithm.coseAlgorithmIdentifier!!,
@@ -215,13 +206,11 @@ class CoseTests {
             unprotectedHeaders = mapOf(),
             keyUnlockData = null
         )
-        assertTrue(
-            Cose.coseSign1Check(
-                sa.getKeyInfo("testKey").publicKey,
-                null,
-                coseSignExplicitHeaderSet,
-                algorithm
-            )
+        Cose.coseSign1Check(
+            sa.getKeyInfo("testKey").publicKey,
+            null,
+            coseSignExplicitHeaderSet,
+            algorithm
         )
         assertEquals(
             algorithm.coseAlgorithmIdentifier!!,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertTests.kt
@@ -141,7 +141,7 @@ class X509CertTests {
             .includeAuthorityKeyIdentifierAsSubjectKeyIdentifier()
             .build()
 
-        assertTrue(cert.verify(key.publicKey))
+        cert.verify(key.publicKey)
 
         // Also check that the fields are as expected.
         assertEquals(curve.defaultSigningAlgorithm, cert.signatureAlgorithm)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
@@ -83,13 +83,11 @@ class SoftwareSecureAreaTest {
         } catch (e: KeyLockedException) {
             throw AssertionError(e)
         }
-        assertTrue(
-            Crypto.checkSignature(
-                keyInfo.publicKey,
-                dataToSign,
-                Algorithm.ES256,
-                signature
-            )
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.ES256,
+            signature
         )
     }
 
@@ -265,13 +263,11 @@ class SoftwareSecureAreaTest {
         }
 
         // Verify the signature is correct.
-        assertTrue(
-            Crypto.checkSignature(
-                keyInfo.publicKey,
-                dataToSign,
-                Algorithm.ES256,
-                signature
-            )
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.ES256,
+            signature
         )
     }
 
@@ -302,13 +298,11 @@ class SoftwareSecureAreaTest {
         assertNotEquals(certChainOld, certChain)
 
         // Check new key is used to sign.
-        assertTrue(
-            Crypto.checkSignature(
-                keyInfo.publicKey,
-                dataToSign,
-                Algorithm.ES256,
-                signature
-            )
+        Crypto.checkSignature(
+            keyInfo.publicKey,
+            dataToSign,
+            Algorithm.ES256,
+            signature
         )
     }
 
@@ -340,13 +334,11 @@ class SoftwareSecureAreaTest {
             } catch (e: KeyLockedException) {
                 throw AssertionError(e)
             }
-            assertTrue(
-                Crypto.checkSignature(
-                    keyInfo.publicKey,
-                    dataToSign,
-                    algorithm,
-                    derSignature
-                )
+            Crypto.checkSignature(
+                keyInfo.publicKey,
+                dataToSign,
+                algorithm,
+                derSignature
             )
         }
     }
@@ -406,13 +398,11 @@ class SoftwareSecureAreaTest {
             val keyInfo = batchCreateKeyResult.keyInfos[n]
             val dataToSign = byteArrayOf(4, 5, 6)
             val signature = sa.sign(keyInfo.alias, dataToSign, null)
-            assertTrue(
-                Crypto.checkSignature(
-                    keyInfo.publicKey,
-                    dataToSign,
-                    keyInfo.algorithm,
-                    signature
-                )
+            Crypto.checkSignature(
+                keyInfo.publicKey,
+                dataToSign,
+                keyInfo.algorithm,
+                signature
             )
         }
     }

--- a/server/src/main/java/com/android/identity/server/openid4vci/jwt.kt
+++ b/server/src/main/java/com/android/identity/server/openid4vci/jwt.kt
@@ -5,6 +5,7 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.EcSignature
+import org.multipaz.crypto.SignatureVerificationException
 import org.multipaz.util.fromBase64Url
 
 fun checkJwtSignature(publicKey: EcPublicKey, jwt: String) {
@@ -16,8 +17,9 @@ fun checkJwtSignature(publicKey: EcPublicKey, jwt: String) {
         EcCurve.P521 -> Algorithm.ES512
         else -> throw IllegalArgumentException("Unsupported public key")
     }
-    if (!Crypto.checkSignature(publicKey, jwt.substring(0, index).toByteArray(),
-            algorithm, signature)) {
-        throw IllegalArgumentException("Invalid JWT signature")
+    try {
+        Crypto.checkSignature(publicKey, jwt.substring(0, index).toByteArray(), algorithm, signature)
+    } catch (e: SignatureVerificationException) {
+        throw IllegalArgumentException("Invalid JWT signature", e)
     }
 }


### PR DESCRIPTION
This is the industry-standard and much safer than relying on having the caller check a boolean. Introduce SignatureVerificationException to convey this and derive this from SecurityException to form sealed hierarchy. This is helpful if want to add other security-related exceptions in the future.

Also add a negative test to check that checkSignature() indeed throws the expected exception when trying to verify a signature made with another key.

Test: All unit tests pass.
