### PR TITLE
Publishing rules for multipaz-cbor-rpc.

### DIFF
--- a/multipaz-cbor-rpc/build.gradle.kts
+++ b/multipaz-cbor-rpc/build.gradle.kts
@@ -14,6 +14,7 @@ kotlin {
 java {
     sourceCompatibility = JavaVersion.VERSION_17
     targetCompatibility = JavaVersion.VERSION_17
+    withSourcesJar()
 }
 
 dependencies {
@@ -30,6 +31,13 @@ publishing {
     repositories {
         maven {
             url = uri("${rootProject.rootDir}/repo")
+        }
+    }
+    publications {
+        create<MavenPublication>("library") {
+            afterEvaluate {
+                from(components["java"])
+            }
         }
     }
     publications.withType(MavenPublication::class) {


### PR DESCRIPTION
Test: tried `@CborSerializable` in `MpzSecureAreaSample` app and it does generate serialization code. 