### PR TITLE
Move SecureArea implementations to use @CborSerializable

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/DataItem.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/DataItem.kt
@@ -6,8 +6,6 @@ import org.multipaz.cose.CoseLabel
 import org.multipaz.cose.CoseMac0
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
-import org.multipaz.securearea.KeyAttestation
-import org.multipaz.securearea.fromDataItem
 import kotlinx.datetime.Instant
 import kotlinx.datetime.LocalDate
 import kotlinx.io.bytestring.ByteStringBuilder

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/AndroidSecureAreaKeyMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/AndroidSecureAreaKeyMetadata.kt
@@ -1,0 +1,21 @@
+package org.multipaz.securearea
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.X509CertChain
+
+// TODO: move this class to Android source tree once annotation processors can work across
+// multiple source trees
+@CborSerializable(
+    schemaHash = "5Bb4RfySd7ew_Rcj-1I85PemAvq6Gb6OG3BroGFsrzs"
+)
+internal data class AndroidSecureAreaKeyMetadata(
+    val algorithm: Algorithm,
+    val attestKeyAlias: String?,
+    val userAuthenticationRequired: Boolean,
+    val userAuthenticationTimeoutMillis: Long,
+    val useStrongBox: Boolean,
+    val attestation: X509CertChain
+) {
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureEnclaveAreaKeyMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureEnclaveAreaKeyMetadata.kt
@@ -1,0 +1,21 @@
+package org.multipaz.securearea
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.EcPublicKey
+
+// TODO: move this class to iOS source tree once annotation processors can work across
+// multiple source trees
+@CborSerializable(
+    schemaHash = "K4-CiPFYjFPIWUDCMmWqVxjHY7eB4LDbg4f1MKHUpwk"
+)
+internal data class SecureEnclaveAreaKeyMetadata(
+    val algorithm: Algorithm,
+    val userAuthenticationRequired: Boolean,
+    val userAuthenticationTypes: Long,
+    val publicKey: EcPublicKey,
+    val keyBlob: ByteString
+) {
+    companion object
+}


### PR DESCRIPTION
Change various SecureArea implementations so that data structures that we put in Storage are serialized using `@CborSerializable` data classes with schemaHash specified. This will help us to be conscious about compatibility going forward.

Actual serialized data in the storage should still be the same (although this was not extensively tested) with the exception of keys in `SoftwareSecureArea` that did not have passphrase (removed duplication storing both `publicKey` and `encodedPublicKey`).

Testing: unit tests and testing using TestApp
