### PR TITLE
mdoc: factor our MdocRole and rename ConnectionMethod.

### DIFF
--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
@@ -79,6 +79,7 @@ import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
+import org.multipaz.mdoc.role.MdocRole
 import java.security.Security
 import java.util.Calendar
 import java.util.concurrent.Executor
@@ -287,7 +288,7 @@ class DeviceRetrievalHelperTest {
                 .build()
         )
         val seReader = SessionEncryption(
-            SessionEncryption.Role.MDOC_READER,
+            MdocRole.MDOC_READER,
             eReaderKey,
             eDeviceKey.publicKey,
             encodedSessionTranscript
@@ -503,7 +504,7 @@ class DeviceRetrievalHelperTest {
                 .build()
         )
         val seReader = SessionEncryption(
-            SessionEncryption.Role.MDOC_READER,
+            MdocRole.MDOC_READER,
             eReaderKey,
             eDeviceKey.publicKey,
             encodedSessionTranscript

--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.kt
@@ -27,10 +27,10 @@ import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.Simple
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodWifiAware
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import org.multipaz.mdoc.engagement.EngagementParser
 import org.multipaz.util.UUID
 import org.multipaz.util.toHex
@@ -78,10 +78,10 @@ class NfcEnagementHelperTest {
         )
 
         // Include all ConnectionMethods that can exist in OOB data
-        val connectionMethods: MutableList<ConnectionMethod> = ArrayList()
+        val connectionMethods: MutableList<MdocConnectionMethod> = ArrayList()
         val bleUuid = UUID.randomUUID()
         connectionMethods.add(
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 true,
                 true,
                 bleUuid,
@@ -89,13 +89,13 @@ class NfcEnagementHelperTest {
             )
         )
         connectionMethods.add(
-            ConnectionMethodNfc(
+            MdocConnectionMethodNfc(
                 0xffff,
                 0xffff
             )
         )
         connectionMethods.add(
-            ConnectionMethodWifiAware(
+            MdocConnectionMethodWifiAware(
                 null,
                 null,
                 null,
@@ -214,10 +214,10 @@ class NfcEnagementHelperTest {
         )
 
         // Include all ConnectionMethods that can exist in OOB data
-        val connectionMethods: MutableList<ConnectionMethod> = ArrayList()
+        val connectionMethods: MutableList<MdocConnectionMethod> = ArrayList()
         val bleUuid = UUID.randomUUID()
         connectionMethods.add(
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 true,
                 true,
                 bleUuid,
@@ -225,13 +225,13 @@ class NfcEnagementHelperTest {
             )
         )
         connectionMethods.add(
-            ConnectionMethodNfc(
+            MdocConnectionMethodNfc(
                 0xffff,
                 0xffff
             )
         )
         connectionMethods.add(
-            ConnectionMethodWifiAware(
+            MdocConnectionMethodWifiAware(
                 null,
                 null,
                 null,
@@ -360,7 +360,7 @@ class NfcEnagementHelperTest {
         // only one to be returned and we expect it to be the BLE one and only the Central
         // Client mode.
         Assert.assertEquals(1, hs.connectionMethods.size.toLong())
-        val cm = hs.connectionMethods[0] as ConnectionMethodBle
+        val cm = hs.connectionMethods[0] as MdocConnectionMethodBle
         Assert.assertFalse(cm.supportsPeripheralServerMode)
         Assert.assertTrue(cm.supportsCentralClientMode)
         Assert.assertNull(cm.peripheralServerModeUuid)

--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportHttpTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/transport/DataTransportHttpTest.kt
@@ -17,7 +17,7 @@ package com.android.identity.android.mdoc.transport
 
 import android.os.ConditionVariable
 import androidx.test.platform.app.InstrumentationRegistry
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodHttp
+import com.android.identity.android.mdoc.connectionmethod.MdocConnectionMethodHttp
 import org.multipaz.util.fromHex
 import org.junit.Assert
 import org.junit.Test
@@ -31,7 +31,7 @@ class DataTransportHttpTest {
     fun uriParsing() {
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         val options = DataTransportOptions.Builder().build()
-        var cm = ConnectionMethodHttp("http://www.example.com/mdlReader/session123")
+        var cm = MdocConnectionMethodHttp("http://www.example.com/mdlReader/session123")
         var transport = DataTransport.fromConnectionMethod(
             appContext, cm, DataTransport.Role.MDOC, options
         ) as DataTransportHttp
@@ -39,7 +39,7 @@ class DataTransportHttpTest {
         Assert.assertEquals("/mdlReader/session123", transport.path)
         Assert.assertEquals(80, transport.port.toLong())
         Assert.assertFalse(transport.useTls)
-        cm = ConnectionMethodHttp("http://www.example2.com:1234/mdlVerifier/session456")
+        cm = MdocConnectionMethodHttp("http://www.example2.com:1234/mdlVerifier/session456")
         transport = DataTransport.fromConnectionMethod(
             appContext, cm, DataTransport.Role.MDOC, options
         ) as DataTransportHttp
@@ -47,7 +47,7 @@ class DataTransportHttpTest {
         Assert.assertEquals("/mdlVerifier/session456", transport.path)
         Assert.assertEquals(1234, transport.port.toLong())
         Assert.assertFalse(transport.useTls)
-        cm = ConnectionMethodHttp("https://www.example3.net/mdocreader/s42")
+        cm = MdocConnectionMethodHttp("https://www.example3.net/mdocreader/s42")
         transport = DataTransport.fromConnectionMethod(
             appContext, cm, DataTransport.Role.MDOC, options
         ) as DataTransportHttp
@@ -55,7 +55,7 @@ class DataTransportHttpTest {
         Assert.assertEquals("/mdocreader/s42", transport.path)
         Assert.assertEquals(443, transport.port.toLong())
         Assert.assertTrue(transport.useTls)
-        cm = ConnectionMethodHttp("https://www.example.com:8080/mdocreader/s43")
+        cm = MdocConnectionMethodHttp("https://www.example.com:8080/mdocreader/s43")
         transport = DataTransport.fromConnectionMethod(
             appContext, cm, DataTransport.Role.MDOC, options
         ) as DataTransportHttp
@@ -63,7 +63,7 @@ class DataTransportHttpTest {
         Assert.assertEquals("/mdocreader/s43", transport.path)
         Assert.assertEquals(8080, transport.port.toLong())
         Assert.assertTrue(transport.useTls)
-        cm = ConnectionMethodHttp("unsupported://www.example.com/mdocreader/s43")
+        cm = MdocConnectionMethodHttp("unsupported://www.example.com/mdocreader/s43")
         try {
             DataTransport.fromConnectionMethod(
                 appContext, cm, DataTransport.Role.MDOC, options
@@ -121,7 +121,7 @@ class DataTransportHttpTest {
             }
         }, executor)
         verifier.connect()
-        val verifierConnectionMethod = verifier.connectionMethodForTransport as ConnectionMethodHttp
+        val verifierConnectionMethod = verifier.connectionMethodForTransport as MdocConnectionMethodHttp
         val prover = DataTransportHttp(
             appContext,
             DataTransport.Role.MDOC,

--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/mdoc/connectionmethod/MdocConnectionMethodNdefTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/mdoc/connectionmethod/MdocConnectionMethodNdefTest.kt
@@ -24,7 +24,7 @@ import com.android.identity.android.mdoc.transport.DataTransportBle.Companion.fr
 import com.android.identity.android.util.NfcUtil
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DiagnosticOption
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod.Companion.fromDeviceEngagement
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod.Companion.fromDeviceEngagement
 import org.multipaz.util.UUID
 import org.multipaz.util.fromHex
 import org.multipaz.util.toHex
@@ -37,12 +37,12 @@ import org.junit.Test
 //  include it in the non-Android specific library and combine this test with
 //  ConnectionMethod
 //
-class ConnectionMethodNdefTest {
+class MdocConnectionMethodNdefTest {
     @Test
     @SmallTest
     fun testConnectionMethodNfc() {
-        val cm = ConnectionMethodNfc(4096, 32768)
-        val decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodNfc?
+        val cm = MdocConnectionMethodNfc(4096, 32768)
+        val decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodNfc?
         Assert.assertNotNull(decoded)
         Assert.assertEquals(decoded!!.commandDataFieldMaxLength, decoded.commandDataFieldMaxLength)
         Assert.assertEquals(decoded.responseDataFieldMaxLength, decoded.responseDataFieldMaxLength)
@@ -64,13 +64,13 @@ class ConnectionMethodNdefTest {
     fun testConnectionMethodBle() {
         val uuidPeripheral = UUID(0UL, 1UL)
         val uuidCentral = UUID(123456789UL, 987654321UL)
-        var cm = ConnectionMethodBle(
+        var cm = MdocConnectionMethodBle(
             true,
             true,
             uuidPeripheral,
             uuidCentral
         )
-        var decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodBle?
+        var decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodBle?
         Assert.assertNotNull(decoded)
         Assert.assertTrue(decoded!!.supportsPeripheralServerMode)
         Assert.assertTrue(decoded.supportsCentralClientMode)
@@ -91,7 +91,7 @@ class ConnectionMethodNdefTest {
 
         // For use in NFC, the UUIDs have to be the same
         val uuidBoth = UUID(0UL, 2UL)
-        cm = ConnectionMethodBle(
+        cm = MdocConnectionMethodBle(
             true,
             true,
             uuidBoth,
@@ -123,13 +123,13 @@ class ConnectionMethodNdefTest {
     @SmallTest
     fun testConnectionMethodBleOnlyCentralClient() {
         val uuid = UUID(123456789UL, 987654321UL)
-        val cm = ConnectionMethodBle(
+        val cm = MdocConnectionMethodBle(
             false,
             true,
             null,
             uuid
         )
-        var decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodBle?
+        var decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodBle?
         Assert.assertNotNull(decoded)
         Assert.assertFalse(decoded!!.supportsPeripheralServerMode)
         Assert.assertTrue(decoded.supportsCentralClientMode)
@@ -185,13 +185,13 @@ class ConnectionMethodNdefTest {
     @SmallTest
     fun testConnectionMethodBleOnlyPeripheralServer() {
         val uuid = UUID(0UL, 1UL)
-        val cm = ConnectionMethodBle(
+        val cm = MdocConnectionMethodBle(
             true,
             false,
             uuid,
             null
         )
-        var decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodBle?
+        var decoded = fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodBle?
         Assert.assertNotNull(decoded)
         Assert.assertTrue(decoded!!.supportsPeripheralServerMode)
         Assert.assertFalse(decoded.supportsCentralClientMode)
@@ -251,7 +251,7 @@ class ConnectionMethodNdefTest {
         // the requester specified in Handover Request and there's no need to repeat it in Handover
         // Select.
         //
-        val cm = ConnectionMethodBle(
+        val cm = MdocConnectionMethodBle(
             false,
             true,
             null,
@@ -275,7 +275,7 @@ class ConnectionMethodNdefTest {
         val ndefHsMessage =
             NdefMessage("91020f487315d10209616301013001046d646f631a2003016170706c69636174696f6e2f766e642e626c7565746f6f74682e6c652e6f6f6230021c015c1e580469736f2e6f72673a31383031333a646576696365656e676167656d656e746d646f63a20063312e30018201d818584ba401022001215820e778fcb1513fad715c755462cb4d3ee3c1de2f618d10e07788a35eda2da58b982258205e6ee59512414cdb11ee330db2590ab6d1b5a78ede4a0ecac02e3af65cafbcd9".fromHex())
         Assert.assertNotNull(ndefHsMessage)
-        var cm: ConnectionMethodBle? = null
+        var cm: MdocConnectionMethodBle? = null
         for (r in ndefHsMessage.records) {
             if (r.tnf == NdefRecord.TNF_MIME_MEDIA) {
                 cm = fromNdefRecord(r, true)

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/connectionmethod/MdocConnectionMethodHttp.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/connectionmethod/MdocConnectionMethodHttp.kt
@@ -1,9 +1,10 @@
-package org.multipaz.mdoc.connectionmethod
+package com.android.identity.android.mdoc.connectionmethod
 
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.addCborMap
 import org.multipaz.cbor.buildCborArray
-import org.multipaz.mdoc.transport.MdocTransport
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.nfc.NdefRecord
 import org.multipaz.util.Logger
 
@@ -12,11 +13,9 @@ import org.multipaz.util.Logger
  *
  * @param uri the URI.
  */
-class ConnectionMethodHttp(val uri: String): ConnectionMethod() {
-    override fun equals(other: Any?): Boolean {
-        return other is ConnectionMethodHttp && other.uri == uri
-    }
-
+data class MdocConnectionMethodHttp(
+    val uri: String
+): MdocConnectionMethod() {
     override fun toString(): String = "http:uri=$uri"
 
     override fun toDeviceEngagement(): ByteArray {
@@ -33,7 +32,7 @@ class ConnectionMethodHttp(val uri: String): ConnectionMethod() {
 
     override fun toNdefRecord(
         auxiliaryReferences: List<String>,
-        role: MdocTransport.Role,
+        role: MdocRole,
         skipUuids: Boolean
     ): Pair<NdefRecord, NdefRecord>? {
         Logger.w(TAG, "toNdefRecord() not yet implemented")
@@ -41,12 +40,21 @@ class ConnectionMethodHttp(val uri: String): ConnectionMethod() {
     }
 
     companion object {
-        private const val TAG = "ConnectionMethodHttp"
+        private const val TAG = "MdocConnectionMethodHttp"
+
+        /**
+         * The device retrieval method type for HTTP according to ISO/IEC TS 18013-7:2024 annex A.
+         */
         const val METHOD_TYPE = 4L
+
+        /**
+         * The supported version of the device retrieval method type for HTTP.
+         */
         const val METHOD_MAX_VERSION = 1L
+
         private const val OPTION_KEY_URI = 0L
 
-        internal fun fromDeviceEngagement(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethodHttp? {
+        internal fun fromDeviceEngagement(encodedDeviceRetrievalMethod: ByteArray): MdocConnectionMethodHttp? {
             val array = Cbor.decode(encodedDeviceRetrievalMethod)
             val type = array[0].asNumber
             val version = array[1].asNumber
@@ -55,7 +63,7 @@ class ConnectionMethodHttp(val uri: String): ConnectionMethod() {
                 return null
             }
             val map = array[2]
-            return ConnectionMethodHttp(map[OPTION_KEY_URI].asTstr)
+            return MdocConnectionMethodHttp(map[OPTION_KEY_URI].asTstr)
         }
     }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.kt
@@ -35,6 +35,7 @@ import org.multipaz.util.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.asCoroutineDispatcher
 import kotlinx.coroutines.launch
+import org.multipaz.mdoc.role.MdocRole
 import java.util.concurrent.Executor
 
 /**
@@ -282,7 +283,7 @@ class DeviceRetrievalHelper internal constructor(
                 .build()
         )
         sessionEncryption = SessionEncryption(
-            SessionEncryption.Role.MDOC,
+            MdocRole.MDOC,
             eDeviceKey,
             _eReaderKey!!,
             encodedSessionTranscript!!

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/engagement/QrEngagementHelper.kt
@@ -12,10 +12,10 @@ import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Simple
 import org.multipaz.cbor.Tagged
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod.Companion.disambiguate
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod.Companion.disambiguate
 import org.multipaz.mdoc.engagement.EngagementGenerator
-import org.multipaz.mdoc.transport.MdocTransport
+import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.util.Logger
 import java.util.concurrent.Executor
 
@@ -36,7 +36,7 @@ import java.util.concurrent.Executor
 class QrEngagementHelper internal constructor(
     context: Context,
     eDeviceKey: EcPublicKey,
-    connectionMethods: List<ConnectionMethod>?,
+    connectionMethods: List<MdocConnectionMethod>?,
     transports: List<DataTransport>?,
     options: DataTransportOptions,
     private val listener: Listener?,
@@ -79,7 +79,7 @@ class QrEngagementHelper internal constructor(
         if (connectionMethods != null) {
             // Need to disambiguate the connection methods here to get e.g. two ConnectionMethods
             // if both BLE modes are available at the same time.
-            val disambiguatedMethods = disambiguate(connectionMethods, MdocTransport.Role.MDOC)
+            val disambiguatedMethods = disambiguate(connectionMethods, MdocRole.MDOC)
             for (cm in disambiguatedMethods) {
                 val transport = fromConnectionMethod(
                     context, cm, DataTransport.Role.MDOC, options
@@ -129,7 +129,7 @@ class QrEngagementHelper internal constructor(
             transport.connect()
         }
         Logger.d(TAG, "All transports are now set up")
-        val connectionMethodsSetup = ArrayList<ConnectionMethod>()
+        val connectionMethodsSetup = ArrayList<MdocConnectionMethod>()
         for (transport in this.transports) {
             connectionMethodsSetup.add(transport.connectionMethodForTransport)
         }
@@ -295,7 +295,7 @@ class QrEngagementHelper internal constructor(
         private val listener: Listener,
         private val executor: Executor
     ) {
-        private var connectionMethods: List<ConnectionMethod>? = null
+        private var connectionMethods: List<MdocConnectionMethod>? = null
         private var transports: List<DataTransport>? = null
 
         /**
@@ -303,10 +303,10 @@ class QrEngagementHelper internal constructor(
          *
          * This is used to indicate which connection methods should be used for QR engagement.
          *
-         * @param connectionMethods a list of [ConnectionMethod] instances.
+         * @param connectionMethods a list of [MdocConnectionMethod] instances.
          * @return the builder.
          */
-        fun setConnectionMethods(connectionMethods: List<ConnectionMethod>) = apply {
+        fun setConnectionMethods(connectionMethods: List<MdocConnectionMethod>) = apply {
             this.connectionMethods = connectionMethods
         }
 

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransport.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransport.kt
@@ -17,12 +17,11 @@ package com.android.identity.android.mdoc.transport
 
 import android.content.Context
 import android.os.Build
-import com.android.identity.android.mdoc.transport.DataTransport.Listener
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodHttp
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodWifiAware
+import com.android.identity.android.mdoc.connectionmethod.MdocConnectionMethodHttp
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import java.util.ArrayDeque
 import java.util.Queue
 import java.util.concurrent.Executor
@@ -70,9 +69,9 @@ abstract class DataTransport(
     private val messageReceivedQueue: Queue<ByteArray> = ArrayDeque()
 
     /**
-     * A [ConnectionMethod] instance that can be used to connect to this transport.
+     * A [MdocConnectionMethod] instance that can be used to connect to this transport.
      *
-     * For most data transports this will return the same [ConnectionMethod] instance
+     * For most data transports this will return the same [MdocConnectionMethod] instance
      * that was passed at construction time. However for some transports where the address to
      * listen on is not known until the connection have been set up (for example dynamic TCP
      * listening port assignments or when a cloud relay is in use) it will differ.
@@ -81,7 +80,7 @@ abstract class DataTransport(
      *
      * This cannot be read until [connect] has been called.
      */
-    abstract val connectionMethodForTransport: ConnectionMethod
+    abstract val connectionMethodForTransport: MdocConnectionMethod
 
     /**
      * Sets the bytes of `EDeviceKeyBytes`.
@@ -315,10 +314,10 @@ abstract class DataTransport(
     companion object {
         /**
          * Creates a new [DataTransport]-derived instance for the given type
-         * of [ConnectionMethod].
+         * of [MdocConnectionMethod].
          *
          * @param context application context.
-         * @param connectionMethod the [ConnectionMethod] to use.
+         * @param connectionMethod the [MdocConnectionMethod] to use.
          * @param role whether the transport will be used by the mdoc or mdoc reader.
          * @param options options for configuring the created instance.
          * @return A [DataTransport]-derived instance configured with the given options.
@@ -327,26 +326,26 @@ abstract class DataTransport(
         @JvmStatic
         fun fromConnectionMethod(
             context: Context,
-            connectionMethod: ConnectionMethod,
+            connectionMethod: MdocConnectionMethod,
             role: Role,
             options: DataTransportOptions
         ): DataTransport {
             // TODO: move this to DataTransportFactory
-            return if (connectionMethod is ConnectionMethodBle) {
+            return if (connectionMethod is MdocConnectionMethodBle) {
                 DataTransportBle.fromConnectionMethod(
                     context,
                     connectionMethod,
                     role,
                     options
                 )
-            } else if (connectionMethod is ConnectionMethodNfc) {
+            } else if (connectionMethod is MdocConnectionMethodNfc) {
                 DataTransportNfc.fromConnectionMethod(
                     context,
                     connectionMethod,
                     role,
                     options
                 )
-            } else if (connectionMethod is ConnectionMethodWifiAware) {
+            } else if (connectionMethod is MdocConnectionMethodWifiAware) {
                 if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     DataTransportWifiAware.fromConnectionMethod(
                         context,
@@ -357,21 +356,21 @@ abstract class DataTransport(
                 } else {
                     throw IllegalStateException("Wifi Aware is not supported")
                 }
-            } else if (connectionMethod is ConnectionMethodHttp) {
+            } else if (connectionMethod is MdocConnectionMethodHttp) {
                 DataTransportHttp.fromConnectionMethod(
                     context,
                     connectionMethod,
                     role,
                     options
                 )
-            } else if (connectionMethod is ConnectionMethodTcp) {
+            } else if (connectionMethod is MdocConnectionMethodTcp) {
                 DataTransportTcp.fromConnectionMethod(
                     context,
                     connectionMethod,
                     role,
                     options
                 )
-            } else if (connectionMethod is ConnectionMethodUdp) {
+            } else if (connectionMethod is MdocConnectionMethodUdp) {
                 DataTransportUdp.fromConnectionMethod(
                     context,
                     connectionMethod,

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBleCentralClientMode.kt
@@ -30,7 +30,7 @@ import android.content.Context
 import android.os.Build
 import android.os.ParcelUuid
 import androidx.annotation.RequiresApi
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.Logger
 import org.multipaz.util.toJavaUuid
 import java.util.UUID
@@ -42,7 +42,7 @@ import java.util.UUID
 class DataTransportBleCentralClientMode(
     context: Context,
     role: Role,
-    connectionMethod: ConnectionMethodBle,
+    connectionMethod: MdocConnectionMethodBle,
     options: DataTransportOptions
 ) : DataTransportBle(context, role, connectionMethod, options) {
     private var characteristicStateUuid = UUID.fromString("00000005-a123-48ce-896b-4c76973373e6")
@@ -289,7 +289,15 @@ class DataTransportBleCentralClientMode(
             return
         }
         if (options.experimentalBleL2CAPPsmInEngagement) {
-            connectionMethodToReturn.peripheralServerModePsm = gattServer!!.psm
+            connectionMethodToReturn =
+                MdocConnectionMethodBle(
+                    supportsPeripheralServerMode = connectionMethodToReturn.supportsPeripheralServerMode,
+                    supportsCentralClientMode = connectionMethodToReturn.supportsCentralClientMode,
+                    peripheralServerModeUuid = connectionMethodToReturn.peripheralServerModeUuid,
+                    centralClientModeUuid = connectionMethodToReturn.centralClientModeUuid,
+                    peripheralServerModePsm = gattServer!!.psm,
+                    peripheralServerModeMacAddress = null
+                )
         }
         val bluetoothAdapter = bluetoothManager.adapter
         bluetoothLeAdvertiser = bluetoothAdapter.bluetoothLeAdvertiser

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportBlePeripheralServerMode.kt
@@ -30,7 +30,7 @@ import android.content.Context
 import android.os.Build
 import android.os.ParcelUuid
 import androidx.annotation.RequiresApi
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.Logger
 import org.multipaz.util.toJavaUuid
 import java.util.UUID
@@ -42,7 +42,7 @@ import java.util.UUID
 class DataTransportBlePeripheralServerMode(
     context: Context,
     role: Role,
-    connectionMethod: ConnectionMethodBle,
+    connectionMethod: MdocConnectionMethodBle,
     options: DataTransportOptions
 ) : DataTransportBle(context, role, connectionMethod, options) {
     private var characteristicStateUuid = UUID.fromString("00000001-a123-48ce-896b-4c76973373e6")
@@ -268,7 +268,15 @@ class DataTransportBlePeripheralServerMode(
             gattServer = null
             return
         }
-        connectionMethodToReturn.peripheralServerModePsm = gattServer!!.psm
+        connectionMethodToReturn =
+            MdocConnectionMethodBle(
+                supportsPeripheralServerMode = connectionMethodToReturn.supportsPeripheralServerMode,
+                supportsCentralClientMode = connectionMethodToReturn.supportsCentralClientMode,
+                peripheralServerModeUuid = connectionMethodToReturn.peripheralServerModeUuid,
+                centralClientModeUuid = connectionMethodToReturn.centralClientModeUuid,
+                peripheralServerModePsm = gattServer!!.psm,
+                peripheralServerModeMacAddress = null
+            )
         bluetoothLeAdvertiser = bluetoothAdapter.bluetoothLeAdvertiser
         if (bluetoothLeAdvertiser == null) {
             reportError(Error("Failed to create BLE advertiser"))

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportHttp.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportHttp.kt
@@ -18,8 +18,8 @@ package com.android.identity.android.mdoc.transport
 import android.content.Context
 import android.net.wifi.WifiManager
 import android.text.format.Formatter
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodHttp
+import com.android.identity.android.mdoc.connectionmethod.MdocConnectionMethodHttp
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.util.Logger
 import com.android.volley.DefaultRetryPolicy
 import com.android.volley.NetworkResponse
@@ -50,7 +50,7 @@ import java.util.concurrent.TimeUnit
 class DataTransportHttp(
     context: Context,
     role: Role,
-    private var connectionMethod: ConnectionMethodHttp?,
+    private var connectionMethod: MdocConnectionMethodHttp?,
     options: DataTransportOptions
 ) : DataTransport(context, role, options) {
     var socket: Socket? = null
@@ -150,7 +150,7 @@ class DataTransportHttp(
         _host = getWifiIpAddress(context)
         this.port = port
         Logger.d(TAG, "Listening with host=$_host port=$port useTls=$useTls")
-        connectionMethod = ConnectionMethodHttp("http://$_host:$port/mdocreader")
+        connectionMethod = MdocConnectionMethodHttp("http://$_host:$port/mdocreader")
     }
 
     var host: String
@@ -321,7 +321,7 @@ Content-Type: application/cbor
         return false
     }
 
-    override val connectionMethodForTransport: ConnectionMethod
+    override val connectionMethodForTransport: MdocConnectionMethod
         get() = connectionMethod!!
 
     /**
@@ -379,7 +379,7 @@ Content-Type: application/cbor
 
         fun fromConnectionMethod(
             context: Context,
-            cm: ConnectionMethodHttp,
+            cm: MdocConnectionMethodHttp,
             role: Role,
             options: DataTransportOptions
         ): DataTransport {

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportNfc.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportNfc.kt
@@ -21,8 +21,8 @@ import android.nfc.cardemulation.HostApduService
 import android.nfc.tech.IsoDep
 import android.util.Pair
 import com.android.identity.android.util.NfcUtil
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.util.Logger
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -40,7 +40,7 @@ import java.util.concurrent.TimeUnit
 class DataTransportNfc(
     context: Context,
     role: Role,
-    private val connectionMethod: ConnectionMethodNfc,
+    private val connectionMethod: MdocConnectionMethodNfc,
     options: DataTransportOptions
 ) : DataTransport(context, role, options) {
     var _isoDep: IsoDep? = null
@@ -717,7 +717,7 @@ class DataTransportNfc(
         return false
     }
 
-    override val connectionMethodForTransport: ConnectionMethod
+    override val connectionMethodForTransport: MdocConnectionMethod
         get() = connectionMethod
 
     companion object {
@@ -727,7 +727,7 @@ class DataTransportNfc(
         fun fromNdefRecord(
             record: NdefRecord,
             isForHandoverSelect: Boolean
-        ): ConnectionMethodNfc? {
+        ): MdocConnectionMethodNfc? {
             val payload = ByteBuffer.wrap(record.payload).order(ByteOrder.LITTLE_ENDIAN)
             val version = payload.get().toInt()
             if (version != 0x01) {
@@ -764,7 +764,7 @@ class DataTransportNfc(
                 responseDataFieldMaxLength *= 256
                 responseDataFieldMaxLength += payload.get().toInt() and 0xff
             }
-            return ConnectionMethodNfc(
+            return MdocConnectionMethodNfc(
                 commandDataFieldMaxLength.toLong(),
                 responseDataFieldMaxLength.toLong()
             )
@@ -823,7 +823,7 @@ class DataTransportNfc(
 
         fun fromConnectionMethod(
             context: Context,
-            cm: ConnectionMethodNfc,
+            cm: MdocConnectionMethodNfc,
             role: Role,
             options: DataTransportOptions
         ): DataTransport {
@@ -851,7 +851,7 @@ class DataTransportNfc(
         }
 
         fun toNdefRecord(
-            cm: ConnectionMethodNfc,
+            cm: MdocConnectionMethodNfc,
             auxiliaryReferences: List<String>,
             isForHandoverSelect: Boolean
         ): Pair<NdefRecord, ByteArray> {

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportTcp.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportTcp.kt
@@ -21,7 +21,7 @@ import android.nfc.NdefRecord
 import android.text.format.Formatter
 import android.util.Log
 import android.util.Pair
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.util.Logger
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -253,8 +253,8 @@ class DataTransportTcp(
         return false
     }
 
-    override val connectionMethodForTransport: ConnectionMethod
-        get() = ConnectionMethodTcp(host!!, port)
+    override val connectionMethodForTransport: MdocConnectionMethod
+        get() = MdocConnectionMethodTcp(host!!, port)
 
     // Function to rewrite incoming messages, used only for testing to inject errors
     // which will cause decryption to fail.
@@ -282,7 +282,7 @@ class DataTransportTcp(
 
         fun fromConnectionMethod(
             context: Context,
-            cm: ConnectionMethodTcp,
+            cm: MdocConnectionMethodTcp,
             role: Role,
             options: DataTransportOptions
         ): DataTransport {
@@ -292,11 +292,11 @@ class DataTransportTcp(
         }
 
         fun toNdefRecord(
-            cm: ConnectionMethodTcp,
+            cm: MdocConnectionMethodTcp,
             auxiliaryReferences: List<String?>,
             isForHandoverSelect: Boolean
         ): Pair<NdefRecord, ByteArray> {
-            val reference = "${ConnectionMethodTcp.METHOD_TYPE}".toByteArray()
+            val reference = "${MdocConnectionMethodTcp.METHOD_TYPE}".toByteArray()
             val record = NdefRecord(
                 0x02.toShort(),  // type = RFC 2046 (MIME)
                 "application/vnd.android.ic.dmr".toByteArray(),

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportUdp.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/DataTransportUdp.kt
@@ -21,7 +21,7 @@ import android.nfc.NdefRecord
 import android.text.format.Formatter
 import android.util.Log
 import android.util.Pair
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.util.Logger
 import java.io.ByteArrayOutputStream
 import java.io.IOException
@@ -237,8 +237,8 @@ class DataTransportUdp(
         return false
     }
 
-    override val connectionMethodForTransport: ConnectionMethod
-        get() = ConnectionMethodUdp(host!!, port)
+    override val connectionMethodForTransport: MdocConnectionMethod
+        get() = MdocConnectionMethodUdp(host!!, port)
 
     companion object {
         private const val TAG = "DataTransportUdp"
@@ -255,7 +255,7 @@ class DataTransportUdp(
 
         fun fromConnectionMethod(
             context: Context,
-            cm: ConnectionMethodUdp,
+            cm: MdocConnectionMethodUdp,
             role: Role,
             options: DataTransportOptions
         ): DataTransport {
@@ -265,11 +265,11 @@ class DataTransportUdp(
         }
 
         fun toNdefRecord(
-            cm: ConnectionMethodUdp,
+            cm: MdocConnectionMethodUdp,
             auxiliaryReferences: List<String?>,
             isForHandoverSelect: Boolean
         ): Pair<NdefRecord, ByteArray> {
-            val reference = "${ConnectionMethodUdp.METHOD_TYPE}".toByteArray()
+            val reference = "${MdocConnectionMethodUdp.METHOD_TYPE}".toByteArray()
             val record = NdefRecord(
                 0x02.toShort(),  // type = RFC 2046 (MIME)
                 "application/vnd.android.ic.dmr".toByteArray(),

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/MdocConnectionMethodTcp.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/MdocConnectionMethodTcp.kt
@@ -3,12 +3,12 @@ package com.android.identity.android.mdoc.transport
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.CborMap
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.transport.MdocTransport
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.nfc.NdefRecord
 import org.multipaz.util.Logger
 
-class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() {
+class MdocConnectionMethodTcp(val host: String, val port: Int) : MdocConnectionMethod() {
 
     override fun toDeviceEngagement(): ByteArray {
         val mapBuilder = CborMap.builder()
@@ -26,7 +26,7 @@ class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() 
 
     override fun toNdefRecord(
         auxiliaryReferences: List<String>,
-        role: MdocTransport.Role,
+        role: MdocRole,
         skipUuids: Boolean
     ): Pair<NdefRecord, NdefRecord>? {
         Logger.w(TAG, "toNdefRecord() not yet implemented")
@@ -34,25 +34,25 @@ class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() 
     }
 
     override fun equals(other: Any?): Boolean {
-        return other is ConnectionMethodUdp && other.host == host && other.port == port
+        return other is MdocConnectionMethodTcp && other.host == host && other.port == port
     }
 
     override fun toString(): String {
-        return "udp:host=$host:port=$port"
+        return "tcp:host=$host:port=$port"
     }
 
     companion object {
-        private const val TAG = "ConnectionMethodUdp"
+        private const val TAG = "ConnectionMethodTcp"
 
         // NOTE: 18013-5 only allows positive integers, but our codebase also supports negative
         // ones and this way we won't clash with types defined in the standard.
-        const val METHOD_TYPE = -11L
+        const val METHOD_TYPE = -10L
         const val METHOD_MAX_VERSION = 1L
 
         private const val OPTION_KEY_HOST = 0L
         private const val OPTION_KEY_PORT = 1L
         @JvmStatic
-        fun fromDeviceEngagementUdp(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethodUdp? {
+        fun fromDeviceEngagementTcp(encodedDeviceRetrievalMethod: ByteArray): MdocConnectionMethodTcp? {
             val array = Cbor.decode(encodedDeviceRetrievalMethod).asArray
             val type = array[0].asNumber
             val version = array[1].asNumber
@@ -63,7 +63,7 @@ class ConnectionMethodUdp(val host: String, val port: Int) : ConnectionMethod() 
             val map = array[2]
             val host = map[OPTION_KEY_HOST].asTstr
             val port = map[OPTION_KEY_PORT].asNumber
-            return ConnectionMethodUdp(host, port.toInt())
+            return MdocConnectionMethodTcp(host, port.toInt())
         }
     }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/MdocConnectionMethodUdp.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/MdocConnectionMethodUdp.kt
@@ -3,12 +3,12 @@ package com.android.identity.android.mdoc.transport
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.CborMap
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.transport.MdocTransport
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.nfc.NdefRecord
 import org.multipaz.util.Logger
 
-class ConnectionMethodTcp(val host: String, val port: Int) : ConnectionMethod() {
+class MdocConnectionMethodUdp(val host: String, val port: Int) : MdocConnectionMethod() {
 
     override fun toDeviceEngagement(): ByteArray {
         val mapBuilder = CborMap.builder()
@@ -26,7 +26,7 @@ class ConnectionMethodTcp(val host: String, val port: Int) : ConnectionMethod() 
 
     override fun toNdefRecord(
         auxiliaryReferences: List<String>,
-        role: MdocTransport.Role,
+        role: MdocRole,
         skipUuids: Boolean
     ): Pair<NdefRecord, NdefRecord>? {
         Logger.w(TAG, "toNdefRecord() not yet implemented")
@@ -34,25 +34,25 @@ class ConnectionMethodTcp(val host: String, val port: Int) : ConnectionMethod() 
     }
 
     override fun equals(other: Any?): Boolean {
-        return other is ConnectionMethodTcp && other.host == host && other.port == port
+        return other is MdocConnectionMethodUdp && other.host == host && other.port == port
     }
 
     override fun toString(): String {
-        return "tcp:host=$host:port=$port"
+        return "udp:host=$host:port=$port"
     }
 
     companion object {
-        private const val TAG = "ConnectionMethodTcp"
+        private const val TAG = "ConnectionMethodUdp"
 
         // NOTE: 18013-5 only allows positive integers, but our codebase also supports negative
         // ones and this way we won't clash with types defined in the standard.
-        const val METHOD_TYPE = -10L
+        const val METHOD_TYPE = -11L
         const val METHOD_MAX_VERSION = 1L
 
         private const val OPTION_KEY_HOST = 0L
         private const val OPTION_KEY_PORT = 1L
         @JvmStatic
-        fun fromDeviceEngagementTcp(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethodTcp? {
+        fun fromDeviceEngagementUdp(encodedDeviceRetrievalMethod: ByteArray): MdocConnectionMethodUdp? {
             val array = Cbor.decode(encodedDeviceRetrievalMethod).asArray
             val type = array[0].asNumber
             val version = array[1].asNumber
@@ -63,7 +63,7 @@ class ConnectionMethodTcp(val host: String, val port: Int) : ConnectionMethod() 
             val map = array[2]
             val host = map[OPTION_KEY_HOST].asTstr
             val port = map[OPTION_KEY_PORT].asNumber
-            return ConnectionMethodTcp(host, port.toInt())
+            return MdocConnectionMethodUdp(host, port.toInt())
         }
     }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/util/NfcUtil.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/util/NfcUtil.kt
@@ -5,8 +5,8 @@ import android.nfc.NdefMessage
 import android.nfc.NdefRecord
 import android.os.Build
 import android.util.Pair
-import com.android.identity.android.mdoc.transport.ConnectionMethodTcp
-import com.android.identity.android.mdoc.transport.ConnectionMethodUdp
+import com.android.identity.android.mdoc.transport.MdocConnectionMethodTcp
+import com.android.identity.android.mdoc.transport.MdocConnectionMethodUdp
 import com.android.identity.android.mdoc.transport.DataTransportBle
 import com.android.identity.android.mdoc.transport.DataTransportNfc
 import com.android.identity.android.mdoc.transport.DataTransportOptions
@@ -14,10 +14,10 @@ import com.android.identity.android.mdoc.transport.DataTransportTcp
 import com.android.identity.android.mdoc.transport.DataTransportUdp
 import com.android.identity.android.mdoc.transport.DataTransportWifiAware
 import org.multipaz.cbor.Cbor
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodWifiAware
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import org.multipaz.util.Logger
 import org.multipaz.util.fromHex
 import org.multipaz.util.toHex
@@ -191,7 +191,7 @@ object NfcUtil {
     }
 
     private fun createNdefMessageHandoverSelectOrRequest(
-        methods: List<ConnectionMethod>,
+        methods: List<MdocConnectionMethod>,
         encodedDeviceEngagement: ByteArray?,
         encodedReaderEngagement: ByteArray?,
         options: DataTransportOptions?
@@ -265,7 +265,7 @@ object NfcUtil {
 
     @JvmStatic
     fun createNdefMessageHandoverSelect(
-        methods: List<ConnectionMethod>,
+        methods: List<MdocConnectionMethod>,
         encodedDeviceEngagement: ByteArray,
         options: DataTransportOptions?
     ): ByteArray {
@@ -279,7 +279,7 @@ object NfcUtil {
 
     @JvmStatic
     fun createNdefMessageHandoverRequest(
-        methods: List<ConnectionMethod>,
+        methods: List<MdocConnectionMethod>,
         encodedReaderEngagement: ByteArray?,
         options: DataTransportOptions?
     ): ByteArray {
@@ -303,7 +303,7 @@ object NfcUtil {
         var validHandoverSelectMessage = false
 
         var phsmEncodedDeviceEngagement: ByteArray? = null
-        var phsmConnectionMethods = mutableListOf<ConnectionMethod>()
+        var phsmConnectionMethods = mutableListOf<MdocConnectionMethod>()
         for (r in m!!.getRecords()) {
             // Handle Handover Select record for NFC Forum Connection Handover specification
             // version 1.5 (encoded as 0x15 below).
@@ -447,15 +447,15 @@ object NfcUtil {
         return null
     }
 
-    private fun getConnectionMethodFromDeviceEngagement(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethod? {
+    private fun getConnectionMethodFromDeviceEngagement(encodedDeviceRetrievalMethod: ByteArray): MdocConnectionMethod? {
         val items = Cbor.decode(encodedDeviceRetrievalMethod)
         val type = items[0].asNumber
         when (type) {
-            ConnectionMethodTcp.METHOD_TYPE -> return ConnectionMethodTcp.fromDeviceEngagementTcp(
+            MdocConnectionMethodTcp.METHOD_TYPE -> return MdocConnectionMethodTcp.fromDeviceEngagementTcp(
                 encodedDeviceRetrievalMethod
             )
 
-            ConnectionMethodUdp.METHOD_TYPE -> return ConnectionMethodUdp.fromDeviceEngagementUdp(
+            MdocConnectionMethodUdp.METHOD_TYPE -> return MdocConnectionMethodUdp.fromDeviceEngagementUdp(
                 encodedDeviceRetrievalMethod
             )
         }
@@ -464,7 +464,7 @@ object NfcUtil {
     }
 
     @JvmStatic
-    fun fromNdefRecord(record: NdefRecord, isForHandoverSelect: Boolean): ConnectionMethod? {
+    fun fromNdefRecord(record: NdefRecord, isForHandoverSelect: Boolean): MdocConnectionMethod? {
         // BLE Carrier Configuration record
         //
         if (record.tnf == NdefRecord.TNF_MIME_MEDIA && Arrays.equals(
@@ -536,23 +536,23 @@ object NfcUtil {
      */
     @JvmStatic
     fun toNdefRecord(
-        connectionMethod: ConnectionMethod,
+        connectionMethod: MdocConnectionMethod,
         auxiliaryReferences: List<String>,
         isForHandoverSelect: Boolean
     ): Pair<NdefRecord, ByteArray>? {
-        if (connectionMethod is ConnectionMethodBle) {
+        if (connectionMethod is MdocConnectionMethodBle) {
             return DataTransportBle.toNdefRecord(
                 connectionMethod,
                 auxiliaryReferences,
                 isForHandoverSelect
             )
-        } else if (connectionMethod is ConnectionMethodNfc) {
+        } else if (connectionMethod is MdocConnectionMethodNfc) {
             return DataTransportNfc.toNdefRecord(
                 connectionMethod,
                 auxiliaryReferences,
                 isForHandoverSelect
             )
-        } else if (connectionMethod is ConnectionMethodWifiAware) {
+        } else if (connectionMethod is MdocConnectionMethodWifiAware) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 return DataTransportWifiAware.toNdefRecord(
                     connectionMethod,
@@ -560,13 +560,13 @@ object NfcUtil {
                     isForHandoverSelect
                 )
             }
-        } else if (connectionMethod is ConnectionMethodTcp) {
+        } else if (connectionMethod is MdocConnectionMethodTcp) {
             return DataTransportTcp.toNdefRecord(
                 connectionMethod,
                 auxiliaryReferences,
                 isForHandoverSelect
             )
-        } else if (connectionMethod is ConnectionMethodUdp) {
+        } else if (connectionMethod is MdocConnectionMethodUdp) {
             return DataTransportUdp.toNdefRecord(
                 connectionMethod,
                 auxiliaryReferences,
@@ -581,7 +581,7 @@ object NfcUtil {
         @JvmField
         val encodedDeviceEngagement: ByteArray,
         @JvmField
-        val connectionMethods: List<ConnectionMethod>
+        val connectionMethods: List<MdocConnectionMethod>
     )
 
     data class ParsedServiceParameterRecord(

--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/mdocPresentment.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/mdocPresentment.kt
@@ -2,7 +2,6 @@ package org.multipaz.models.presentment
 
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.Tagged
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.document.Document
@@ -27,6 +26,7 @@ import org.multipaz.util.Logger
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.first
 import org.multipaz.cbor.buildCborArray
+import org.multipaz.mdoc.role.MdocRole
 
 private const val TAG = "mdocPresentment"
 
@@ -83,7 +83,7 @@ internal suspend fun mdocPresentment(
                         }
                     )
                 sessionEncryption = SessionEncryption(
-                    SessionEncryption.Role.MDOC,
+                    MdocRole.MDOC,
                     mechanism.eDeviceKey,
                     eReaderKey,
                     encodedSessionTranscript,

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.android.kt
@@ -1,16 +1,17 @@
 package org.multipaz.mdoc.transport
 
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
+import org.multipaz.mdoc.role.MdocRole
 
 internal actual fun defaultMdocTransportFactoryCreateTransport(
-    connectionMethod: ConnectionMethod,
-    role: MdocTransport.Role,
+    connectionMethod: MdocConnectionMethod,
+    role: MdocRole,
     options: MdocTransportOptions
 ): MdocTransport {
     when (connectionMethod) {
-        is ConnectionMethodBle -> {
+        is MdocConnectionMethodBle -> {
             if (connectionMethod.supportsCentralClientMode &&
                 connectionMethod.supportsPeripheralServerMode) {
                 throw IllegalArgumentException(
@@ -18,7 +19,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                 )
             } else if (connectionMethod.supportsCentralClientMode) {
                 return when (role) {
-                    MdocTransport.Role.MDOC -> {
+                    MdocRole.MDOC -> {
                         BleTransportCentralMdoc(
                             role,
                             options,
@@ -27,7 +28,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                             connectionMethod.peripheralServerModePsm
                         )
                     }
-                    MdocTransport.Role.MDOC_READER -> {
+                    MdocRole.MDOC_READER -> {
                         BleTransportCentralMdocReader(
                             role,
                             options,
@@ -38,7 +39,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                 }
             } else {
                 return when (role) {
-                    MdocTransport.Role.MDOC -> {
+                    MdocRole.MDOC -> {
                         BleTransportPeripheralMdoc(
                             role,
                             options,
@@ -46,7 +47,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                             connectionMethod.peripheralServerModeUuid!!
                         )
                     }
-                    MdocTransport.Role.MDOC_READER -> {
+                    MdocRole.MDOC_READER -> {
                         BleTransportPeripheralMdocReader(
                             role,
                             options,
@@ -58,16 +59,16 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                 }
             }
         }
-        is ConnectionMethodNfc -> {
+        is MdocConnectionMethodNfc -> {
             return when (role) {
-                MdocTransport.Role.MDOC -> {
+                MdocRole.MDOC -> {
                     NfcTransportMdoc(
                         role,
                         options,
                         connectionMethod
                     )
                 }
-                MdocTransport.Role.MDOC_READER -> {
+                MdocRole.MDOC_READER -> {
                     NfcTransportMdocReader(
                         role,
                         options,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethod.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethod.kt
@@ -2,22 +2,24 @@ package org.multipaz.mdoc.connectionmethod
 
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor.decode
-import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.nfc.NdefRecord
 import org.multipaz.nfc.Nfc
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
 import kotlinx.io.bytestring.decodeToString
+import org.multipaz.mdoc.role.MdocRole
+
+// TODO: Make this a sealed class when multipaz-android-legacy is removed.
 
 /**
  * A class representing the ConnectionMethod structure exchanged between mdoc and mdoc reader.
  *
  * This is an abstract class - applications are expected to interact with concrete
- * implementations, for example [ConnectionMethodBle] or [ConnectionMethodNfc].
+ * implementations, for example [MdocConnectionMethodBle] or [MdocConnectionMethodNfc].
  */
-abstract class ConnectionMethod {
+abstract class MdocConnectionMethod {
     /**
-     * Generates `DeviceRetrievalMethod` CBOR for the given [ConnectionMethod].
+     * Generates `DeviceRetrievalMethod` CBOR for the given [MdocConnectionMethod].
      *
      * See ISO/IEC 18013-5:2021 section 8.2.1.1 Device engagement structure for where
      * `DeviceRetrievalMethod` CBOR is defined.
@@ -30,14 +32,14 @@ abstract class ConnectionMethod {
      * Creates a NDEF Connection Handover Carrier Reference record and Auxiliary Data Reference records.
      *
      * @param auxiliaryReferences A list of references to include in the Alternative Carrier Record
-     * @param role If [MdocTransport.Role.MDOC] the generated records will be for the Handover Select message, otherwise
+     * @param role If [MdocRole.MDOC] the generated records will be for the Handover Select message, otherwise
      * for Handover  Request.
      * @param skipUuids if `true`, UUIDs will not be included in the record
      * @return The NDEF record and the Alternative Carrier record or null if NFC handover is not supported.
      */
     abstract fun toNdefRecord(
         auxiliaryReferences: List<String>,
-        role: MdocTransport.Role,
+        role: MdocRole,
         skipUuids: Boolean
     ): Pair<NdefRecord, NdefRecord>?
 
@@ -45,7 +47,7 @@ abstract class ConnectionMethod {
         private const val TAG = "ConnectionMethod"
 
         /**
-         * Constructs a new [ConnectionMethod] from `DeviceRetrievalMethod` CBOR.
+         * Constructs a new [MdocConnectionMethod] from `DeviceRetrievalMethod` CBOR.
          *
          * See ISO/IEC 18013-5:2021 section 8.2.1.1 Device engagement structure for where
          * `DeviceRetrievalMethod` CBOR is defined.
@@ -53,27 +55,23 @@ abstract class ConnectionMethod {
          * This is the reverse operation of [.toDeviceEngagement].
          *
          * @param encodedDeviceRetrievalMethod the bytes of `DeviceRetrievalMethod` CBOR.
-         * @return A [ConnectionMethod]-derived instance or `null` if the method
+         * @return A [MdocConnectionMethod]-derived instance or `null` if the method
          * isn't supported.
          * @throws IllegalArgumentException if the given CBOR is malformed.
          */
-        fun fromDeviceEngagement(encodedDeviceRetrievalMethod: ByteArray): ConnectionMethod? {
+        fun fromDeviceEngagement(encodedDeviceRetrievalMethod: ByteArray): MdocConnectionMethod? {
             val array = decode(encodedDeviceRetrievalMethod)
             val type = array[0].asNumber
             when (type) {
-                ConnectionMethodNfc.METHOD_TYPE -> return ConnectionMethodNfc.fromDeviceEngagement(
+                MdocConnectionMethodNfc.METHOD_TYPE -> return MdocConnectionMethodNfc.fromDeviceEngagement(
                     encodedDeviceRetrievalMethod
                 )
 
-                ConnectionMethodBle.METHOD_TYPE -> return ConnectionMethodBle.fromDeviceEngagement(
+                MdocConnectionMethodBle.METHOD_TYPE -> return MdocConnectionMethodBle.fromDeviceEngagement(
                     encodedDeviceRetrievalMethod
                 )
 
-                ConnectionMethodWifiAware.METHOD_TYPE -> return ConnectionMethodWifiAware.fromDeviceEngagement(
-                    encodedDeviceRetrievalMethod
-                )
-
-                ConnectionMethodHttp.METHOD_TYPE -> return ConnectionMethodHttp.fromDeviceEngagement(
+                MdocConnectionMethodWifiAware.METHOD_TYPE -> return MdocConnectionMethodWifiAware.fromDeviceEngagement(
                     encodedDeviceRetrievalMethod
                 )
             }
@@ -82,26 +80,26 @@ abstract class ConnectionMethod {
         }
 
         /**
-         * Constructs a new [ConnectionMethod] from a NFC record.
+         * Constructs a new [MdocConnectionMethod] from a NFC record.
          *
-         * @param role If [MdocTransport.Role.MDOC] the record is from a Handover Select message,
-         * [MdocTransport.Role.MDOC_READER] if from a for Handover Request message.
+         * @param role If [MdocRole.MDOC] the record is from a Handover Select message,
+         *   [MdocRole.MDOC_READER] if from a for Handover Request message.
          * @param uuid If a UUID in a record isn't available, use this instead.
          * @returns the decoded method or `null` if the method isn't supported.
          */
         fun fromNdefRecord(
             record: NdefRecord,
-            role: MdocTransport.Role,
+            role: MdocRole,
             uuid: UUID?
-        ): ConnectionMethod? {
+        ): MdocConnectionMethod? {
             if (record.tnf == NdefRecord.Tnf.MIME_MEDIA &&
                 record.type.decodeToString() == Nfc.MIME_TYPE_CONNECTION_HANDOVER_BLE &&
                 record.id.decodeToString() == "0") {
-                return ConnectionMethodBle.fromNdefRecord(record, role, uuid)
+                return MdocConnectionMethodBle.fromNdefRecord(record, role, uuid)
             } else if (record.tnf == NdefRecord.Tnf.EXTERNAL_TYPE &&
                 record.type.decodeToString() == Nfc.EXTERNAL_TYPE_ISO_18013_5_NFC &&
                 record.id.decodeToString() == "nfc") {
-                return ConnectionMethodNfc.fromNdefRecord(record, role)
+                return MdocConnectionMethodNfc.fromNdefRecord(record, role)
             }
             // TODO: add support for Wifi Aware and others.
             Logger.w(TAG, "No support for NDEF record $record")
@@ -122,13 +120,13 @@ abstract class ConnectionMethod {
          * @return the given list of connection methods where similar methods are combined into one.
          * @throws IllegalArgumentException if some methods couldn't be combined
          */
-        fun combine(connectionMethods: List<ConnectionMethod>): List<ConnectionMethod> {
-            val result = mutableListOf<ConnectionMethod>()
+        fun combine(connectionMethods: List<MdocConnectionMethod>): List<MdocConnectionMethod> {
+            val result = mutableListOf<MdocConnectionMethod>()
 
             // Don't change the order if there is nothing to combine.
             var numBleMethods = 0
             for (cm in connectionMethods) {
-                if (cm is ConnectionMethodBle) {
+                if (cm is MdocConnectionMethodBle) {
                     numBleMethods += 1
                 }
             }
@@ -136,9 +134,9 @@ abstract class ConnectionMethod {
                 result.addAll(connectionMethods)
                 return result
             }
-            val bleMethods: MutableList<ConnectionMethodBle> = ArrayList()
+            val bleMethods: MutableList<MdocConnectionMethodBle> = ArrayList()
             for (cm in connectionMethods) {
-                if (cm is ConnectionMethodBle) {
+                if (cm is MdocConnectionMethodBle) {
                     bleMethods.add(cm)
                 } else {
                     result.add(cm)
@@ -179,14 +177,14 @@ abstract class ConnectionMethod {
                 }
             }
             val combined =
-                ConnectionMethodBle(
-                    supportsPeripheralServerMode,
-                    supportsCentralClientMode,
-                    if (supportsPeripheralServerMode) uuid else null,
-                    if (supportsCentralClientMode) uuid else null
+                MdocConnectionMethodBle(
+                    supportsPeripheralServerMode = supportsPeripheralServerMode,
+                    supportsCentralClientMode = supportsCentralClientMode,
+                    peripheralServerModeUuid = if (supportsPeripheralServerMode) uuid else null,
+                    centralClientModeUuid = if (supportsCentralClientMode) uuid else null,
+                    peripheralServerModePsm = psm,
+                    peripheralServerModeMacAddress = mac
                 )
-            combined.peripheralServerModeMacAddress = mac
-            combined.peripheralServerModePsm = psm
             return listOf(combined) + result
         }
 
@@ -198,52 +196,58 @@ abstract class ConnectionMethod {
          * server mode is set, replaces this with two connection methods so it's clear which one is
          * which.
          *
-         * The [ConnectionMethodBle.peripheralServerModePsm] and [ConnectionMethodBle.peripheralServerModeMacAddress]
-         * properties are duplicated in each of the resulting [ConnectionMethodBle] instances. The PSM
+         * The [MdocConnectionMethodBle.peripheralServerModePsm] and [MdocConnectionMethodBle.peripheralServerModeMacAddress]
+         * properties are duplicated in each of the resulting [MdocConnectionMethodBle] instances. The PSM
          * and MAC address is only conveyed on one of the instances, see [role] argument for which one.
          *
          * This is the reverse of [.combine].
          *
          * @param connectionMethods a list of connection methods.
-         * @param role If [MdocTransport.Role.MDOC] the PSM and MAC address will appear only in the resulting
-         *   [ConnectionMethodBle] objects for central client mode, otherwise they only appear in the object for
+         * @param role If [MdocRole.MDOC] the PSM and MAC address will appear only in the resulting
+         *   [MdocConnectionMethodBle] objects for central client mode, otherwise they only appear in the object for
          *   peripheral server mode.
          * @return the given list of connection methods where each instance is unambiguously refers
          * to one and only one connectable endpoint.
          */
         fun disambiguate(
-            connectionMethods: List<ConnectionMethod>,
-            role: MdocTransport.Role,
-        ): List<ConnectionMethod> {
-            val result = mutableListOf<ConnectionMethod>()
+            connectionMethods: List<MdocConnectionMethod>,
+            role: MdocRole,
+        ): List<MdocConnectionMethod> {
+            val result = mutableListOf<MdocConnectionMethod>()
             for (cm in connectionMethods) {
                 // Only BLE needs disambiguation
-                if (cm is ConnectionMethodBle) {
+                if (cm is MdocConnectionMethodBle) {
                     val cmBle = cm
                     if (cmBle.supportsCentralClientMode && cmBle.supportsPeripheralServerMode) {
+                        val (ccMac, ccPsm) = if (role == MdocRole.MDOC) {
+                            Pair(cmBle.peripheralServerModeMacAddress, cmBle.peripheralServerModePsm)
+                        } else {
+                            Pair(null, null)
+                        }
                         val centralClientMode =
-                            ConnectionMethodBle(
-                                false,
-                                true,
-                                null,
-                                cmBle.centralClientModeUuid
+                            MdocConnectionMethodBle(
+                                supportsPeripheralServerMode = false,
+                                supportsCentralClientMode = true,
+                                peripheralServerModeUuid = null,
+                                centralClientModeUuid = cmBle.centralClientModeUuid,
+                                peripheralServerModePsm = ccPsm,
+                                peripheralServerModeMacAddress = ccMac
                             )
-                        if (role == MdocTransport.Role.MDOC) {
-                            centralClientMode.peripheralServerModeMacAddress = cmBle.peripheralServerModeMacAddress
-                            centralClientMode.peripheralServerModePsm = cmBle.peripheralServerModePsm
-                        }
                         result.add(centralClientMode)
-                        val peripheralServerMode =
-                            ConnectionMethodBle(
-                                true,
-                                false,
-                                cmBle.peripheralServerModeUuid,
-                                null
-                            )
-                        if (role == MdocTransport.Role.MDOC_READER) {
-                            peripheralServerMode.peripheralServerModeMacAddress = cmBle.peripheralServerModeMacAddress
-                            peripheralServerMode.peripheralServerModePsm = cmBle.peripheralServerModePsm
+                        val (psMac, psPsm) = if (role == MdocRole.MDOC_READER) {
+                            Pair(cmBle.peripheralServerModeMacAddress, cmBle.peripheralServerModePsm)
+                        } else {
+                            Pair(null, null)
                         }
+                        val peripheralServerMode =
+                            MdocConnectionMethodBle(
+                                supportsPeripheralServerMode = true,
+                                supportsCentralClientMode = false,
+                                peripheralServerModeUuid = cmBle.peripheralServerModeUuid,
+                                centralClientModeUuid = null,
+                                peripheralServerModePsm = psPsm,
+                                peripheralServerModeMacAddress = psMac
+                            )
                         result.add(peripheralServerMode)
                         continue
                     }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementGenerator.kt
@@ -19,11 +19,10 @@ import org.multipaz.cbor.ArrayBuilder
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.CborBuilder
-import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborArray
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.origininfo.OriginInfo
 
 /**
@@ -43,10 +42,10 @@ class EngagementGenerator(
     /**
      * Adds connection methods to the engagement.
      *
-     * @param connectionMethods A list with instances derived from [ConnectionMethod].
+     * @param connectionMethods A list with instances derived from [MdocConnectionMethod].
      * @return the generator.
      */
-    fun addConnectionMethods(connectionMethods: List<ConnectionMethod>): EngagementGenerator {
+    fun addConnectionMethods(connectionMethods: List<MdocConnectionMethod>): EngagementGenerator {
         for (connectionMethod in connectionMethods) {
             deviceRetrievalMethodsArrayBuilder.add(
                 Cbor.decode(connectionMethod.toDeviceEngagement()))

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementParser.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/engagement/EngagementParser.kt
@@ -19,8 +19,8 @@ import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.DataItem
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod.Companion.fromDeviceEngagement
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod.Companion.fromDeviceEngagement
 import org.multipaz.mdoc.origininfo.OriginInfo
 import org.multipaz.util.Logger
 
@@ -70,7 +70,7 @@ class EngagementParser(private val encodedEngagement: ByteArray) {
         /**
          * The connection methods in the engagement.
          */
-        lateinit var connectionMethods: List<ConnectionMethod>
+        lateinit var connectionMethods: List<MdocConnectionMethod>
 
         /**
          * The origin infos in the engagement.
@@ -86,7 +86,7 @@ class EngagementParser(private val encodedEngagement: ByteArray) {
             eSenderKey = security[1].asTaggedEncodedCbor.asCoseKey.ecPublicKey
             this.eSenderKeyBytes = Cbor.encode(security[1])
             val connectionMethodsArray = map.getOrNull(2)
-            val cms = mutableListOf<ConnectionMethod>()
+            val cms = mutableListOf<MdocConnectionMethod>()
             if (connectionMethodsArray != null) {
                 for (cmDataItem in (connectionMethodsArray as CborArray).items) {
                     val connectionMethod = fromDeviceEngagement(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanNfcMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanNfcMdocReader.kt
@@ -1,8 +1,7 @@
 package org.multipaz.mdoc.nfc
 
 import org.multipaz.cbor.DataItem
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.mdoc.transport.MdocTransportFactory
 import org.multipaz.mdoc.transport.MdocTransportOptions
@@ -10,13 +9,8 @@ import org.multipaz.mdoc.transport.NfcTransportMdocReader
 import org.multipaz.nfc.scanNfcTag
 import org.multipaz.prompt.PromptDismissedException
 import org.multipaz.util.Logger
-import org.multipaz.util.UUID
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
-import kotlin.time.Duration.Companion.seconds
+import org.multipaz.mdoc.role.MdocRole
 
 const private val TAG = "scanNfcMdocReader"
 
@@ -34,7 +28,7 @@ private data class ScanNfcMdocReaderResult(
  * When a connection has been established, [onHandover] is called with the created transport as well as
  * the device engagement and handover structures used.
  *
- * If the given transport is for [org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc] the
+ * If the given transport is for [org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc] the
  * [onHandover] callback is called in the same coroutine used for interacting with the tag to ensure
  * continued communications with the remote NFC tag reader and the `updateMessage` parameter to [onHandover]
  * will be non-`null` which the application can use to update the message in the NFC scanning dialog.
@@ -55,8 +49,8 @@ suspend fun scanNfcMdocReader(
     message: String,
     options: MdocTransportOptions,
     transportFactory: MdocTransportFactory = MdocTransportFactory.Default,
-    selectConnectionMethod: suspend (connectionMethods: List<ConnectionMethod>) -> ConnectionMethod?,
-    negotiatedHandoverConnectionMethods: List<ConnectionMethod>,
+    selectConnectionMethod: suspend (connectionMethods: List<MdocConnectionMethod>) -> MdocConnectionMethod?,
+    negotiatedHandoverConnectionMethods: List<MdocConnectionMethod>,
     onHandover: suspend (
         transport: MdocTransport,
         encodedDeviceEngagement: ByteString,
@@ -72,7 +66,7 @@ suspend fun scanNfcMdocReader(
     val negotiatedHandoverTransports = negotiatedHandoverConnectionMethods.map {
         val transport = transportFactory.createTransport(
             it,
-            MdocTransport.Role.MDOC_READER,
+            MdocRole.MDOC_READER,
             options
         )
         transport.advertise()
@@ -117,7 +111,7 @@ suspend fun scanNfcMdocReader(
                 if (transport == null) {
                     transport = transportFactory.createTransport(
                         connectionMethod,
-                        MdocTransport.Role.MDOC_READER,
+                        MdocRole.MDOC_READER,
                         options
                     )
                 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/role/MdocRole.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/role/MdocRole.kt
@@ -1,0 +1,12 @@
+package org.multipaz.mdoc.role
+
+/**
+ * An enumeration for the two different roles in mdoc presentment.
+ */
+enum class MdocRole {
+    /** The role is the  _mdoc_ (e.g. wallet app). */
+    MDOC,
+
+    /** The role is the _mdoc reader_ (e.g. verifier). */
+    MDOC_READER
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
@@ -1,13 +1,11 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
@@ -21,10 +19,11 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.time.Duration
 
 internal class BleTransportCentralMdoc(
-    override val role: Role,
+    override val role: MdocRole,
     private val options: MdocTransportOptions,
     private val centralManager: BleCentralManager,
     private val uuid: UUID,
@@ -40,8 +39,8 @@ internal class BleTransportCentralMdoc(
     private val _state = MutableStateFlow<State>(State.IDLE)
     override val state: StateFlow<State> = _state.asStateFlow()
 
-    override val connectionMethod: ConnectionMethod
-        get() = ConnectionMethodBle(false, true, null, uuid)
+    override val connectionMethod: MdocConnectionMethod
+        get() = MdocConnectionMethodBle(false, true, null, uuid)
 
     init {
         centralManager.setUuids(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
@@ -1,8 +1,8 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
 import kotlinx.coroutines.CoroutineScope
@@ -17,10 +17,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.time.Duration
 
 internal class BleTransportCentralMdocReader(
-    override val role: Role,
+    override val role: MdocRole,
     private val options: MdocTransportOptions,
     private val peripheralManager: BlePeripheralManager,
     private val uuid: UUID
@@ -35,11 +36,16 @@ internal class BleTransportCentralMdocReader(
     private val _state = MutableStateFlow<State>(State.IDLE)
     override val state: StateFlow<State> = _state.asStateFlow()
 
-    override val connectionMethod: ConnectionMethod
+    override val connectionMethod: MdocConnectionMethod
         get() {
-            val cm = ConnectionMethodBle(false, true, null, uuid)
-            peripheralManager.l2capPsm?.let { cm.peripheralServerModePsm = it }
-            return cm
+            return MdocConnectionMethodBle(
+                supportsPeripheralServerMode = false,
+                supportsCentralClientMode = true,
+                peripheralServerModeUuid = null,
+                centralClientModeUuid = uuid,
+                peripheralServerModePsm = peripheralManager.l2capPsm,
+                peripheralServerModeMacAddress = null
+            )
         }
 
     init {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
@@ -1,8 +1,8 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
 import kotlinx.coroutines.CoroutineScope
@@ -17,10 +17,11 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.time.Duration
 
 internal class BleTransportPeripheralMdoc(
-    override val role: Role,
+    override val role: MdocRole,
     private val options: MdocTransportOptions,
     private val peripheralManager: BlePeripheralManager,
     private val uuid: UUID
@@ -35,11 +36,16 @@ internal class BleTransportPeripheralMdoc(
     private val _state = MutableStateFlow<State>(State.IDLE)
     override val state: StateFlow<State> = _state.asStateFlow()
 
-    override val connectionMethod: ConnectionMethod
+    override val connectionMethod: MdocConnectionMethod
         get() {
-            val cm = ConnectionMethodBle(true, false, uuid, null)
-            peripheralManager.l2capPsm?.let { cm.peripheralServerModePsm = it }
-            return cm
+            return MdocConnectionMethodBle(
+                supportsPeripheralServerMode = true,
+                supportsCentralClientMode = false,
+                peripheralServerModeUuid = uuid,
+                centralClientModeUuid = null,
+                peripheralServerModePsm = peripheralManager.l2capPsm,
+                peripheralServerModeMacAddress = null
+            )
         }
 
     init {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
@@ -1,18 +1,15 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.IO
 import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.currentCoroutineContext
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -21,11 +18,11 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.time.Duration
-import kotlin.time.Duration.Companion.milliseconds
 
 internal class BleTransportPeripheralMdocReader(
-    override val role: Role,
+    override val role: MdocRole,
     private val options: MdocTransportOptions,
     private val centralManager: BleCentralManager,
     private val uuid: UUID,
@@ -41,8 +38,8 @@ internal class BleTransportPeripheralMdocReader(
     private val _state = MutableStateFlow<State>(State.IDLE)
     override val state: StateFlow<State> = _state.asStateFlow()
 
-    override val connectionMethod: ConnectionMethod
-        get() = ConnectionMethodBle(true, false, uuid, null)
+    override val connectionMethod: MdocConnectionMethod
+        get() = MdocConnectionMethodBle(true, false, uuid, null)
 
     init {
         centralManager.setUuids(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransport.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransport.kt
@@ -1,8 +1,9 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import kotlinx.coroutines.flow.StateFlow
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.time.Duration
 
 /**
@@ -17,12 +18,12 @@ import kotlin.time.Duration
  * and [waitForMessage] to exchange messages with the remote peer.
  *
  * Each [MdocTransport] has a role, indicating whether the application is acting as
- * the _mdoc_ or _mdoc reader_. For forward engagement, if acting in the role [Role.MDOC]
- * the application should create one or more [ConnectionMethod] instances, call [open] on
- * each of them, share the [ConnectionMethod]s (through QR or NFC in _Device Engagement_
+ * the _mdoc_ or _mdoc reader_. For forward engagement, if acting in the role [MdocRole.MDOC]
+ * the application should create one or more [MdocConnectionMethod] instances, call [open] on
+ * each of them, share the [MdocConnectionMethod]s (through QR or NFC in _Device Engagement_
  * according to ISO/EC 18013-5:2021). Similarly, the other peer - acting in the role
- * [Role.MDOC_READER] - should obtain the _Device Engagement_, get one or more
- * [ConnectionMethod] objects and call [open] on one of them. For reverse engagement,
+ * [MdocRole.MDOC_READER] - should obtain the _Device Engagement_, get one or more
+ * [MdocConnectionMethod] objects and call [open] on one of them. For reverse engagement,
  * the process is the same but with the roles reversed.
  *
  * The transport can fail at any time, for example if the other peer sends invalid data
@@ -36,16 +37,6 @@ import kotlin.time.Duration
  * any thread or coroutine.
  */
 abstract class MdocTransport {
-    /**
-     * The role of the transport
-     */
-    enum class Role {
-        /** The transport is being used by an _mdoc_. */
-        MDOC,
-
-        /** The transport is being used by an _mdoc reader_. */
-        MDOC_READER
-    }
 
     /**
      * Possible states for a transport.
@@ -81,19 +72,19 @@ abstract class MdocTransport {
     /**
      * The role which the transport is for.
      */
-    abstract val role: Role
+    abstract val role: MdocRole
 
     /**
-     * A [ConnectionMethod] which can be sent to the other peer to connect to.
+     * A [MdocConnectionMethod] which can be sent to the other peer to connect to.
      */
-    abstract val connectionMethod: ConnectionMethod
+    abstract val connectionMethod: MdocConnectionMethod
 
     /**
      * The time spent scanning for the other peer.
      *
      * This is always `null` until [open] completes and it's only set for transports that actually perform active
-     * scanning for the other peer. This includes _BLE mdoc central client mode_ for [Role.MDOC] and
-     * _BLE mdoc peripheral server mode_ for [Role.MDOC_READER].
+     * scanning for the other peer. This includes _BLE mdoc central client mode_ for [MdocRole.MDOC] and
+     * _BLE mdoc peripheral server mode_ for [MdocRole.MDOC_READER].
      */
     abstract val scanningTime: Duration?
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.kt
@@ -1,6 +1,7 @@
 package org.multipaz.mdoc.transport
 
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.role.MdocRole
 
 /**
  * An interface used to create [MdocTransport] instances.
@@ -15,8 +16,8 @@ interface MdocTransportFactory {
      * @return A [MdocTransport] instance, ready to be used.
      */
     fun createTransport(
-        connectionMethod: ConnectionMethod,
-        role: MdocTransport.Role,
+        connectionMethod: MdocConnectionMethod,
+        role: MdocRole,
         options: MdocTransportOptions = MdocTransportOptions()
     ): MdocTransport
 
@@ -25,15 +26,15 @@ interface MdocTransportFactory {
      */
     object Default : MdocTransportFactory {
         override fun createTransport(
-            connectionMethod: ConnectionMethod,
-            role: MdocTransport.Role,
+            connectionMethod: MdocConnectionMethod,
+            role: MdocRole,
             options: MdocTransportOptions
         ): MdocTransport = defaultMdocTransportFactoryCreateTransport(connectionMethod, role, options)
     }
 }
 
 internal expect fun defaultMdocTransportFactoryCreateTransport(
-    connectionMethod: ConnectionMethod,
-    role: MdocTransport.Role,
+    connectionMethod: MdocConnectionMethod,
+    role: MdocRole,
     options: MdocTransportOptions
 ): MdocTransport

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdoc.kt
@@ -1,7 +1,7 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.nfc.CommandApdu
 import org.multipaz.nfc.Nfc
 import org.multipaz.nfc.ResponseApdu
@@ -17,13 +17,14 @@ import kotlinx.coroutines.sync.withLock
 import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.bytestring.append
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.math.min
 import kotlin.time.Duration
 
 class NfcTransportMdoc(
-    override val role: Role,
+    override val role: MdocRole,
     private val options: MdocTransportOptions,
-    override val connectionMethod: ConnectionMethod
+    override val connectionMethod: MdocConnectionMethod
 ) : MdocTransport() {
     companion object {
         private const val TAG = "NfcTransportMdoc"

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
@@ -1,7 +1,7 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.nfc.CommandApdu
 import org.multipaz.nfc.Nfc
 import org.multipaz.nfc.NfcCommandFailedException
@@ -22,6 +22,7 @@ import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.bytestring.append
 import kotlinx.io.bytestring.buildByteString
+import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.util.ByteDataReader
 import org.multipaz.util.appendByteString
 import org.multipaz.util.appendUInt16
@@ -30,9 +31,9 @@ import kotlin.math.min
 import kotlin.time.Duration
 
 class NfcTransportMdocReader(
-    override val role: Role,
+    override val role: MdocRole,
     private val options: MdocTransportOptions,
-    override val connectionMethod: ConnectionMethodNfc
+    override val connectionMethod: MdocConnectionMethodNfc
 ) : MdocTransport() {
     companion object {
         private const val TAG = "NfcTransportMdocReader"

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/connectionHelper.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/connectionHelper.kt
@@ -1,7 +1,7 @@
 package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.util.Logger
 import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.CoroutineScope
@@ -10,13 +10,14 @@ import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.suspendCancellableCoroutine
+import org.multipaz.mdoc.role.MdocRole
 
 private const val TAG = "connectionHelper"
 
 /**
  * A helper for advertising a number of connections to a remote peer.
  *
- * For each [ConnectionMethod] this creates a [MdocTransport] which is advertised and opened.
+ * For each [MdocConnectionMethod] this creates a [MdocTransport] which is advertised and opened.
  * The first connection which a remote peer connects to is returned and the other ones are closed.
  *
  * @param role the role to use when creating connections.
@@ -29,12 +30,12 @@ private const val TAG = "connectionHelper"
  * or [MdocTransport.State.CONNECTED] state.
  */
 @OptIn(ExperimentalCoroutinesApi::class)
-suspend fun List<ConnectionMethod>.advertiseAndWait(
-    role: MdocTransport.Role,
+suspend fun List<MdocConnectionMethod>.advertiseAndWait(
+    role: MdocRole,
     transportFactory: MdocTransportFactory,
     options: MdocTransportOptions,
     eSenderKey: EcPublicKey,
-    onConnectionMethodsReady: suspend (advertisedConnectionMethods: List<ConnectionMethod>) -> Unit,
+    onConnectionMethodsReady: suspend (advertisedConnectionMethods: List<MdocConnectionMethod>) -> Unit,
 ): MdocTransport {
     val transports = mutableListOf<MdocTransport>()
     for (connectionMethod in this) {
@@ -46,7 +47,7 @@ suspend fun List<ConnectionMethod>.advertiseAndWait(
         transport.advertise()
         transports.add(transport)
     }
-    onConnectionMethodsReady(ConnectionMethod.combine(transports.map { it.connectionMethod }))
+    onConnectionMethodsReady(MdocConnectionMethod.combine(transports.map { it.connectionMethod }))
 
     lateinit var continuation: CancellableContinuation<MdocTransport>
     for (transport in transports) {

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/connectionmethod/MdocConnectionMethodTest.kt
@@ -19,10 +19,9 @@ import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.toHexString
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DiagnosticOption
-import org.multipaz.mdoc.transport.MdocTransport
+import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.util.UUID
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -30,11 +29,11 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
-class ConnectionMethodTest {
+class MdocConnectionMethodTest {
     @Test
     fun testConnectionMethodNfc() {
-        val cm = ConnectionMethodNfc(4096, 32768)
-        val decoded = ConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodNfc?
+        val cm = MdocConnectionMethodNfc(4096, 32768)
+        val decoded = MdocConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodNfc?
         assertNotNull(decoded)
         assertEquals(decoded.commandDataFieldMaxLength, decoded.commandDataFieldMaxLength)
         assertEquals(decoded.responseDataFieldMaxLength, decoded.responseDataFieldMaxLength)
@@ -48,8 +47,8 @@ class ConnectionMethodTest {
   }
 ]""", Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
         )
-        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false)!!.first
-        val decodedNfc = ConnectionMethodNfc.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC)!!
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocRole.MDOC, false)!!.first
+        val decodedNfc = MdocConnectionMethodNfc.fromNdefRecord(ndefRecord, MdocRole.MDOC)!!
         assertEquals(cm, decodedNfc)
     }
 
@@ -57,13 +56,13 @@ class ConnectionMethodTest {
     fun testConnectionMethodBle() {
         val uuidPeripheral = UUID(0U, 1U)
         val uuidCentral = UUID(123456789U, 987654321U)
-        var cm = ConnectionMethodBle(
+        var cm = MdocConnectionMethodBle(
             true,
             true,
             uuidPeripheral,
             uuidCentral
         )
-        val decoded = ConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodBle?
+        val decoded = MdocConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodBle?
         assertNotNull(decoded)
         assertTrue(decoded.supportsPeripheralServerMode)
         assertTrue(decoded.supportsCentralClientMode)
@@ -84,27 +83,27 @@ class ConnectionMethodTest {
 
         // For use in NFC, the UUIDs have to be the same
         val uuidBoth = UUID(0U, 2U)
-        cm = ConnectionMethodBle(
+        cm = MdocConnectionMethodBle(
             true,
             true,
             uuidBoth,
             uuidBoth
         )
-        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false).first
-        val decodedNfc = ConnectionMethodBle.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC, null)!!
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocRole.MDOC, false).first
+        val decodedNfc = MdocConnectionMethodBle.fromNdefRecord(ndefRecord, MdocRole.MDOC, null)!!
         assertEquals(cm, decodedNfc)
     }
 
     @Test
     fun testConnectionMethodBleOnlyCentralClient() {
         val uuid = UUID(123456789U, 987654321U)
-        val cm = ConnectionMethodBle(
+        val cm = MdocConnectionMethodBle(
             false,
             true,
             null,
             uuid
         )
-        val decoded = ConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodBle?
+        val decoded = MdocConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodBle?
         assertNotNull(decoded)
         assertFalse(decoded.supportsPeripheralServerMode)
         assertTrue(decoded.supportsCentralClientMode)
@@ -122,21 +121,21 @@ class ConnectionMethodTest {
 ]""", Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
         )
 
-        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false).first
-        val decodedNfc = ConnectionMethodBle.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC, null)!!
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocRole.MDOC, false).first
+        val decodedNfc = MdocConnectionMethodBle.fromNdefRecord(ndefRecord, MdocRole.MDOC, null)!!
         assertEquals(cm, decodedNfc)
     }
 
     @Test
     fun testConnectionMethodBleOnlyPeripheralServer() {
         val uuid = UUID(0U, 1U)
-        val cm = ConnectionMethodBle(
+        val cm = MdocConnectionMethodBle(
             true,
             false,
             uuid,
             null
         )
-        val decoded = ConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodBle?
+        val decoded = MdocConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodBle?
         assertNotNull(decoded)
         assertTrue(decoded.supportsPeripheralServerMode)
         assertFalse(decoded.supportsCentralClientMode)
@@ -154,25 +153,25 @@ class ConnectionMethodTest {
 ]""", Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
         )
 
-        val ndefRecord = cm.toNdefRecord(listOf(), MdocTransport.Role.MDOC, false).first
-        val decodedNfc = ConnectionMethodBle.fromNdefRecord(ndefRecord, MdocTransport.Role.MDOC, null)!!
+        val ndefRecord = cm.toNdefRecord(listOf(), MdocRole.MDOC, false).first
+        val decodedNfc = MdocConnectionMethodBle.fromNdefRecord(ndefRecord, MdocRole.MDOC, null)!!
         assertEquals(cm, decodedNfc)
     }
 
     @Test
     fun testConnectionMethodWifiAware() {
-        val cm = ConnectionMethodWifiAware(
+        val cm = MdocConnectionMethodWifiAware(
             "foobar",
             42,
             43,
-            byteArrayOf(1, 2)
+            ByteString(1, 2)
         )
-        val decoded = ConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodWifiAware?
+        val decoded = MdocConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as MdocConnectionMethodWifiAware?
         assertNotNull(decoded)
         assertEquals("foobar", decoded!!.passphraseInfoPassphrase)
         assertEquals(42, decoded.channelInfoChannelNumber)
         assertEquals(43, decoded.channelInfoOperatingClass)
-        assertContentEquals(byteArrayOf(1, 2), decoded.bandInfoSupportedBands)
+        assertEquals(ByteString(1, 2), decoded.bandInfoSupportedBands)
         assertEquals(
             """[
   3,
@@ -187,30 +186,13 @@ class ConnectionMethodTest {
         )
     }
 
-    @Test
-    fun testConnectionMethodRestApi() {
-        val cm = ConnectionMethodHttp("https://www.example.com/mdocReader")
-        val decoded = ConnectionMethod.fromDeviceEngagement(cm.toDeviceEngagement()) as ConnectionMethodHttp?
-        assertNotNull(decoded)
-        assertEquals(decoded.uri, cm.uri)
-        assertEquals(
-            """[
-  4,
-  1,
-  {
-    0: "https://www.example.com/mdocReader"
-  }
-]""", Cbor.toDiagnostics(cm.toDeviceEngagement(), setOf(DiagnosticOption.PRETTY_PRINT))
-        )
-    }
-
     @OptIn(ExperimentalStdlibApi::class)
     @Test
     fun testConnectionMethodDisambiguateMdoc() {
-        val disambiguated = ConnectionMethod.disambiguate(
+        val disambiguated = MdocConnectionMethod.disambiguate(
             listOf(
-                ConnectionMethodHttp("https://www.example.com/mdocReader"),
-                ConnectionMethodBle(
+                MdocConnectionMethodNfc(4096, 4096),
+                MdocConnectionMethodBle(
                     supportsPeripheralServerMode = true,
                     supportsCentralClientMode = true,
                     peripheralServerModeUuid = UUID(0U, 1U),
@@ -219,14 +201,14 @@ class ConnectionMethodTest {
                     peripheralServerModeMacAddress = ByteString(0x11, 0x22, 0x33, 0x44, 0x55, 0x66)
                 )
             ),
-            MdocTransport.Role.MDOC
+            MdocRole.MDOC
         )
         assertEquals(3, disambiguated.size.toLong())
-        assertTrue(disambiguated[0] is ConnectionMethodHttp)
-        assertTrue(disambiguated[1] is ConnectionMethodBle)
-        assertTrue(disambiguated[2] is ConnectionMethodBle)
+        assertTrue(disambiguated[0] is MdocConnectionMethodNfc)
+        assertTrue(disambiguated[1] is MdocConnectionMethodBle)
+        assertTrue(disambiguated[2] is MdocConnectionMethodBle)
 
-        val bleCc = disambiguated[1] as ConnectionMethodBle
+        val bleCc = disambiguated[1] as MdocConnectionMethodBle
         assertFalse(bleCc.supportsPeripheralServerMode)
         assertTrue(bleCc.supportsCentralClientMode)
         assertNull(bleCc.peripheralServerModeUuid)
@@ -234,7 +216,7 @@ class ConnectionMethodTest {
         assertEquals(192, bleCc.peripheralServerModePsm)
         assertEquals("112233445566", bleCc.peripheralServerModeMacAddress!!.toHexString())
 
-        val blePs = disambiguated[2] as ConnectionMethodBle
+        val blePs = disambiguated[2] as MdocConnectionMethodBle
         assertTrue(blePs.supportsPeripheralServerMode)
         assertFalse(blePs.supportsCentralClientMode)
         assertEquals(UUID(0U, 1U), blePs.peripheralServerModeUuid)
@@ -246,10 +228,10 @@ class ConnectionMethodTest {
     @OptIn(ExperimentalStdlibApi::class)
     @Test
     fun testConnectionMethodDisambiguateMdocReader() {
-        val disambiguated = ConnectionMethod.disambiguate(
+        val disambiguated = MdocConnectionMethod.disambiguate(
             listOf(
-                ConnectionMethodHttp("https://www.example.com/mdocReader"),
-                ConnectionMethodBle(
+                MdocConnectionMethodNfc(4096, 4096),
+                MdocConnectionMethodBle(
                     supportsPeripheralServerMode = true,
                     supportsCentralClientMode = true,
                     peripheralServerModeUuid = UUID(0U, 1U),
@@ -258,14 +240,14 @@ class ConnectionMethodTest {
                     peripheralServerModeMacAddress = ByteString(0x11, 0x22, 0x33, 0x44, 0x55, 0x66)
                 )
             ),
-            MdocTransport.Role.MDOC_READER
+            MdocRole.MDOC_READER
         )
         assertEquals(3, disambiguated.size.toLong())
-        assertTrue(disambiguated[0] is ConnectionMethodHttp)
-        assertTrue(disambiguated[1] is ConnectionMethodBle)
-        assertTrue(disambiguated[2] is ConnectionMethodBle)
+        assertTrue(disambiguated[0] is MdocConnectionMethodNfc)
+        assertTrue(disambiguated[1] is MdocConnectionMethodBle)
+        assertTrue(disambiguated[2] is MdocConnectionMethodBle)
 
-        val bleCc = disambiguated[1] as ConnectionMethodBle
+        val bleCc = disambiguated[1] as MdocConnectionMethodBle
         assertFalse(bleCc.supportsPeripheralServerMode)
         assertTrue(bleCc.supportsCentralClientMode)
         assertNull(bleCc.peripheralServerModeUuid)
@@ -273,7 +255,7 @@ class ConnectionMethodTest {
         assertNull(bleCc.peripheralServerModePsm)
         assertNull(bleCc.peripheralServerModeMacAddress)
 
-        val blePs = disambiguated[2] as ConnectionMethodBle
+        val blePs = disambiguated[2] as MdocConnectionMethodBle
         assertTrue(blePs.supportsPeripheralServerMode)
         assertFalse(blePs.supportsCentralClientMode)
         assertEquals(UUID(0U, 1U), blePs.peripheralServerModeUuid)
@@ -285,14 +267,14 @@ class ConnectionMethodTest {
     @Test
     fun testConnectionMethodCombineUuidNotSame() {
         val disambiguated = listOf(
-            ConnectionMethodHttp("https://www.example.com/mdocReader"),
-            ConnectionMethodBle(
+            MdocConnectionMethodNfc(4096, 4096),
+            MdocConnectionMethodBle(
                 true,
                 false,
                 UUID(0U, 1U),
                 null
             ),
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 false,
                 true,
                 null,
@@ -300,7 +282,7 @@ class ConnectionMethodTest {
             )
         )
         assertFailsWith<IllegalArgumentException> {
-            val combined = ConnectionMethod.combine(disambiguated)
+            val combined = MdocConnectionMethod.combine(disambiguated)
         }
     }
 
@@ -308,23 +290,23 @@ class ConnectionMethodTest {
     fun testConnectionMethodCombineUuid() {
         val uuid = UUID(0U, 3U)
         val disambiguated = listOf(
-            ConnectionMethodHttp("https://www.example.com/mdocReader"),
-            ConnectionMethodBle(
+            MdocConnectionMethodNfc(4096, 4096),
+            MdocConnectionMethodBle(
                 true,
                 false,
                 uuid,
                 null
             ),
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 false,
                 true,
                 null,
                 uuid
             )
         )
-        val combined = ConnectionMethod.combine(disambiguated)
+        val combined = MdocConnectionMethod.combine(disambiguated)
         assertEquals(2, combined.size.toLong())
-        val ble = combined[0] as ConnectionMethodBle
+        val ble = combined[0] as MdocConnectionMethodBle
         assertTrue(ble.supportsPeripheralServerMode)
         assertTrue(ble.supportsCentralClientMode)
         assertEquals(uuid, ble.peripheralServerModeUuid)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/engagement/EngagementGeneratorTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/engagement/EngagementGeneratorTest.kt
@@ -17,9 +17,8 @@ package org.multipaz.mdoc.engagement
 
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodHttp
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.origininfo.OriginInfo
 import org.multipaz.mdoc.origininfo.OriginInfoDomain
 import org.multipaz.util.UUID
@@ -48,33 +47,6 @@ class EngagementGeneratorTest {
 
     @Test
     @Throws(Exception::class)
-    fun testWebsiteEngagement() {
-        val eSenderKey = Crypto.createEcPrivateKey(EcCurve.P256)
-        val eg = EngagementGenerator(
-            eSenderKey.publicKey,
-            EngagementGenerator.ENGAGEMENT_VERSION_1_1
-        )
-        val connectionMethods = mutableListOf<ConnectionMethod>()
-        connectionMethods.add(ConnectionMethodHttp("http://www.example.com/verifier/123"))
-        eg.addConnectionMethods(connectionMethods)
-        val originInfos = mutableListOf<OriginInfo>()
-        originInfos.add(OriginInfoDomain("http://www.example.com/verifier"))
-        eg.addOriginInfos(originInfos)
-        val encodedEngagement = eg.generate()
-        val parser = EngagementParser(encodedEngagement)
-        val engagement = parser.parse()
-        assertEquals(engagement.eSenderKey, eSenderKey.publicKey)
-        assertEquals(EngagementGenerator.ENGAGEMENT_VERSION_1_1, engagement.version)
-        assertEquals(1, engagement.connectionMethods.size.toLong())
-        val cm = engagement.connectionMethods[0] as ConnectionMethodHttp
-        assertEquals("http://www.example.com/verifier/123", cm.uri)
-        assertEquals(1, engagement.originInfos.size.toLong())
-        val oi = engagement.originInfos[0] as OriginInfoDomain
-        assertEquals("http://www.example.com/verifier", oi.url)
-    }
-
-    @Test
-    @Throws(Exception::class)
     fun testDeviceEngagementQrBleCentralClientMode() {
         val eSenderKey = Crypto.createEcPrivateKey(EcCurve.P256)
         val uuid = UUID.randomUUID()
@@ -82,9 +54,9 @@ class EngagementGeneratorTest {
             eSenderKey.publicKey,
             EngagementGenerator.ENGAGEMENT_VERSION_1_0
         )
-        val connectionMethods = mutableListOf<ConnectionMethod>()
+        val connectionMethods = mutableListOf<MdocConnectionMethod>()
         connectionMethods.add(
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 false,
                 true,
                 null,
@@ -98,7 +70,7 @@ class EngagementGeneratorTest {
         assertEquals(engagement.eSenderKey, eSenderKey.publicKey)
         assertEquals(EngagementGenerator.ENGAGEMENT_VERSION_1_0, engagement.version)
         assertEquals(1, engagement.connectionMethods.size.toLong())
-        val cm = engagement.connectionMethods[0] as ConnectionMethodBle
+        val cm = engagement.connectionMethods[0] as MdocConnectionMethodBle
         assertFalse(cm.supportsPeripheralServerMode)
         assertTrue(cm.supportsCentralClientMode)
         assertNull(cm.peripheralServerModeUuid)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/engagement/EngagementParserTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/engagement/EngagementParserTest.kt
@@ -16,7 +16,7 @@
 package org.multipaz.mdoc.engagement
 
 import org.multipaz.mdoc.TestVectors
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.fromHex
 import org.multipaz.util.toHex
 import kotlin.test.Test
@@ -34,8 +34,8 @@ class EngagementParserTest {
         assertEquals("1.0", engagement.version)
         val connectionMethods = engagement.connectionMethods
         assertEquals(1, connectionMethods.size.toLong())
-        assertTrue(connectionMethods[0] is ConnectionMethodBle)
-        val cmBle = connectionMethods[0] as ConnectionMethodBle
+        assertTrue(connectionMethods[0] is MdocConnectionMethodBle)
+        val cmBle = connectionMethods[0] as MdocConnectionMethodBle
         assertFalse(cmBle.supportsPeripheralServerMode)
         assertTrue(cmBle.supportsCentralClientMode)
         assertNull(cmBle.peripheralServerModeUuid)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelperTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/nfc/MdocNfcEngagementHelperTest.kt
@@ -4,9 +4,9 @@ import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.EcPublicKeyDoubleCoordinate
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.nfc.CommandApdu
 import org.multipaz.nfc.Nfc
 import org.multipaz.nfc.NfcCommandFailedException
@@ -45,24 +45,24 @@ class MdocNfcEngagementHelperTest {
         }
     }
 
-    private fun getConnectionMethods(): List<ConnectionMethod> {
+    private fun getConnectionMethods(): List<MdocConnectionMethod> {
         // Include all ConnectionMethods that can exist in OOB data. Use static identifiers
         // to ensure we get the same transcripts every time.
         val bleUuid = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb6")
         return listOf(
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 supportsPeripheralServerMode = false,
                 supportsCentralClientMode = true,
                 peripheralServerModeUuid = null,
                 centralClientModeUuid = bleUuid
             ),
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 supportsPeripheralServerMode = true,
                 supportsCentralClientMode = false,
                 peripheralServerModeUuid = bleUuid,
                 centralClientModeUuid = null
             ),
-            ConnectionMethodNfc(
+            MdocConnectionMethodNfc(
                 commandDataFieldMaxLength = 0xffff,
                 responseDataFieldMaxLength = 0x10000
             )
@@ -185,13 +185,13 @@ class MdocNfcEngagementHelperTest {
         val bleUuid1 = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb6")
         val bleUuid2 = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb7")
         val staticHandoverConnectionMethods = listOf(
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 supportsPeripheralServerMode = false,
                 supportsCentralClientMode = true,
                 peripheralServerModeUuid = null,
                 centralClientModeUuid = bleUuid1
             ),
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 supportsPeripheralServerMode = true,
                 supportsCentralClientMode = false,
                 peripheralServerModeUuid = bleUuid2,
@@ -230,13 +230,13 @@ class MdocNfcEngagementHelperTest {
         val bleUuid1 = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb6")
         val bleUuid2 = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb7")
         val connectionMethods = listOf(
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 supportsPeripheralServerMode = false,
                 supportsCentralClientMode = true,
                 peripheralServerModeUuid = null,
                 centralClientModeUuid = bleUuid1
             ),
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 supportsPeripheralServerMode = true,
                 supportsCentralClientMode = false,
                 peripheralServerModeUuid = bleUuid2,
@@ -274,13 +274,13 @@ class MdocNfcEngagementHelperTest {
     fun testStaticHandoverBlePsm() = runTest {
         val bleUuid = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb6")
 
-        val bleCc =  ConnectionMethodBle(
+        val bleCc =  MdocConnectionMethodBle(
             supportsPeripheralServerMode = false,
             supportsCentralClientMode = true,
             peripheralServerModeUuid = null,
             centralClientModeUuid = bleUuid
         )
-        val blePs = ConnectionMethodBle(
+        val blePs = MdocConnectionMethodBle(
             supportsPeripheralServerMode = true,
             supportsCentralClientMode = false,
             peripheralServerModeUuid = bleUuid,
@@ -316,14 +316,14 @@ class MdocNfcEngagementHelperTest {
     fun testNegotiatedHandoverBlePsm() = runTest {
         val bleUuid = UUID.fromString("b3d52ac4-a1b6-4b51-a22e-78ee55ef6eb6")
 
-        val bleCc =  ConnectionMethodBle(
+        val bleCc =  MdocConnectionMethodBle(
             supportsPeripheralServerMode = false,
             supportsCentralClientMode = true,
             peripheralServerModeUuid = null,
             centralClientModeUuid = bleUuid,
             peripheralServerModePsm = 192,
         )
-        val blePs = ConnectionMethodBle(
+        val blePs = MdocConnectionMethodBle(
             supportsPeripheralServerMode = true,
             supportsCentralClientMode = false,
             peripheralServerModeUuid = bleUuid,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryptionTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryptionTest.kt
@@ -22,6 +22,7 @@ import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPrivateKeyDoubleCoordinate
 import org.multipaz.mdoc.TestVectors
 import org.multipaz.mdoc.engagement.EngagementParser
+import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.util.Constants
 import org.multipaz.util.fromHex
 import kotlin.test.Test
@@ -49,7 +50,7 @@ class SessionEncryptionTest {
         val engagement = engagementParser.parse()
         val eDeviceKey = engagement.eSenderKey
         val sessionEncryption = SessionEncryption(
-            SessionEncryption.Role.MDOC_READER,
+            MdocRole.MDOC_READER,
             eReaderKey,
             eDeviceKey,
             Cbor.encode(sessionTranscript)
@@ -108,7 +109,7 @@ class SessionEncryptionTest {
         val eReaderKey = Cbor.decode(sessionEstablishment)["eReaderKey"]
             .asTaggedEncodedCbor.asCoseKey.ecPublicKey
         val sessionEncryptionDevice = SessionEncryption(
-            SessionEncryption.Role.MDOC,
+            MdocRole.MDOC,
             eDeviceKey,
             eReaderKey,
             Cbor.encode(sessionTranscript)
@@ -161,14 +162,14 @@ class SessionEncryptionTest {
         val eDeviceKey = Crypto.createEcPrivateKey(curve)
         val encodedSessionTranscript = byteArrayOf(1, 2, 3)
         val sessionEncryptionReader = SessionEncryption(
-            SessionEncryption.Role.MDOC_READER,
+            MdocRole.MDOC_READER,
             eReaderKey,
             eDeviceKey.publicKey,
             encodedSessionTranscript
         )
         sessionEncryptionReader.setSendSessionEstablishment(false)
         val sessionEncryptionHolder = SessionEncryption(
-            SessionEncryption.Role.MDOC,
+            MdocRole.MDOC,
             eDeviceKey,
             eReaderKey.publicKey,
             encodedSessionTranscript

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/transport/NfcTransportTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/transport/NfcTransportTests.kt
@@ -2,7 +2,7 @@ package org.multipaz.mdoc.transport
 
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.nfc.CommandApdu
 import org.multipaz.nfc.NfcIsoTag
 import org.multipaz.nfc.ResponseApdu
@@ -10,6 +10,7 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlinx.coroutines.test.runTest
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
@@ -54,14 +55,14 @@ class NfcTransportTests {
     @Test
     fun testHappyPath() = runTest {
         val mdoc = NfcTransportMdoc(
-            role = MdocTransport.Role.MDOC,
+            role = MdocRole.MDOC,
             options = MdocTransportOptions(),
-            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+            connectionMethod = MdocConnectionMethodNfc(0xffff, 0x10000)
         )
         val mdocReader = NfcTransportMdocReader(
-            role = MdocTransport.Role.MDOC_READER,
+            role = MdocRole.MDOC_READER,
             options = MdocTransportOptions(),
-            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+            connectionMethod = MdocConnectionMethodNfc(0xffff, 0x10000)
         )
         val tag = LoopbackIsoTag(mdoc)
         mdocReader.setTag(tag)
@@ -115,14 +116,14 @@ ResponseApdu(status=36864, payload=ByteString(size=8989 hex=00000000000000000000
     @Test
     fun testLowTransceiveLength() = runTest {
         val mdoc = NfcTransportMdoc(
-            role = MdocTransport.Role.MDOC,
+            role = MdocRole.MDOC,
             options = MdocTransportOptions(),
-            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+            connectionMethod = MdocConnectionMethodNfc(0xffff, 0x10000)
         )
         val mdocReader = NfcTransportMdocReader(
-            role = MdocTransport.Role.MDOC_READER,
+            role = MdocRole.MDOC_READER,
             options = MdocTransportOptions(),
-            connectionMethod = ConnectionMethodNfc(0xffff, 0x10000)
+            connectionMethod = MdocConnectionMethodNfc(0xffff, 0x10000)
         )
         val tag = LoopbackIsoTag(mdoc)
         tag.maxTransceiveLength = 4096

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/MdocTransportFactory.ios.kt
@@ -1,16 +1,17 @@
 package org.multipaz.mdoc.transport
 
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
+import org.multipaz.mdoc.role.MdocRole
 
 internal actual fun defaultMdocTransportFactoryCreateTransport(
-    connectionMethod: ConnectionMethod,
-    role: MdocTransport.Role,
+    connectionMethod: MdocConnectionMethod,
+    role: MdocRole,
     options: MdocTransportOptions
 ): MdocTransport {
     when (connectionMethod) {
-        is ConnectionMethodBle -> {
+        is MdocConnectionMethodBle -> {
             if (connectionMethod.supportsCentralClientMode &&
                 connectionMethod.supportsPeripheralServerMode) {
                 throw IllegalArgumentException(
@@ -18,7 +19,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                 )
             } else if (connectionMethod.supportsCentralClientMode) {
                 return when (role) {
-                    MdocTransport.Role.MDOC -> {
+                    MdocRole.MDOC -> {
                         BleTransportCentralMdoc(
                             role,
                             options,
@@ -27,7 +28,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                             connectionMethod.peripheralServerModePsm
                         )
                     }
-                    MdocTransport.Role.MDOC_READER -> {
+                    MdocRole.MDOC_READER -> {
                         BleTransportCentralMdocReader(
                             role,
                             options,
@@ -38,7 +39,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                 }
             } else {
                 return when (role) {
-                    MdocTransport.Role.MDOC -> {
+                    MdocRole.MDOC -> {
                         BleTransportPeripheralMdoc(
                             role,
                             options,
@@ -46,7 +47,7 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                             connectionMethod.peripheralServerModeUuid!!
                         )
                     }
-                    MdocTransport.Role.MDOC_READER -> {
+                    MdocRole.MDOC_READER -> {
                         BleTransportPeripheralMdocReader(
                             role,
                             options,
@@ -58,10 +59,10 @@ internal actual fun defaultMdocTransportFactoryCreateTransport(
                 }
             }
         }
-        is ConnectionMethodNfc -> {
+        is MdocConnectionMethodNfc -> {
             return when (role) {
-                MdocTransport.Role.MDOC -> throw NotImplementedError("Not yet implemented")
-                MdocTransport.Role.MDOC_READER -> {
+                MdocRole.MDOC -> throw NotImplementedError("Not yet implemented")
+                MdocRole.MDOC_READER -> {
                     NfcTransportMdocReader(
                         role,
                         options,

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/mdoc/transport/TransportFactory.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/mdoc/transport/TransportFactory.jvm.kt
@@ -1,10 +1,11 @@
 package org.multipaz.mdoc.transport
 
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.role.MdocRole
 
 actual fun defaultMdocTransportFactoryCreateTransport(
-    connectionMethod: ConnectionMethod,
-    role: MdocTransport.Role,
+    connectionMethod: MdocConnectionMethod,
+    role: MdocRole,
     options: MdocTransportOptions
 ): MdocTransport {
     throw NotImplementedError("MdocTransportFactory is not available for JVM")

--- a/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
+++ b/samples/age-verifier-mdl/src/main/java/com/android/identity/age_verifier_mdl/TransferHelper.kt
@@ -11,14 +11,14 @@ import androidx.core.content.edit
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import com.android.identity.android.mdoc.deviceretrieval.VerificationHelper
-import com.android.identity.android.mdoc.transport.ConnectionMethodTcp
-import com.android.identity.android.mdoc.transport.ConnectionMethodUdp
+import com.android.identity.android.mdoc.transport.MdocConnectionMethodTcp
+import com.android.identity.android.mdoc.transport.MdocConnectionMethodUdp
 import com.android.identity.android.mdoc.transport.DataTransportOptions
 import org.multipaz.securearea.AndroidKeystoreSecureArea
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodWifiAware
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import org.multipaz.securearea.SecureAreaProvider
 import org.multipaz.storage.Storage
 import org.multipaz.storage.android.AndroidStorage
@@ -65,7 +65,7 @@ class TransferHelper private constructor(
     private var verificationHelper: VerificationHelper? = null
     var deviceResponseBytes: ByteArray? = null
     var error: Throwable? = null
-    private var connectionMethodUsed: ConnectionMethod? = null
+    private var connectionMethodUsed: MdocConnectionMethod? = null
 
     private var state = MutableLiveData<State>()
 
@@ -83,7 +83,7 @@ class TransferHelper private constructor(
             Logger.d(TAG, "onReaderEngagementReady")
         }
 
-        override fun onDeviceEngagementReceived(connectionMethods: List<ConnectionMethod>) {
+        override fun onDeviceEngagementReceived(connectionMethods: List<MdocConnectionMethod>) {
             Logger.d(TAG, "onDeviceEngagementReceived")
             connectionMethodUsed = connectionMethods.first()
             verificationHelper!!.connect(connectionMethods.first())
@@ -130,33 +130,33 @@ class TransferHelper private constructor(
             .build()
         builder.setDataTransportOptions(options)
 
-        val connectionMethods = mutableListOf<ConnectionMethod>()
+        val connectionMethods = mutableListOf<MdocConnectionMethod>()
         val bleUuid = UUID.randomUUID()
         if (getBleCentralClientDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodBle(
+            connectionMethods.add(MdocConnectionMethodBle(
                 false,
                 true,
                 null,
                 bleUuid))
         }
         if (getBlePeripheralServerDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodBle(
+            connectionMethods.add(MdocConnectionMethodBle(
                 true,
                 false,
                 bleUuid,
                 null))
         }
         if (getWifiAwareDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodWifiAware(null, null, null, null))
+            connectionMethods.add(MdocConnectionMethodWifiAware(null, null, null, null))
         }
         if (getNfcDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodNfc(4096, 32768))
+            connectionMethods.add(MdocConnectionMethodNfc(4096, 32768))
         }
         if (getTcpDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodTcp("", 0))
+            connectionMethods.add(MdocConnectionMethodTcp("", 0))
         }
         if (getUdpDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodUdp("", 0))
+            connectionMethods.add(MdocConnectionMethodUdp("", 0))
         }
         builder.setNegotiatedHandoverConnectionMethods(connectionMethods)
 

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/NfcEngagementHandler.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/NfcEngagementHandler.kt
@@ -25,15 +25,15 @@ import android.os.VibrationEffect
 import android.os.Vibrator
 import androidx.core.content.ContextCompat
 import com.android.identity.android.mdoc.engagement.NfcEngagementHelper
-import com.android.identity.android.mdoc.transport.ConnectionMethodTcp
-import com.android.identity.android.mdoc.transport.ConnectionMethodUdp
+import com.android.identity.android.mdoc.transport.MdocConnectionMethodTcp
+import com.android.identity.android.mdoc.transport.MdocConnectionMethodUdp
 import com.android.identity.android.mdoc.transport.DataTransport
 import com.android.identity.android.mdoc.transport.DataTransportOptions
 import org.multipaz.crypto.Crypto
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodWifiAware
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import org.multipaz.crypto.EcCurve
 import org.multipaz.util.Logger
 import org.multipaz.util.UUID
@@ -111,33 +111,33 @@ class NfcEngagementHandler : HostApduService() {
             .setBleUseL2CAP(transferHelper.getL2CapEnabled())
             .setExperimentalBleL2CAPPsmInEngagement(transferHelper.getExperimentalPsmEnabled())
             .build()
-        val connectionMethods = mutableListOf<ConnectionMethod>()
+        val connectionMethods = mutableListOf<MdocConnectionMethod>()
         val bleUuid = UUID.randomUUID()
         if (transferHelper.getBleCentralClientDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodBle(
+            connectionMethods.add(MdocConnectionMethodBle(
                 false,
                 true,
                 null,
                 bleUuid))
         }
         if (transferHelper.getBlePeripheralServerDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodBle(
+            connectionMethods.add(MdocConnectionMethodBle(
                 true,
                 false,
                 bleUuid,
                 null))
         }
         if (transferHelper.getWifiAwareDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodWifiAware(null, null, null, null))
+            connectionMethods.add(MdocConnectionMethodWifiAware(null, null, null, null))
         }
         if (transferHelper.getNfcDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodNfc(4096, 32768))
+            connectionMethods.add(MdocConnectionMethodNfc(4096, 32768))
         }
         if (transferHelper.getTcpDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodTcp("", 0))
+            connectionMethods.add(MdocConnectionMethodTcp("", 0))
         }
         if (transferHelper.getUdpDataTransferEnabled()) {
-            connectionMethods.add(ConnectionMethodUdp("", 0))
+            connectionMethods.add(MdocConnectionMethodUdp("", 0))
         }
         val builder = NfcEngagementHelper.Builder(
             applicationContext,
@@ -149,7 +149,7 @@ class NfcEngagementHandler : HostApduService() {
         if (transferHelper.getNfcNegotiatedHandoverEnabled()) {
             builder.useNegotiatedHandover()
         } else {
-            builder.useStaticHandover(ConnectionMethod.combine(connectionMethods))
+            builder.useStaticHandover(MdocConnectionMethod.combine(connectionMethods))
         }
         engagementHelper = builder.build()
     }

--- a/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
+++ b/samples/preconsent-mdl/src/main/java/com/android/identity/preconsent_mdl/TransferHelper.kt
@@ -30,7 +30,7 @@ import com.android.identity.android.mdoc.transport.DataTransport
 import org.multipaz.securearea.AndroidKeystoreSecureArea
 import org.multipaz.credential.CredentialLoader
 import org.multipaz.document.DocumentStore
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.response.DeviceResponseGenerator
 import org.multipaz.crypto.EcPrivateKey
 import org.multipaz.crypto.EcPublicKey
@@ -81,7 +81,7 @@ class TransferHelper private constructor(private val context: Context) {
     private var sharedPreferences: SharedPreferences
     private var storage: Storage
     private var deviceRetrievalHelper: DeviceRetrievalHelper? = null
-    private var connectionMethod: ConnectionMethod? = null
+    private var connectionMethod: MdocConnectionMethod? = null
     private var deviceRequest: ByteArray? = null
 
     private var timestampTap: Long = 0
@@ -310,7 +310,7 @@ class TransferHelper private constructor(private val context: Context) {
         state.value = State.RESPONSE_SENT
     }
 
-    fun getConnectionMethod(): ConnectionMethod {
+    fun getConnectionMethod(): MdocConnectionMethod {
         return connectionMethod!!
     }
 

--- a/samples/simple-verifier/src/main/java/com/android/identity/simple_verifier/MdocReaderPrompt.kt
+++ b/samples/simple-verifier/src/main/java/com/android/identity/simple_verifier/MdocReaderPrompt.kt
@@ -76,8 +76,8 @@ import androidx.navigation.compose.rememberNavController
 import com.android.identity.android.mdoc.deviceretrieval.VerificationHelper
 import com.android.identity.android.mdoc.transport.DataTransportOptions
 import org.multipaz.crypto.Algorithm
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.request.DeviceRequestGenerator
 import org.multipaz.mdoc.response.DeviceResponseParser
 import org.multipaz.util.Logger
@@ -92,7 +92,7 @@ import com.google.android.material.bottomsheet.BottomSheetBehavior
 import com.google.android.material.bottomsheet.BottomSheetDialog
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.multipaz.mdoc.transport.MdocTransport
+import org.multipaz.mdoc.role.MdocRole
 import java.security.Security
 
 class MdocReaderPrompt(
@@ -107,7 +107,7 @@ class MdocReaderPrompt(
     private lateinit var vibrator: Vibrator
     var readerEngagement: ByteArray? = null
     var responseBytes: ByteArray? = null
-    private var mdocConnectionMethod: ConnectionMethod? = null
+    private var mdocConnectionMethod: MdocConnectionMethod? = null
 
     private lateinit var responseListener: VerificationHelper.Listener
     private lateinit var verification: VerificationHelper
@@ -152,15 +152,15 @@ class MdocReaderPrompt(
                 this@MdocReaderPrompt.readerEngagement = readerEngagement
             }
 
-            override fun onDeviceEngagementReceived(connectionMethods: List<ConnectionMethod>) {
+            override fun onDeviceEngagementReceived(connectionMethods: List<MdocConnectionMethod>) {
                 // Need to disambiguate the connection methods here to get e.g. two ConnectionMethods
                 // if both BLE modes are available at the same time.
                 Logger.d("Listener", "device engagement received")
                 navController.navigate("ReaderReady/Connecting")
                 vibrator.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK))
-                val availableMdocConnectionMethods = ConnectionMethod.disambiguate(
+                val availableMdocConnectionMethods = MdocConnectionMethod.disambiguate(
                     connectionMethods,
-                    MdocTransport.Role.MDOC_READER
+                    MdocRole.MDOC_READER
                 )
                 if (availableMdocConnectionMethods.isNotEmpty()) {
                     this@MdocReaderPrompt.mdocConnectionMethod = availableMdocConnectionMethods.first()
@@ -211,10 +211,10 @@ class MdocReaderPrompt(
             }
         }
 
-        val connectionMethods = mutableListOf<ConnectionMethod>()
+        val connectionMethods = mutableListOf<MdocConnectionMethod>()
         val bleUuid = UUID.randomUUID()
         connectionMethods.add(
-            ConnectionMethodBle(
+            MdocConnectionMethodBle(
                 false,
                 true,
                 null,

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -73,7 +73,6 @@ kotlin {
                 implementation(libs.play.services.identity.credentials)
                 implementation(libs.androidx.credentials)
                 implementation(libs.androidx.credentials.registry.provider)
-                implementation(project(":multipaz-android-legacy"))
             }
         }
 

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/multidevicetests/MultiDeviceTestsClient.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/multidevicetests/MultiDeviceTestsClient.kt
@@ -2,10 +2,9 @@ package org.multipaz.testapp.multidevicetests
 
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.engagement.EngagementParser
 import org.multipaz.mdoc.sessionencryption.SessionEncryption
-import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.mdoc.transport.MdocTransportFactory
 import org.multipaz.mdoc.transport.MdocTransportOptions
 import org.multipaz.util.Constants
@@ -19,6 +18,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.withTimeout
 import kotlinx.datetime.Clock
+import org.multipaz.mdoc.role.MdocRole
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.DurationUnit
 
@@ -64,7 +64,7 @@ class MultiDeviceTestsClient(
                 val eDeviceKey = deviceEngagement.eSenderKey
                 val transport = MdocTransportFactory.Default.createTransport(
                     connectionMethod,
-                    MdocTransport.Role.MDOC_READER,
+                    MdocRole.MDOC_READER,
                     options
                 )
                 Logger.i(TAG, "usePrewarming: $usePrewarming")
@@ -72,7 +72,7 @@ class MultiDeviceTestsClient(
                     transport.advertise()
                 }
                 if (getPsmFromReader) {
-                    val cm = transport.connectionMethod as ConnectionMethodBle
+                    val cm = transport.connectionMethod as MdocConnectionMethodBle
                     sendChannel.writeStringUtf8("${cm.peripheralServerModePsm!!}\n")
                 }
                 val nextCmd = receiveChannel.readUTF8Line(LINE_LIMIT)
@@ -88,7 +88,7 @@ class MultiDeviceTestsClient(
                         val eReaderKey = Crypto.createEcPrivateKey(EcCurve.P256)
                         val encodedSessionTranscript = byteArrayOf(0x01, 0x02)
                         val sessionEncryption = SessionEncryption(
-                            role = SessionEncryption.Role.MDOC_READER,
+                            role = MdocRole.MDOC_READER,
                             eSelfKey = eReaderKey,
                             remotePublicKey = eDeviceKey,
                             encodedSessionTranscript = encodedSessionTranscript

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/IsoMdocProximitySharingScreen.kt
@@ -24,11 +24,10 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.Simple
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodNfc
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.mdoc.engagement.EngagementGenerator
-import org.multipaz.mdoc.transport.MdocTransport
 import org.multipaz.mdoc.transport.MdocTransportFactory
 import org.multipaz.mdoc.transport.MdocTransportOptions
 import org.multipaz.mdoc.transport.advertiseAndWait
@@ -42,6 +41,7 @@ import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.compose.permissions.rememberBluetoothPermissionState
 import org.multipaz.compose.qrcode.ShowQrCodeDialog
+import org.multipaz.mdoc.role.MdocRole
 
 private const val TAG = "IsoMdocProximitySharingScreen"
 
@@ -103,11 +103,11 @@ fun IsoMdocProximitySharingScreen(
                             presentmentModel.reset()
                             presentmentModel.setConnecting()
                             presentmentModel.presentmentScope.launch() {
-                                val connectionMethods = mutableListOf<ConnectionMethod>()
+                                val connectionMethods = mutableListOf<MdocConnectionMethod>()
                                 val bleUuid = UUID.randomUUID()
                                 if (settingsModel.presentmentBleCentralClientModeEnabled.value) {
                                     connectionMethods.add(
-                                        ConnectionMethodBle(
+                                        MdocConnectionMethodBle(
                                             supportsPeripheralServerMode = false,
                                             supportsCentralClientMode = true,
                                             peripheralServerModeUuid = null,
@@ -117,7 +117,7 @@ fun IsoMdocProximitySharingScreen(
                                 }
                                 if (settingsModel.presentmentBlePeripheralServerModeEnabled.value) {
                                     connectionMethods.add(
-                                        ConnectionMethodBle(
+                                        MdocConnectionMethodBle(
                                             supportsPeripheralServerMode = true,
                                             supportsCentralClientMode = false,
                                             peripheralServerModeUuid = bleUuid,
@@ -127,7 +127,7 @@ fun IsoMdocProximitySharingScreen(
                                 }
                                 if (settingsModel.presentmentNfcDataTransferEnabled.value) {
                                     connectionMethods.add(
-                                        ConnectionMethodNfc(
+                                        MdocConnectionMethodNfc(
                                             commandDataFieldMaxLength = 0xffff,
                                             responseDataFieldMaxLength = 0x10000
                                         )
@@ -168,7 +168,7 @@ fun IsoMdocProximitySharingScreen(
 }
 
 private suspend fun doHolderFlow(
-    connectionMethods: List<ConnectionMethod>,
+    connectionMethods: List<MdocConnectionMethod>,
     handover: DataItem,
     options: MdocTransportOptions,
     sessionEncryptionCurve: EcCurve,
@@ -181,7 +181,7 @@ private suspend fun doHolderFlow(
     val eDeviceKey = Crypto.createEcPrivateKey(sessionEncryptionCurve)
     lateinit var encodedDeviceEngagement: ByteString
     val transport = connectionMethods.advertiseAndWait(
-        role = MdocTransport.Role.MDOC,
+        role = MdocRole.MDOC,
         transportFactory = MdocTransportFactory.Default,
         options = options,
         eSenderKey = eDeviceKey.publicKey,

--- a/wallet/src/androidMain/kotlin/org/multipaz/wallet/ReaderModel.kt
+++ b/wallet/src/androidMain/kotlin/org/multipaz/wallet/ReaderModel.kt
@@ -16,7 +16,7 @@ import org.multipaz.crypto.javaX509Certificate
 import org.multipaz.documenttype.DocumentAttributeType
 import org.multipaz.documenttype.DocumentTypeRepository
 import org.multipaz.documenttype.DocumentCannedRequest
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.request.DeviceRequestGenerator
 import org.multipaz.mdoc.response.DeviceResponseParser
 import org.multipaz.trustmanagement.TrustManager
@@ -139,7 +139,7 @@ class ReaderModel(
             override fun onReaderEngagementReady(readerEngagement: ByteArray) {
             }
 
-            override fun onDeviceEngagementReceived(connectionMethods: List<ConnectionMethod>) {
+            override fun onDeviceEngagementReceived(connectionMethods: List<MdocConnectionMethod>) {
                 Logger.i(TAG, "onDeviceEngagementReceived")
                 vibrator.vibrate(VibrationEffect.createPredefined(VibrationEffect.EFFECT_HEAVY_CLICK))
                 if (connectionMethods.isEmpty()) {

--- a/wallet/src/androidMain/kotlin/org/multipaz/wallet/SettingsModel.kt
+++ b/wallet/src/androidMain/kotlin/org/multipaz/wallet/SettingsModel.kt
@@ -10,8 +10,8 @@ import androidx.core.content.edit
 import androidx.lifecycle.MutableLiveData
 import com.android.identity.android.mdoc.transport.DataTransportOptions
 import com.android.identity.android.util.AndroidLogPrinter
-import org.multipaz.mdoc.connectionmethod.ConnectionMethod
-import org.multipaz.mdoc.connectionmethod.ConnectionMethodBle
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.util.Logger
 import org.multipaz.mrtd.mrtdSetLogger
 import org.multipaz.util.UUID
@@ -210,17 +210,17 @@ class SettingsModel(
         return sharingIntent
     }
 
-    fun createConnectionMethodsAndOptions(): Pair<List<ConnectionMethod>, DataTransportOptions> {
-        val connectionMethods = mutableListOf<ConnectionMethod>()
+    fun createConnectionMethodsAndOptions(): Pair<List<MdocConnectionMethod>, DataTransportOptions> {
+        val connectionMethods = mutableListOf<MdocConnectionMethod>()
         if (bleCentralClientMode.value == true && blePeripheralServerMode.value == true) {
             val bleUuid = UUID.randomUUID()
-            connectionMethods.add(ConnectionMethodBle(true, true, bleUuid, bleUuid))
+            connectionMethods.add(MdocConnectionMethodBle(true, true, bleUuid, bleUuid))
         } else if (bleCentralClientMode.value == true) {
             val bleUuid = UUID.randomUUID()
-            connectionMethods.add(ConnectionMethodBle(false, true, null, bleUuid))
+            connectionMethods.add(MdocConnectionMethodBle(false, true, null, bleUuid))
         } else if (blePeripheralServerMode.value == true) {
             val bleUuid = UUID.randomUUID()
-            connectionMethods.add(ConnectionMethodBle(true, false, bleUuid, null))
+            connectionMethods.add(MdocConnectionMethodBle(true, false, bleUuid, null))
         }
 
         val optionsBuilder = DataTransportOptions.Builder()


### PR DESCRIPTION
This PR renames ConnectionMethod to MdocConnectionMethod including the same for all subclasses. Also use ByteString instead of ByteArray where needed and turn all concrete subclasses into data classes. Also move MdocConnectionMethodHttp to multipaz-android-legacy since we have no plans of supporting 18013-7 Annex A or Annex B in our non-legacy library stack.

Also introduce MdocRole and delete SessionEncryption.Role and MdocTransport.Role and use MdocRole instead.

Additionally, remove unneeded dependency on multipaz-android-legacy in samples/testapp.

Test: ./gradlew check && ./gradlew connectedCheck
Test: Manually tested W3C DC presentment and proximity presentment.
Test: Manually tested appverifier against samples/testapp.
