### PR TITLE
Allow MdocTransport.waitForMessage() cancellation

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
@@ -133,6 +134,8 @@ internal class BleTransportCentralMdoc(
         }
         try {
             return centralManager.incomingMessages.receive()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
@@ -145,6 +146,8 @@ internal class BleTransportCentralMdocReader(
         }
         try {
             return peripheralManager.incomingMessages.receive()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
@@ -145,6 +146,8 @@ internal class BleTransportPeripheralMdoc(
         }
         try {
             return peripheralManager.incomingMessages.receive()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
@@ -131,6 +132,8 @@ internal class BleTransportPeripheralMdocReader(
         }
         try {
             return centralManager.incomingMessages.receive()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.nfc.CommandApdu
@@ -216,6 +217,8 @@ class NfcTransportMdocReader(
         }
         try {
             return incomingMessages.receive().toByteArray()
+        } catch (error: CancellationException) {
+            throw error
         } catch (error: Throwable) {
             if (_state.value == State.CLOSED) {
                 throw MdocTransportClosedException("Transport was closed while waiting for message")


### PR DESCRIPTION
Allow `CancellationException` to pass through instead of treating it as an error while `MdocTransport.waitForMessage()` execution is being suspended, waiting for the incoming message channel to send new values. This prevents the transport from being erroneously marked as failed, as the cancellation doesn't have any side effects in the presentation session itself.

Test: ./gradlew check && ./gradlew connectedCheck
Test: Manually tested testapp proximity sharing

Fixes #949