### PR TITLE
Inject Ktor engine to Multipaz library

### DIFF
--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -83,7 +83,6 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.core)
                 implementation(libs.kotlinx.serialization.json)
                 implementation(libs.ktor.client.core)
-                implementation(libs.ktor.client.cio)
 
                 // TODO: remove when JsonWebEncryption is implemented fully in Kotlin
                 implementation(libs.nimbus.oauth2.oidc.sdk)
@@ -169,6 +168,7 @@ kotlin {
                 implementation(libs.androidx.test.junit)
                 implementation(libs.androidx.espresso.core)
                 implementation(libs.kotlinx.coroutines.android)
+                implementation(libs.ktor.client.mock)
                 implementation(project(":multipaz-csa"))
             }
         }

--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/cloud/CloudSecureAreaTest.kt
@@ -2,6 +2,10 @@ package org.multipaz.securearea.cloud
 
 import android.content.pm.PackageManager
 import androidx.test.platform.app.InstrumentationRegistry
+import io.ktor.client.engine.HttpClientEngine
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.MockEngineConfig
 import org.multipaz.securearea.AndroidKeystoreSecureArea
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.asn1.OID
@@ -52,10 +56,16 @@ class CloudSecureAreaTest {
 
     var serverTime = Instant.fromEpochMilliseconds(0)
 
+    val mockEngineFactory =  object : HttpClientEngineFactory<MockEngineConfig> {
+        override fun create(block: MockEngineConfig.() -> Unit): HttpClientEngine = MockEngine {
+            error("Mock engine should not receive any requests")
+        }
+    }
+
     internal inner class LoopbackCloudSecureArea(
         storageTable: StorageTable,
         private val packageToAllow: String?,
-    ) : CloudSecureArea(storageTable, "CloudSecureArea", "uri-not-used") {
+    ) : CloudSecureArea(storageTable, "CloudSecureArea", "uri-not-used", mockEngineFactory) {
         val context = applicationContext
         private lateinit var server: CloudSecureAreaServer
 

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
@@ -28,6 +28,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.android.identity.testapp.ui.AppTheme
 import com.android.identity.testapp.ui.CameraScreen
+import io.ktor.client.engine.cio.CIO
 import org.multipaz.models.digitalcredentials.DigitalCredentials
 import org.multipaz.models.presentment.PresentmentModel
 import org.multipaz.asn1.ASN1Integer
@@ -187,7 +188,8 @@ class App private constructor(val promptModel: PromptModel) {
                 CloudSecureArea.create(
                     platformStorage(),
                     identifier,
-                    cloudSecureAreaUrl
+                    cloudSecureAreaUrl,
+                    CIO
                 )
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
@@ -38,6 +38,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
+import io.ktor.client.engine.cio.CIO
 import org.multipaz.cbor.Cbor
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -101,7 +102,8 @@ fun CloudSecureAreaScreen(
                     cloudSecureArea = CloudSecureArea.create(
                         EphemeralStorage(),
                         "CloudSecureArea",
-                        url
+                        url,
+                        CIO
                     )
                     try {
                         cloudSecureArea!!.register(

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
+import io.ktor.client.engine.cio.CIO
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -105,7 +106,8 @@ fun DocumentStoreScreen(
                     val cloudSecureArea = CloudSecureArea.create(
                         platformStorage(),
                         "CloudSecureArea?url=${url.encodeURLParameter()}",
-                        url
+                        url,
+                        CIO
                     )
                     try {
                         cloudSecureArea.register(

--- a/wallet/src/main/java/org/multipaz/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/org/multipaz/wallet/WalletApplication.kt
@@ -28,6 +28,7 @@ import androidx.work.PeriodicWorkRequestBuilder
 import androidx.work.WorkManager
 import androidx.work.Worker
 import androidx.work.WorkerParameters
+import io.ktor.client.engine.android.Android
 import org.multipaz.android.direct_access.DirectAccess
 import org.multipaz.android.direct_access.DirectAccessCredential
 import org.multipaz.context.initializeApplication
@@ -195,7 +196,8 @@ class WalletApplication : Application() {
                 CloudSecureArea.create(
                     storage,
                     identifier,
-                    cloudSecureAreaUrl
+                    cloudSecureAreaUrl,
+                    Android
                 )
             }
         }


### PR DESCRIPTION
Instead of using explicit CIO engine in `:multipaz`, inject the `HttpClientEngineFactory` into `CloudSecureArea` and remove the `io.ktor:ktor-client-cio` dependency from the module. This prevents interop issues with projects that already have another engine configured.

In `:samples:testapp`, provide `CIO` as the `HttpClientEngineFactory`, and in `:wallet`, use `Android` engine (as it's already used there).

"Use" `MockEngine` in `CloudSecureAreaTest`; The engine is provided by the factory, as the `HttpClient` object is created, but as it's not being used, it will throw an error should it receive a request.

Test: ./gradlew check && ./gradlew connectedCheck
Test: Manually smoke tested the build, but haven't tested the parts that use the `HttpClient`!

Fixes #941 