### PR TITLE
testapp: Use platform-specific HttpClientEngineFactory.

### DIFF
--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/PlatformAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/PlatformAndroid.kt
@@ -1,6 +1,8 @@
 package org.multipaz.testapp
 
 import android.os.Build
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.android.Android
 import org.multipaz.crypto.EcCurve
 import org.multipaz.context.applicationContext
 import org.multipaz.securearea.AndroidKeystoreCreateKeySettings
@@ -79,6 +81,8 @@ private val androidStorage: AndroidStorage by lazy {
 actual fun platformStorage(): Storage {
     return androidStorage
 }
+
+actual fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*> = Android
 
 private val androidKeystoreSecureAreaProvider = SecureAreaProvider {
     AndroidKeystoreSecureArea.create(androidStorage)

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
@@ -28,7 +28,6 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
 import com.android.identity.testapp.ui.AppTheme
 import com.android.identity.testapp.ui.CameraScreen
-import io.ktor.client.engine.cio.CIO
 import org.multipaz.models.digitalcredentials.DigitalCredentials
 import org.multipaz.models.presentment.PresentmentModel
 import org.multipaz.asn1.ASN1Integer
@@ -189,7 +188,7 @@ class App private constructor(val promptModel: PromptModel) {
                     platformStorage(),
                     identifier,
                     cloudSecureAreaUrl,
-                    CIO
+                    platformHttpClientEngineFactory()
                 )
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
@@ -1,6 +1,7 @@
 package org.multipaz.testapp
 
 import androidx.compose.ui.graphics.painter.Painter
+import io.ktor.client.engine.HttpClientEngineFactory
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.SecureArea
 import org.multipaz.securearea.SecureAreaProvider
@@ -28,6 +29,8 @@ expect fun getLocalIpAddress(): String
 expect val platformIsEmulator: Boolean
 
 expect fun platformStorage(): Storage
+
+expect fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*>
 
 /**
  * Gets a provider for the preferred [SecureArea] implementation for the platform.

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/CloudSecureAreaScreen.kt
@@ -38,7 +38,6 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.Dialog
-import io.ktor.client.engine.cio.CIO
 import org.multipaz.cbor.Cbor
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -59,6 +58,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.io.bytestring.encodeToByteString
 import org.multipaz.crypto.Algorithm
+import org.multipaz.testapp.platformHttpClientEngineFactory
 import kotlin.time.Duration.Companion.days
 
 private val TAG = "CloudSecureAreaScreen"
@@ -103,7 +103,7 @@ fun CloudSecureAreaScreen(
                         EphemeralStorage(),
                         "CloudSecureArea",
                         url,
-                        CIO
+                        platformHttpClientEngineFactory()
                     )
                     try {
                         cloudSecureArea!!.register(

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
@@ -22,7 +22,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import io.ktor.client.engine.cio.CIO
 import org.multipaz.asn1.ASN1Integer
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -55,6 +54,7 @@ import kotlinx.datetime.TimeZone
 import kotlinx.datetime.atStartOfDayIn
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.crypto.Algorithm
+import org.multipaz.testapp.platformHttpClientEngineFactory
 
 private const val TAG = "DocumentStoreScreen"
 
@@ -107,7 +107,7 @@ fun DocumentStoreScreen(
                         platformStorage(),
                         "CloudSecureArea?url=${url.encodeURLParameter()}",
                         url,
-                        CIO
+                        platformHttpClientEngineFactory()
                     )
                     try {
                         cloudSecureArea.register(

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
@@ -2,6 +2,9 @@ package org.multipaz.testapp
 
 import androidx.sqlite.SQLiteConnection
 import androidx.sqlite.driver.NativeSQLiteDriver
+import io.ktor.client.engine.HttpClientEngineFactory
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.engine.darwin.Darwin
 import org.multipaz.crypto.EcCurve
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.PassphraseConstraints
@@ -132,6 +135,8 @@ private val secureEnclaveSecureAreaProvider = SecureAreaProvider {
 actual fun platformStorage(): Storage {
     return iosStorage
 }
+
+actual fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*> = Darwin
 
 actual fun platformSecureAreaProvider(): SecureAreaProvider<SecureArea> {
     return secureEnclaveSecureAreaProvider


### PR DESCRIPTION
CIO doesn't support TLS for native so use Darwin on iOS.

Test: Manually tested, CloudSecureArea works on iOS again.
