### PR TITLE
Interop fixes.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/asn1/OID.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/asn1/OID.kt
@@ -44,6 +44,7 @@ enum class OID(
     X509_EXTENSION_BASIC_CONSTRAINTS("2.5.29.19", "basicConstraints (X.509 extension)"),
     X509_EXTENSION_SUBJECT_KEY_IDENTIFIER("2.5.29.14", "subjectKeyIdentifier (X.509 extension)"),
     X509_EXTENSION_AUTHORITY_KEY_IDENTIFIER("2.5.29.35", "authorityKeyIdentifier (X.509 extension)"),
+    X509_EXTENSION_SUBJECT_ALT_NAME("2.5.29.17", "subjectAltName (X.509 extension)"),
     X509_EXTENSION_ISSUER_ALT_NAME("2.5.29.18", "issuerAltName (X.509 extension)"),
     X509_EXTENSION_CRL_DISTRIBUTION_POINTS("2.5.29.31", "cRLDistributionPoints (X.509 extension)"),
     X509_EXTENSION_ANDROID_KEYSTORE_ATTESTATION("1.3.6.1.4.1.11129.2.1.17", "Android Keystore Key Attestation (X.509 extension)"),

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
@@ -106,6 +106,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.storage.base.BaseStorageTable
+import org.multipaz.util.fromHex
 
 /**
  * Application singleton.
@@ -253,8 +254,8 @@ class App private constructor(val promptModel: PromptModel) {
     val bundledIacaCert: X509Cert by lazy {
         MdocUtil.generateIacaCertificate(
             iacaKey = iacaKey,
-            subject = X500Name.fromName("C=ZZ,CN=OWF Identity Credential TEST IACA"),
-            serial = ASN1Integer(1L),
+            subject = X500Name.fromName("C=US,CN=OWF Multipaz TEST IACA"),
+            serial = ASN1Integer("26457B125F0AD75217A98EE6CFDEA7FC486221".fromHex()),
             validFrom = certsValidFrom,
             validUntil = certsValidUntil,
             issuerAltNameUrl = "https://github.com/openwallet-foundation-labs/identity-credential",

--- a/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/VerifierServlet.kt
@@ -80,11 +80,19 @@ import kotlinx.serialization.json.putJsonObject
 import net.minidev.json.JSONArray
 import net.minidev.json.JSONObject
 import net.minidev.json.JSONStyle
+import org.multipaz.asn1.ASN1
+import org.multipaz.asn1.ASN1Encoding
+import org.multipaz.asn1.ASN1Sequence
+import org.multipaz.asn1.ASN1TagClass
+import org.multipaz.asn1.ASN1TaggedObject
+import org.multipaz.asn1.OID
 import org.multipaz.cbor.addCborArray
 import org.multipaz.cbor.addCborMap
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.putCborMap
+import org.multipaz.crypto.X509Cert
+import org.multipaz.crypto.X509KeyUsage
 import java.net.InetAddress
 import java.net.NetworkInterface
 import java.net.URLEncoder
@@ -114,6 +122,7 @@ private data class OpenID4VPBeginRequest(
     val requestId: String,
     val protocol: String,
     val origin: String,
+    val host: String,
     val scheme: String
 )
 
@@ -150,7 +159,8 @@ data class Session(
     val requestId: String,          // DocumentWellKnownRequest.id
     val protocol: Protocol,
     val nonce: ByteString,
-    val origin: String,
+    val origin: String,             // e.g. https://ws.davidz25.net
+    val host: String,               // e.g. ws.davidz25.net
     val encryptionKey: EcPrivateKey,
     val signRequest: Boolean = true,
     val encryptResponse: Boolean = true,
@@ -191,6 +201,7 @@ private data class DCBeginRequest(
     val requestId: String,
     val protocol: String,
     val origin: String,
+    val host: String,
     val signRequest: Boolean,
     val encryptResponse: Boolean,
 )
@@ -263,7 +274,7 @@ class VerifierServlet : BaseHttpServlet() {
                 //
                 val readerRootKey = Crypto.createEcPrivateKey(EcCurve.P256)
                 val readerRootKeySignatureAlgorithm = Algorithm.ES256
-                val readerRootKeySubject = "CN=OWF IC Online Verifier Reader Root Key"
+                val readerRootKeySubject = "CN=OWF Multipaz Online Verifier Reader Root Key"
                 val readerRootKeyCertificate = MdocUtil.generateReaderRootCertificate(
                     readerRootKey = readerRootKey,
                     subject = X500Name.fromName(readerRootKeySubject),
@@ -387,12 +398,12 @@ class VerifierServlet : BaseHttpServlet() {
         "x509_san_dns:$ret"
     }
 
-    private fun createSingleUseReaderKey(): Pair<EcPrivateKey, X509CertChain> {
+    private fun createSingleUseReaderKey(dnsName: String): Pair<EcPrivateKey, X509CertChain> {
         val now = Clock.System.now()
         val validFrom = now.plus(DateTimePeriod(minutes = -10), TimeZone.currentSystemDefault())
         val validUntil = now.plus(DateTimePeriod(minutes = 10), TimeZone.currentSystemDefault())
         val readerKey = Crypto.createEcPrivateKey(EcCurve.P256)
-        val readerKeySubject = "CN=OWF IC Online Verifier Single-Use Reader Key"
+        val readerKeySubject = "CN=OWF Multipaz Online Verifier Single-Use Reader Key"
 
         // TODO: for now, instead of using the per-site Reader Root generated at first run, use the
         //  well-know OWF IC Reader root checked into Git.
@@ -421,21 +432,41 @@ class VerifierServlet : BaseHttpServlet() {
         val certsValidUntil = LocalDate.parse("2034-12-01").atStartOfDayIn(TimeZone.UTC)
         val owfIcReaderRootCert = MdocUtil.generateReaderRootCertificate(
             readerRootKey = owfIcReaderRootKey,
-            subject = X500Name.fromName("CN=OWF IC TestApp Reader Root"),
+            subject = X500Name.fromName("CN=OWF Multipaz TestApp Reader Root"),
             serial = ASN1Integer(1L),
             validFrom = certsValidFrom,
             validUntil = certsValidUntil,
         )
 
-        val readerKeyCertificate = MdocUtil.generateReaderCertificate(
-            readerRootCert = owfIcReaderRootCert,
-            readerRootKey = owfIcReaderRootKey,
-            readerKey = readerKey.publicKey,
+        val readerKeyCertificate = X509Cert.Builder(
+            publicKey = readerKey.publicKey,
+            signingKey = owfIcReaderRootKey,
+            signatureAlgorithm = owfIcReaderRootKey.curve.defaultSigningAlgorithm,
+            serialNumber = ASN1Integer(1L),
             subject = X500Name.fromName(readerKeySubject),
-            serial = ASN1Integer(1L),
+            issuer = owfIcReaderRootCert.subject,
             validFrom = validFrom,
             validUntil = validUntil
         )
+            .includeSubjectKeyIdentifier()
+            .setAuthorityKeyIdentifierToCertificate(owfIcReaderRootCert)
+            .setKeyUsage(setOf(X509KeyUsage.DIGITAL_SIGNATURE))
+            .addExtension(
+                OID.X509_EXTENSION_SUBJECT_ALT_NAME.oid,
+                false,
+                ASN1.encode(
+                    ASN1Sequence(listOf(
+                        ASN1TaggedObject(
+                            ASN1TagClass.CONTEXT_SPECIFIC,
+                            ASN1Encoding.PRIMITIVE,
+                            2, // dNSName
+                            dnsName.encodeToByteArray()
+                        )
+                    ))
+                )
+            )
+            .build()
+
         return Pair(
             readerKey,
             X509CertChain(listOf(readerKeyCertificate) + owfIcReaderRootCert)
@@ -567,6 +598,7 @@ class VerifierServlet : BaseHttpServlet() {
         val session = Session(
             nonce = ByteString(Random.Default.nextBytes(16)),
             origin = request.origin,
+            host = request.host,
             encryptionKey = Crypto.createEcPrivateKey(EcCurve.P256),
             requestFormat = request.format,
             requestDocType = request.docType,
@@ -583,7 +615,7 @@ class VerifierServlet : BaseHttpServlet() {
             )
         }
 
-        val (readerAuthKey, readerAuthKeyCertification) = createSingleUseReaderKey()
+        val (readerAuthKey, readerAuthKeyCertification) = createSingleUseReaderKey(session.host)
 
         // Uncomment when making test vectors...
         //Logger.iCbor(TAG, "readerKey: ", Cbor.encode(session.encryptionKey.toCoseKey().toDataItem()))
@@ -653,7 +685,7 @@ class VerifierServlet : BaseHttpServlet() {
                 }
                 "vc" -> {
                     val clientIdToUse = if (session.signRequest) {
-                        "x509_san_uri:${session.origin}/server/verifier.html"
+                        "x509_san_dns:${session.host}"
                     } else {
                         "web-origin:${session.origin}"
                     }
@@ -818,7 +850,7 @@ class VerifierServlet : BaseHttpServlet() {
         when (session.requestFormat) {
             "mdoc" -> {
                 val effectiveClientId = if (session.signRequest) {
-                    "x509_san_uri:${session.origin}/server/verifier.html"
+                    "x509_san_dns:${session.host}"
                 } else {
                     "web-origin:${session.origin}"
                 }
@@ -879,6 +911,7 @@ class VerifierServlet : BaseHttpServlet() {
         val session = Session(
             nonce = ByteString(Random.Default.nextBytes(16)),
             origin = request.origin,
+            host = request.host,
             encryptionKey = Crypto.createEcPrivateKey(EcCurve.P256),
             requestFormat = request.format,
             requestDocType = request.docType,
@@ -941,7 +974,7 @@ class VerifierServlet : BaseHttpServlet() {
 
         val responseUri = baseUrl + "/verifier/openid4vpResponse?sessionId=${sessionId}"
 
-        val (singleUseReaderKeyPriv, singleUseReaderKeyCertChain) = createSingleUseReaderKey()
+        val (singleUseReaderKeyPriv, singleUseReaderKeyCertChain) = createSingleUseReaderKey(session.host)
 
         val readerPublic = singleUseReaderKeyPriv.publicKey.javaPublicKey as ECPublicKey
         val readerPrivate = singleUseReaderKeyPriv.javaPrivateKey as ECPrivateKey
@@ -1495,7 +1528,10 @@ private fun calcDcRequestStringOpenID4VP(
         put("client_metadata", clientMetadata)
         // Only include client_id for signed requests
         if (signRequest) {
-            put("client_id", JsonPrimitive("x509_san_uri:${session.origin}/server/verifier.html"))
+            put("client_id", JsonPrimitive("x509_san_dns:${session.host}"))
+            putJsonArray("expected_origins") {
+                add(JsonPrimitive(session.origin))
+            }
         }
         put("nonce", JsonPrimitive(nonce.toByteArray().toBase64Url()))
 

--- a/server/src/main/webapp/verifier.js
+++ b/server/src/main/webapp/verifier.js
@@ -172,6 +172,7 @@ async function requestDocument(format, docType, requestId) {
                 requestId: requestId,
                 protocol: selectedProtocol,
                 origin: location.origin,
+                host: location.host,
                 scheme: document.getElementById("scheme-input").value
             }
         )
@@ -186,6 +187,7 @@ async function requestDocument(format, docType, requestId) {
                       requestId: requestId,
                       protocol: selectedProtocol,
                       origin: location.origin,
+                      host: location.host,
                       scheme: ""
                   }
               )
@@ -201,6 +203,7 @@ async function requestDocument(format, docType, requestId) {
                     requestId: requestId,
                     protocol: selectedProtocol,
                     origin: location.origin,
+                    host: location.host,
                     signRequest: false,
                     encryptResponse: true
                 }
@@ -219,6 +222,7 @@ async function requestDocument(format, docType, requestId) {
                     requestId: requestId,
                     protocol: selectedProtocol,
                     origin: location.origin,
+                    host: location.host,
                     signRequest: true,
                     encryptResponse: true
                 }
@@ -237,6 +241,7 @@ async function requestDocument(format, docType, requestId) {
                     requestId: requestId,
                     protocol: selectedProtocol,
                     origin: location.origin,
+                    host: location.host,
                     signRequest: true,
                     encryptResponse: true
                 }
@@ -255,6 +260,7 @@ async function requestDocument(format, docType, requestId) {
                     requestId: requestId,
                     protocol: selectedProtocol,
                     origin: location.origin,
+                    host: location.host,
                     signRequest: document.getElementById("openid4vp-sign-request-input").checked,
                     encryptResponse: document.getElementById("openid4vp-encrypt-response-input").checked
                 }


### PR DESCRIPTION
Identified during OpenID test event.

- Switch to x509_san_dns for W3C DC API with OpenID and include dNSName in subjectAltName X.509 extension in reader cert as required
- Use a serial number in IACA certificate with sufficient entropy
- Add expected_origins for OpenID4VP signed requests, as required

Test: Manually tested and tested in OpenID interop event
