### PR TITLE
Prevent R8 from removing BouncyCastle components

### DIFF
--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -209,6 +209,7 @@ android {
     defaultConfig {
         minSdk = 26
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+        consumerProguardFiles("consumer-rules.pro")
     }
 
     compileOptions {

--- a/multipaz/consumer-rules.pro
+++ b/multipaz/consumer-rules.pro
@@ -1,0 +1,5 @@
+# Prevent BouncyCastle BC provider and EC algorithm from being stripped out
+-keep class org.bouncycastle.jcajce.provider.keystore.BC$Mappings { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings { *; }
+-keep class org.bouncycastle.jcajce.provider.keystore.bc.* { *; }
+-keep class org.bouncycastle.jcajce.provider.asymmetric.ec.* { *; }


### PR DESCRIPTION
Due to the nature of how BouncyCastle is being used as a Java security provider, R8 strips the BC provider and EC algorithm in the release build because it looks like they're not being used in the project.

Add the necessary ProGuard consumer rules to Multipaz to keep them from being removed.

Test: Release builds of both `:wallet` and `:samples:testapp` now run properly.

Fixes #942.