### PR TITLE
Avoid mapping CancellationException in MdocTransports

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdoc.kt
@@ -1,16 +1,10 @@
 package org.multipaz.mdoc.transport
 
+import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
-import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
-import org.multipaz.util.Logger
-import org.multipaz.util.UUID
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -20,7 +14,12 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.util.Logger
+import org.multipaz.util.UUID
 import kotlin.time.Duration
 
 internal class BleTransportCentralMdoc(
@@ -58,7 +57,7 @@ internal class BleTransportCentralMdoc(
         centralManager.setCallbacks(
             onError = { error ->
                 runBlocking {
-                    currentJob?.cancel("onError was called")
+                    currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
                     }
@@ -82,46 +81,45 @@ internal class BleTransportCentralMdoc(
     override val scanningTime: Duration?
         get() = _scanningTime
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun open(eSenderKey: EcPublicKey) {
         var timeScanningStarted: Instant
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    _state.value = State.SCANNING
-                    centralManager.waitForPowerOn()
-                    timeScanningStarted = Clock.System.now()
-                    centralManager.waitForPeripheralWithUuid(uuid)
-                    _scanningTime = Clock.System.now() - timeScanningStarted
-                    _state.value = State.CONNECTING
-                    if (psm != null) {
-                        // If the PSM is known at engagement-time we can bypass the entire GATT server
-                        // and just connect directly.
-                        Logger.i(TAG, "Connecting directly to PSM $psm")
-                        centralManager.connectL2cap(psm)
-                    } else {
-                        centralManager.connectToPeripheral()
-                        centralManager.requestMtu()
-                        centralManager.peripheralDiscoverServices(uuid)
-                        centralManager.peripheralDiscoverCharacteristics()
-                        centralManager.checkReaderIdentMatches(eSenderKey)
-                        if (centralManager.l2capPsm != null) {
-                            centralManager.connectL2cap(centralManager.l2capPsm!!)
+                coroutineScope {
+                    currentJob = launch {
+                        _state.value = State.SCANNING
+                        centralManager.waitForPowerOn()
+                        timeScanningStarted = Clock.System.now()
+                        centralManager.waitForPeripheralWithUuid(uuid)
+                        _scanningTime = Clock.System.now() - timeScanningStarted
+                        _state.value = State.CONNECTING
+                        if (psm != null) {
+                            // If the PSM is known at engagement-time we can bypass the entire GATT server
+                            // and just connect directly.
+                            Logger.i(TAG, "Connecting directly to PSM $psm")
+                            centralManager.connectL2cap(psm)
                         } else {
-                            centralManager.subscribeToCharacteristics()
-                            centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
+                            centralManager.connectToPeripheral()
+                            centralManager.requestMtu()
+                            centralManager.peripheralDiscoverServices(uuid)
+                            centralManager.peripheralDiscoverCharacteristics()
+                            centralManager.checkReaderIdentMatches(eSenderKey)
+                            if (centralManager.l2capPsm != null) {
+                                centralManager.connectL2cap(centralManager.l2capPsm!!)
+                            } else {
+                                centralManager.subscribeToCharacteristics()
+                                centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
+                            }
                         }
+                        _state.value = State.CONNECTED
                     }
-                    _state.value = State.CONNECTED
-                }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
                 }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while opening transport", error)
+                error.unwrapCancellationException().let {
+                    failTransport(it)
+                    throw it.wrapUnlessCancellationException("Failed while opening transport")
+                }
             } finally {
                 currentJob = null
             }
@@ -148,7 +146,6 @@ internal class BleTransportCentralMdoc(
         }
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun sendMessage(message: ByteArray) {
         mutex.withLock {
             check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
@@ -156,20 +153,20 @@ internal class BleTransportCentralMdoc(
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    if (message.isEmpty()) {
-                        centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                    } else {
-                        centralManager.sendMessage(message)
+                coroutineScope {
+                    currentJob = launch {
+                        if (message.isEmpty()) {
+                            centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                        } else {
+                            centralManager.sendMessage(message)
+                        }
                     }
                 }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw MdocTransportException(currentJob!!.getCancellationException())
-                }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while sending message", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while sending message")
+                }
             } finally {
                 currentJob = null
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportCentralMdocReader.kt
@@ -1,16 +1,10 @@
 package org.multipaz.mdoc.transport
 
+import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
-import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
-import org.multipaz.util.Logger
-import org.multipaz.util.UUID
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,7 +12,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.util.Logger
+import org.multipaz.util.UUID
 import kotlin.time.Duration
 
 internal class BleTransportCentralMdocReader(
@@ -64,7 +63,7 @@ internal class BleTransportCentralMdocReader(
         peripheralManager.setCallbacks(
             onError = { error ->
                 runBlocking {
-                    currentJob?.cancel("onError was called")
+                    currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
                     }
@@ -80,23 +79,22 @@ internal class BleTransportCentralMdocReader(
         )
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun advertise() {
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    peripheralManager.waitForPowerOn()
-                    peripheralManager.advertiseService(uuid)
-                    _state.value = State.ADVERTISING
-                }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
+                coroutineScope {
+                    currentJob = launch {
+                        peripheralManager.waitForPowerOn()
+                        peripheralManager.advertiseService(uuid)
+                        _state.value = State.ADVERTISING
+                    }
                 }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while advertising", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while advertising")
+                }
             } finally {
                 currentJob = null
             }
@@ -106,34 +104,33 @@ internal class BleTransportCentralMdocReader(
     override val scanningTime: Duration?
         get() = null
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun open(eSenderKey: EcPublicKey) {
         mutex.withLock {
             check(_state.value == State.IDLE || _state.value == State.ADVERTISING) {
                 "Expected state IDLE or ADVERTISING, got ${_state.value}"
             }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    if (_state.value != State.ADVERTISING) {
-                        // Start advertising if we aren't already...
-                        _state.value = State.ADVERTISING
-                        peripheralManager.waitForPowerOn()
-                        peripheralManager.advertiseService(uuid)
+                coroutineScope {
+                    currentJob = launch {
+                        if (_state.value != State.ADVERTISING) {
+                            // Start advertising if we aren't already...
+                            _state.value = State.ADVERTISING
+                            peripheralManager.waitForPowerOn()
+                            peripheralManager.advertiseService(uuid)
+                        }
+                        peripheralManager.setESenderKey(eSenderKey)
+                        // Note: It's not really possible to know someone is connecting to use until they're _actually_
+                        // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
+                        // to go into State.CONNECTING...
+                        peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
+                        _state.value = State.CONNECTED
                     }
-                    peripheralManager.setESenderKey(eSenderKey)
-                    // Note: It's not really possible to know someone is connecting to use until they're _actually_
-                    // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
-                    // to go into State.CONNECTING...
-                    peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
-                    _state.value = State.CONNECTED
-                }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
                 }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while opening transport", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while opening transport")
+                }
             } finally {
                 currentJob = null
             }
@@ -160,7 +157,6 @@ internal class BleTransportCentralMdocReader(
         }
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun sendMessage(message: ByteArray) {
         mutex.withLock {
             check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
@@ -168,20 +164,20 @@ internal class BleTransportCentralMdocReader(
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    if (message.isEmpty()) {
-                        peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                    } else {
-                        peripheralManager.sendMessage(message)
+                coroutineScope {
+                    currentJob = launch {
+                        if (message.isEmpty()) {
+                            peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                        } else {
+                            peripheralManager.sendMessage(message)
+                        }
                     }
                 }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
-                }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while sending message", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while sending message")
+                }
             } finally {
                 currentJob = null
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdoc.kt
@@ -1,16 +1,10 @@
 package org.multipaz.mdoc.transport
 
+import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
-import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
-import org.multipaz.util.Logger
-import org.multipaz.util.UUID
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -18,7 +12,12 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.util.Logger
+import org.multipaz.util.UUID
 import kotlin.time.Duration
 
 internal class BleTransportPeripheralMdoc(
@@ -64,6 +63,7 @@ internal class BleTransportPeripheralMdoc(
         peripheralManager.setCallbacks(
             onError = { error ->
                 runBlocking {
+                    currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
                     }
@@ -80,23 +80,22 @@ internal class BleTransportPeripheralMdoc(
         )
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun advertise() {
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    peripheralManager.waitForPowerOn()
-                    peripheralManager.advertiseService(uuid)
-                    _state.value = State.ADVERTISING
-                }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
+                coroutineScope {
+                    currentJob = launch {
+                        peripheralManager.waitForPowerOn()
+                        peripheralManager.advertiseService(uuid)
+                        _state.value = State.ADVERTISING
+                    }
                 }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while advertising", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while advertising")
+                }
             } finally {
                 currentJob = null
             }
@@ -106,34 +105,33 @@ internal class BleTransportPeripheralMdoc(
     override val scanningTime: Duration?
         get() = null
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun open(eSenderKey: EcPublicKey) {
         mutex.withLock {
             check(_state.value == State.IDLE || _state.value == State.ADVERTISING) {
                 "Expected state IDLE or ADVERTISING, got ${_state.value}"
             }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    if (_state.value != State.ADVERTISING) {
-                        // Start advertising if we aren't already...
-                        _state.value = State.ADVERTISING
-                        peripheralManager.waitForPowerOn()
-                        peripheralManager.advertiseService(uuid)
+                coroutineScope {
+                    currentJob = launch {
+                        if (_state.value != State.ADVERTISING) {
+                            // Start advertising if we aren't already...
+                            _state.value = State.ADVERTISING
+                            peripheralManager.waitForPowerOn()
+                            peripheralManager.advertiseService(uuid)
+                        }
+                        peripheralManager.setESenderKey(eSenderKey)
+                        // Note: It's not really possible to know someone is connecting to us until they're _actually_
+                        // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
+                        // to go into State.CONNECTING...
+                        peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
+                        _state.value = State.CONNECTED
                     }
-                    peripheralManager.setESenderKey(eSenderKey)
-                    // Note: It's not really possible to know someone is connecting to us until they're _actually_
-                    // connected. I mean, for all we know, someone could be BLE scanning us. So not really possible
-                    // to go into State.CONNECTING...
-                    peripheralManager.waitForStateCharacteristicWriteOrL2CAPClient()
-                    _state.value = State.CONNECTED
-                }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
                 }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while opening transport", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while opening transport")
+                }
             } finally {
                 currentJob = null
             }
@@ -160,7 +158,6 @@ internal class BleTransportPeripheralMdoc(
         }
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun sendMessage(message: ByteArray) {
         mutex.withLock {
             check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
@@ -168,20 +165,20 @@ internal class BleTransportPeripheralMdoc(
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    if (message.isEmpty()) {
-                        peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                    } else {
-                        peripheralManager.sendMessage(message)
+                coroutineScope {
+                    currentJob = launch {
+                        if (message.isEmpty()) {
+                            peripheralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                        } else {
+                            peripheralManager.sendMessage(message)
+                        }
                     }
                 }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
-                }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while sending message", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while sending message")
+                }
             } finally {
                 currentJob = null
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/BleTransportPeripheralMdocReader.kt
@@ -1,16 +1,10 @@
 package org.multipaz.mdoc.transport
 
+import io.ktor.client.utils.unwrapCancellationException
 import kotlinx.coroutines.CancellationException
-import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
-import org.multipaz.util.Logger
-import org.multipaz.util.UUID
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.InternalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancel
-import kotlinx.coroutines.currentCoroutineContext
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -19,7 +13,12 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodBle
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.util.Logger
+import org.multipaz.util.UUID
 import kotlin.time.Duration
 
 internal class BleTransportPeripheralMdocReader(
@@ -57,6 +56,7 @@ internal class BleTransportPeripheralMdocReader(
         centralManager.setCallbacks(
             onError = { error ->
                 runBlocking {
+                    currentJob?.cancel("onError was called", error)
                     mutex.withLock {
                         failTransport(error)
                     }
@@ -81,45 +81,44 @@ internal class BleTransportPeripheralMdocReader(
     override val scanningTime: Duration?
         get() = _scanningTime
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun open(eSenderKey: EcPublicKey) {
         mutex.withLock {
             check(_state.value == State.IDLE) { "Expected state IDLE, got ${_state.value}" }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    _state.value = State.SCANNING
-                    centralManager.waitForPowerOn()
-                    val timeScanningStarted = Clock.System.now()
-                    centralManager.waitForPeripheralWithUuid(uuid)
-                    _scanningTime = Clock.System.now() - timeScanningStarted
-                    _state.value = State.CONNECTING
-                    if (psm != null) {
-                        // If the PSM is known at engagement-time we can bypass the entire GATT server
-                        // and just connect directly.
-                        centralManager.connectL2cap(psm)
-                    } else {
-                        centralManager.connectToPeripheral()
-                        centralManager.requestMtu()
-                        centralManager.peripheralDiscoverServices(uuid)
-                        centralManager.peripheralDiscoverCharacteristics()
-                        // NOTE: ident characteristic isn't used when the mdoc is the GATT server so we don't call
-                        // centralManager.checkReaderIdentMatches(eSenderKey)
-                        if (centralManager.l2capPsm != null) {
-                            centralManager.connectL2cap(centralManager.l2capPsm!!)
+                coroutineScope {
+                    currentJob = launch {
+                        _state.value = State.SCANNING
+                        centralManager.waitForPowerOn()
+                        val timeScanningStarted = Clock.System.now()
+                        centralManager.waitForPeripheralWithUuid(uuid)
+                        _scanningTime = Clock.System.now() - timeScanningStarted
+                        _state.value = State.CONNECTING
+                        if (psm != null) {
+                            // If the PSM is known at engagement-time we can bypass the entire GATT server
+                            // and just connect directly.
+                            centralManager.connectL2cap(psm)
                         } else {
-                            centralManager.subscribeToCharacteristics()
-                            centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
+                            centralManager.connectToPeripheral()
+                            centralManager.requestMtu()
+                            centralManager.peripheralDiscoverServices(uuid)
+                            centralManager.peripheralDiscoverCharacteristics()
+                            // NOTE: ident characteristic isn't used when the mdoc is the GATT server so we don't call
+                            // centralManager.checkReaderIdentMatches(eSenderKey)
+                            if (centralManager.l2capPsm != null) {
+                                centralManager.connectL2cap(centralManager.l2capPsm!!)
+                            } else {
+                                centralManager.subscribeToCharacteristics()
+                                centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_START)
+                            }
                         }
+                        _state.value = State.CONNECTED
                     }
-                    _state.value = State.CONNECTED
-                }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
                 }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while opening transport", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while opening transport")
+                }
             } finally {
                 currentJob = null
             }
@@ -139,14 +138,13 @@ internal class BleTransportPeripheralMdocReader(
                 throw MdocTransportClosedException("Transport was closed while waiting for message")
             } else {
                 mutex.withLock {
-                failTransport(error)
-                    }
+                    failTransport(error)
+                }
                 throw MdocTransportException("Failed while waiting for message", error)
             }
         }
     }
 
-    @OptIn(InternalCoroutinesApi::class)
     override suspend fun sendMessage(message: ByteArray) {
         mutex.withLock {
             check(_state.value == State.CONNECTED) { "Expected state CONNECTED, got ${_state.value}" }
@@ -154,20 +152,20 @@ internal class BleTransportPeripheralMdocReader(
                 throw MdocTransportTerminationException("Transport-specific termination not available with L2CAP")
             }
             try {
-                currentJob = CoroutineScope(currentCoroutineContext()).launch {
-                    if (message.isEmpty()) {
-                        centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
-                    } else {
-                        centralManager.sendMessage(message)
+                coroutineScope {
+                    currentJob = launch {
+                        if (message.isEmpty()) {
+                            centralManager.writeToStateCharacteristic(BleTransportConstants.STATE_CHARACTERISTIC_END)
+                        } else {
+                            centralManager.sendMessage(message)
+                        }
                     }
                 }
-                currentJob!!.join()
-                if (currentJob!!.isCancelled) {
-                    throw currentJob!!.getCancellationException()
-                }
             } catch (error: Throwable) {
-                failTransport(error)
-                throw MdocTransportException("Failed while sending message", error)
+                throw error.unwrapCancellationException().let {
+                    failTransport(it)
+                    it.wrapUnlessCancellationException("Failed while sending message")
+                }
             } finally {
                 currentJob = null
             }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransport.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/MdocTransport.kt
@@ -1,5 +1,6 @@
 package org.multipaz.mdoc.transport
 
+import kotlinx.coroutines.CancellationException
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.mdoc.connectionmethod.MdocConnectionMethod
 import kotlinx.coroutines.flow.StateFlow
@@ -139,4 +140,11 @@ abstract class MdocTransport {
      * This is idempotent and can be called from any thread.
      */
     abstract suspend fun close()
+
+    /**
+     * Wraps this [Throwable] as an [MdocTransportException] unless it's a [CancellationException].
+     */
+    protected fun Throwable.wrapUnlessCancellationException(message: String): Throwable =
+        if (this is CancellationException) this
+        else MdocTransportException(message, this)
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/transport/NfcTransportMdocReader.kt
@@ -1,14 +1,6 @@
 package org.multipaz.mdoc.transport
 
 import kotlinx.coroutines.CancellationException
-import org.multipaz.crypto.EcPublicKey
-import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
-import org.multipaz.nfc.CommandApdu
-import org.multipaz.nfc.Nfc
-import org.multipaz.nfc.NfcCommandFailedException
-import org.multipaz.nfc.NfcIsoTag
-import org.multipaz.nfc.ResponseApdu
-import org.multipaz.util.Logger
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
@@ -23,8 +15,16 @@ import kotlinx.io.bytestring.ByteString
 import kotlinx.io.bytestring.ByteStringBuilder
 import kotlinx.io.bytestring.append
 import kotlinx.io.bytestring.buildByteString
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodNfc
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.nfc.CommandApdu
+import org.multipaz.nfc.Nfc
+import org.multipaz.nfc.NfcCommandFailedException
+import org.multipaz.nfc.NfcIsoTag
+import org.multipaz.nfc.ResponseApdu
 import org.multipaz.util.ByteDataReader
+import org.multipaz.util.Logger
 import org.multipaz.util.appendByteString
 import org.multipaz.util.appendUInt16
 import org.multipaz.util.appendUInt8
@@ -84,7 +84,7 @@ class NfcTransportMdocReader(
                 _state.value = State.CONNECTED
             } catch (error: Throwable) {
                 failTransport(error)
-                throw MdocTransportException("Failed while opening transport", error)
+                throw error.wrapUnlessCancellationException("Failed while opening transport")
             }
         }
 


### PR DESCRIPTION
Add new protected `Throwable.wrapUnlessCancellationException()` extension method to `MdocTransport` that can be used to map exceptions to `MdocTransportExceptions` with a supplied message, unless it's a `CancellationException`, and replace the existing `MdocTransport` logic to use it instead of blindly mapping every exception.

But, to avoid swallowing the BLE stack errors reported by the `onError()` callback, use the Ktor `unwrapCancellationException()` helper to find them (and wrap them).

Replace `CoroutineScope(currentCoroutineContext())` with `coroutineScope` to avoid the `onJoin()` dance and remove the coroutines-internal `getCancellationException()` call. The cancellation exception will be thrown anyway because `coroutineScope` is suspended while the launched job is running.

Test: ./gradlew check connectedCheck
Test: Manually tested the local library build against our implementation
Test: Not tested with Multipaz apps on real devices, though!