### PR TITLE
Add guidance and runtime check for Digital Credentials API flag

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -51,6 +51,8 @@ possible approaches to do this. One of the simpler ones, if you're planning on r
 1. Forward the test device's port 8080 to the dev machine's port 8080: `adb reverse tcp:8080 tcp:8080`
 1. Start the server: `./gradlew server:tomcatRun`
 1. For verification (sharing a document), on the test device, navigate to: `http://localhost:8080/server/verifier.html`
+1. Enable support for Web Identity Digital Credentials: In your Chrome browser, go to `chrome://flags#web-identity-digital-credentials`, enable the feature, and restart your browser.
+   This is required to avoid errors like `TypeError: cannot read properties of undefined (reading 'get')`
 
 #### Test Matrix
 This is a more detailed checklist that needs to be tested before each release. This can serve as a guide for an

--- a/server/src/main/webapp/verifier.js
+++ b/server/src/main/webapp/verifier.js
@@ -267,6 +267,10 @@ async function requestDocument(format, docType, requestId) {
 }
 
 async function dcRequestCredential(sessionId, dcRequestProtocol, dcRequest) {
+    if (!navigator.identity || !navigator.identity.get) {
+        alert("Digital Credentials API is not available. Please enable it via chrome://flags#web-identity-digital-credentials.");
+        return;
+    }
     try {
         const credentialResponse = await navigator.identity.get({
             digital: {


### PR DESCRIPTION
Hit a runtime error during local doc verification and traced it to a missing Chrome flag. Added a note in the README and a runtime check in dcRequestCredential to guide devs to enable chrome://flags#web-identity-digital-credentials.

Didn’t open an issue first — let me know if that’s needed. Thanks!

- [X] Tests pass
- [X] Appropriate changes to README are included in PR

