### PR TITLE
OpenId4VCI provisioning in test app.

### DIFF
--- a/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/Authentication.kt
+++ b/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/Authentication.kt
@@ -12,5 +12,5 @@ interface Authentication {
     suspend fun requestChallenge(clientId: String): ClientChallenge
 
     @RpcMethod
-    suspend fun authenticate(auth: ClientAuthentication): WalletServerCapabilities
+    suspend fun authenticate(auth: ClientAuthentication): ProvisioningBackendCapabilities
 }

--- a/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningBackend.kt
+++ b/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningBackend.kt
@@ -4,7 +4,7 @@ import org.multipaz.rpc.annotation.RpcInterface
 import org.multipaz.rpc.annotation.RpcMethod
 
 @RpcInterface
-interface WalletServer {
+interface ProvisioningBackend {
     /**
      * General-purpose server-side application support.
      *

--- a/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningBackendCapabilities.kt
+++ b/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningBackendCapabilities.kt
@@ -9,7 +9,7 @@ import kotlinx.datetime.Instant
  * @property generatedAt The point in time this data was generated.
  */
 @CborSerializable
-data class WalletServerCapabilities(
+data class ProvisioningBackendCapabilities(
     val generatedAt: Instant
 ) {
     companion object

--- a/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningBackendSettings.kt
+++ b/multipaz-provisioning-api/src/commonMain/kotlin/org/multipaz/provisioning/ProvisioningBackendSettings.kt
@@ -8,7 +8,7 @@ import kotlinx.io.bytestring.ByteString
 /**
  * Wallet Server settings.
  */
-class WalletServerSettings(private val conf: Configuration) {
+class ProvisioningBackendSettings(private val conf: Configuration) {
 
     val developerMode
         get() = getBool("developerMode", false)

--- a/multipaz-provisioning/src/main/java/org/multipaz/provisioning/hardcoded/IssuingAuthorityState.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/provisioning/hardcoded/IssuingAuthorityState.kt
@@ -45,7 +45,7 @@ import org.multipaz.provisioning.RegistrationResponse
 import org.multipaz.provisioning.IssuingAuthorityNotification
 import org.multipaz.provisioning.SdJwtVcDocumentConfiguration
 import org.multipaz.provisioning.WalletApplicationCapabilities
-import org.multipaz.provisioning.WalletServerSettings
+import org.multipaz.provisioning.ProvisioningBackendSettings
 import org.multipaz.rpc.cache
 import org.multipaz.rpc.backend.getTable
 import org.multipaz.provisioning.evidence.DirectAccessDocumentConfiguration
@@ -126,7 +126,7 @@ class IssuingAuthorityState(
                 IssuingAuthorityConfiguration::class,
                 id
             ) { configuration, resources ->
-                val settings = WalletServerSettings(configuration)
+                val settings = ProvisioningBackendSettings(configuration)
                 val prefix = "issuingAuthority.$id"
                 val logoPath = settings.getString("${prefix}.logo") ?: "default/logo.png"
                 val logo = resources.getRawResource(logoPath)!!
@@ -259,7 +259,7 @@ class IssuingAuthorityState(
         issuerDocument.state = DocumentCondition.PROOFING_PROCESSING
         issuerDocument.collectedEvidence.clear()
         // TODO: propagate developer mode
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         return ProofingState(documentId, authorityId, settings.developerMode)
     }
 
@@ -364,7 +364,7 @@ class IssuingAuthorityState(
         notifyApplicationOfUpdate: Boolean
     ) {
         checkClientId()
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val prefix = "issuingAuthority.$authorityId"
         val type = settings.getString("$prefix.type") ?: TYPE_DRIVING_LICENSE
 
@@ -421,7 +421,7 @@ class IssuingAuthorityState(
         documentId: String,
         administrativeNumber: String
     ) {
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val prefix = "issuingAuthority.$authorityId"
         val type = settings.getString("$prefix.type") ?: TYPE_DRIVING_LICENSE
 
@@ -478,7 +478,7 @@ class IssuingAuthorityState(
     ): ByteArray {
         val now = Clock.System.now()
 
-        val settings = WalletServerSettings(env.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(env.getInterface(Configuration::class)!!)
         val prefix = "issuingAuthority.$authorityId"
         val type = settings.getString("$prefix.type") ?: TYPE_DRIVING_LICENSE
 
@@ -668,7 +668,7 @@ class IssuingAuthorityState(
     private suspend fun generateDocumentConfiguration(
         collectedEvidence: Map<String, EvidenceResponse>
     ): DocumentConfiguration {
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val prefix = "issuingAuthority.$authorityId"
         val type = settings.getString("$prefix.type") ?: TYPE_DRIVING_LICENSE
         return when (type) {
@@ -685,7 +685,7 @@ class IssuingAuthorityState(
         val now = Clock.System.now()
         val issueDate = now
         val resources = BackendEnvironment.getInterface(Resources::class)!!
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val expiryDate = now + 365.days * 5
 
         val prefix = "issuingAuthority.$authorityId"
@@ -787,7 +787,7 @@ class IssuingAuthorityState(
         val now = Clock.System.now()
         val issueDate = now
         val resources = BackendEnvironment.getInterface(Resources::class)!!
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val expiryDate = now + 365.days * 5
 
         val prefix = "issuingAuthority.$authorityId"
@@ -912,7 +912,7 @@ class IssuingAuthorityState(
         val now = Clock.System.now()
         val issueDate = now
         val resources = BackendEnvironment.getInterface(Resources::class)!!
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val expiryDate = now + 365.days * 5
 
         val prefix = "issuingAuthority.$authorityId"

--- a/multipaz-provisioning/src/main/java/org/multipaz/provisioning/hardcoded/ProofingState.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/provisioning/hardcoded/ProofingState.kt
@@ -5,7 +5,7 @@ import org.multipaz.rpc.annotation.RpcState
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.provisioning.Proofing
 import org.multipaz.provisioning.WalletApplicationCapabilities
-import org.multipaz.provisioning.WalletServerSettings
+import org.multipaz.provisioning.ProvisioningBackendSettings
 import org.multipaz.rpc.cache
 import org.multipaz.provisioning.evidence.EvidenceRequest
 import org.multipaz.provisioning.evidence.EvidenceResponse
@@ -115,7 +115,7 @@ class ProofingState(
 
         val key = GraphKey(issuingAuthorityId, documentId, developerModeEnabled)
         return env.cache(ProofingGraph::class, key) { configuration, resources ->
-            val cloudSecureAreaUrl = WalletServerSettings(configuration).cloudSecureAreaUrl
+            val cloudSecureAreaUrl = ProvisioningBackendSettings(configuration).cloudSecureAreaUrl
             defaultGraph(
                 documentId,
                 resources,

--- a/multipaz-provisioning/src/main/java/org/multipaz/provisioning/wallet/ApplicationSupportState.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/provisioning/wallet/ApplicationSupportState.kt
@@ -13,7 +13,7 @@ import org.multipaz.rpc.backend.Configuration
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.provisioning.ApplicationSupport
 import org.multipaz.provisioning.LandingUrlUnknownException
-import org.multipaz.provisioning.WalletServerSettings
+import org.multipaz.provisioning.ProvisioningBackendSettings
 import org.multipaz.rpc.cache
 import org.multipaz.rpc.backend.getTable
 import org.multipaz.provisioning.openid4vci.toJson
@@ -103,16 +103,16 @@ class ApplicationSupportState(
 
     override suspend fun createJwtClientAssertion(
         keyAttestation: KeyAttestation,
-        keyAssertion: DeviceAssertion
+        deviceAssertion: DeviceAssertion
     ): String {
         checkClientId()
         val deviceAttestation = RpcAuthInspectorAssertion.getClientDeviceAttestation(clientId)!!
-        deviceAttestation.validateAssertion(keyAssertion)
+        deviceAttestation.validateAssertion(deviceAssertion)
 
-        val assertion = keyAssertion.assertion as AssertionDPoPKey
+        val assertion = deviceAssertion.assertion as AssertionDPoPKey
 
         if (deviceAttestation is DeviceAttestationAndroid) {
-            val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+            val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
             val certChain = keyAttestation.certChain!!
             check(assertion.publicKey == certChain.certificates.first().ecPublicKey)
             validateAndroidKeyAttestation(

--- a/multipaz-provisioning/src/main/java/org/multipaz/provisioning/wallet/AuthenticationState.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/provisioning/wallet/AuthenticationState.kt
@@ -11,8 +11,8 @@ import org.multipaz.rpc.backend.getTable
 import org.multipaz.provisioning.Authentication
 import org.multipaz.provisioning.ClientAuthentication
 import org.multipaz.provisioning.ClientChallenge
-import org.multipaz.provisioning.WalletServerCapabilities
-import org.multipaz.provisioning.WalletServerSettings
+import org.multipaz.provisioning.ProvisioningBackendCapabilities
+import org.multipaz.provisioning.ProvisioningBackendSettings
 import org.multipaz.provisioning.toCbor
 import org.multipaz.storage.StorageTableSpec
 import org.multipaz.util.toBase64Url
@@ -63,8 +63,8 @@ class AuthenticationState(
         return ClientChallenge(nonce!!, this.clientId)
     }
 
-    override suspend fun authenticate(auth: ClientAuthentication): WalletServerCapabilities {
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+    override suspend fun authenticate(auth: ClientAuthentication): ProvisioningBackendCapabilities {
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val clientTable = BackendEnvironment.getTable(RpcAuthInspectorAssertion.rpcClientTableSpec)
 
         val attestation = auth.attestation
@@ -110,7 +110,7 @@ class AuthenticationState(
                 data = ByteString(auth.walletApplicationCapabilities.toCbor())
             )
         }
-        return WalletServerCapabilities(
+        return ProvisioningBackendCapabilities(
             Clock.System.now()
         )
     }

--- a/multipaz-provisioning/src/main/java/org/multipaz/provisioning/wallet/ProvisioningBackendState.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/provisioning/wallet/ProvisioningBackendState.kt
@@ -12,8 +12,8 @@ import org.multipaz.provisioning.DocumentConfiguration
 import org.multipaz.provisioning.IssuingAuthorityConfiguration
 import org.multipaz.provisioning.IssuingAuthorityException
 import org.multipaz.provisioning.LandingUrlUnknownException
-import org.multipaz.provisioning.WalletServer
-import org.multipaz.provisioning.WalletServerSettings
+import org.multipaz.provisioning.ProvisioningBackend
+import org.multipaz.provisioning.ProvisioningBackendSettings
 import org.multipaz.provisioning.openid4vci.Openid4VciIssuingAuthorityState
 import org.multipaz.provisioning.openid4vci.Openid4VciProofingState
 import org.multipaz.provisioning.openid4vci.Openid4VciRegistrationState
@@ -37,7 +37,7 @@ import kotlin.coroutines.coroutineContext
     creatable = true
 )
 @CborSerializable
-class WalletServerState: WalletServer, RpcAuthInspector by RpcAuthBackendDelegate {
+class ProvisioningBackendState: ProvisioningBackend, RpcAuthInspector by RpcAuthBackendDelegate {
     companion object {
         private const val TAG = "WalletServerState"
 
@@ -71,7 +71,7 @@ class WalletServerState: WalletServer, RpcAuthInspector by RpcAuthBackendDelegat
         }
 
         fun registerAll(dispatcher: RpcDispatcherLocal.Builder) {
-            WalletServerState.register(dispatcher)
+            ProvisioningBackendState.register(dispatcher)
             ApplicationSupportState.register(dispatcher)
             AuthenticationState.register(dispatcher)
             IssuingAuthorityState.register(dispatcher)
@@ -96,7 +96,7 @@ class WalletServerState: WalletServer, RpcAuthInspector by RpcAuthBackendDelegat
     }
 
     override suspend fun getIssuingAuthorityConfigurations(): List<IssuingAuthorityConfiguration> {
-        val settings = WalletServerSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+        val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
         val issuingAuthorityList = settings.getStringList("issuingAuthorityList")
         return if (issuingAuthorityList.isEmpty()) {
             listOf(devConfig(BackendEnvironment.get(coroutineContext)))

--- a/multipaz/src/androidMain/kotlin/org/multipaz/applinks/AppLinksCheck.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/applinks/AppLinksCheck.kt
@@ -1,0 +1,179 @@
+package org.multipaz.applinks
+
+import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.yield
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.add
+import kotlinx.serialization.json.buildJsonArray
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
+import org.multipaz.util.Logger
+import java.util.Locale
+
+/**
+ * Utility to verify that app links work correctly in the hosting app environment.
+ */
+object AppLinksCheck {
+    const val TAG = "AppLinksCheck"
+
+    /**
+     * Checks that the server setup for the Android app links is valid for the app instance
+     * that uses multipaz library.
+     *
+     * Important: this function does not determine if app links should be trusted or not (that is
+     * done independently in Android OS). Instead, it attempts to evaluate if Android is going to
+     * trust the way the server set up and if the answer is no, helps to diagnose and fix the
+     * problem.
+     *
+     * Server setup might no work for various reasons:
+     *  - app was configured to use a server that simply lacks any setup
+     *  - `assetlinks.json` is not formatted correctly
+     *  - app was signed by a key that is not known to the server
+     *
+     *  This function attempts to validate the setup. If it is valid it returns `true`. If it is
+     *  invalid, it prints to a log a sample `assetlinks.json` that would be acceptable and returns
+     *  `false`.
+     *
+     *  If the server is unreachable, setup is not validated and assumed valid, `true` is returned.
+     *  This is to avoid flagging errors when offline. Also no validation happens below Android "P"
+     *  release.
+     *
+     *  Note that correct intent filter for the app links must also be specified in the
+     *  application's `AndroidManifest.xml`. It is not possible to verify this part at runtime.
+     *
+     *  @param context application or Activity context
+     *  @param appLinkServer server URL, e.g, "https://example.com" __without__ trailing slash.
+     *  @param httpClient HTTP client to use for fetching `assetlinks.json`
+     */
+    suspend fun checkAppLinksServerSetup(
+        context: Context,
+        appLinkServer: String,
+        httpClient: HttpClient
+    ): Boolean {
+        if (appLinkServer.endsWith("/")) {
+            throw IllegalArgumentException("Trailing slash in server name: '$appLinkServer'")
+        }
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.P) {
+            // No validation on old Android for now
+            return true
+        }
+        // Extract our app info
+        val packageName = context.applicationInfo.packageName
+        val signingInfo = context.packageManager.getPackageInfo(
+            packageName,
+            PackageManager.GET_SIGNING_CERTIFICATES
+        ).signingInfo!!
+        val requireAllSigners = signingInfo.hasMultipleSigners()
+        val signatures = if (requireAllSigners) {
+            signingInfo.apkContentsSigners
+        } else {
+            signingInfo.signingCertificateHistory
+        }
+        val digests = signatures.map {
+            ByteString(Crypto.digest(Algorithm.SHA256, it.toByteArray()))
+        }.toSet()
+
+        // Fetch assetlinks.json file
+        val assetLinksUrl = "$appLinkServer/.well-known/assetlinks.json"
+        val jsonText = try {
+            val response = httpClient.get(assetLinksUrl)
+            if (response.status != HttpStatusCode.OK) {
+                Logger.e(TAG, "Error fetching '$assetLinksUrl': HTTP status ${response.status.value}")
+                "[]"
+            } else {
+                response.readBytes().decodeToString()
+            }
+        } catch (err: Exception) {
+            Logger.e(TAG, "Error connecting to $appLinkServer", err)
+            // Assume we are offline, don't complain.
+            return true
+        }
+        // Parse and validate assetlinks.json file
+        for (permission in Json.parseToJsonElement(jsonText).jsonArray) {
+            try {
+                val relation = permission.jsonObject["relation"]!!.jsonArray
+                if (relation[0].jsonPrimitive.content != "delegate_permission/common.handle_all_urls") {
+                    continue
+                }
+                val target = permission.jsonObject["target"]!!.jsonObject
+                if (target["namespace"]?.jsonPrimitive?.content != "android_app") {
+                    continue
+                }
+                if (target["package_name"]?.jsonPrimitive?.content != packageName) {
+                    continue
+                }
+                val serverDigests = target["sha256_cert_fingerprints"]!!.jsonArray.map {
+                    ByteString(it.jsonPrimitive.content.split(':').map { byteCode ->
+                        byteCode.toInt(16).toByte()
+                    }.toByteArray())
+                }.toSet()
+                var digestsValid = false
+                if (requireAllSigners) {
+                    digestsValid = serverDigests.containsAll(digests)
+                } else {
+                    for (digest in digests) {
+                        if (serverDigests.contains(digest)) {
+                            digestsValid = true
+                            break
+                        }
+                    }
+                }
+                if (digestsValid) {
+                    Logger.i(TAG, "Server app link setup is validated")
+                    return true
+                } else {
+                    Logger.e(TAG, "Server app link setup appears to be invalid")
+                    break
+                }
+            } catch (err: Exception) {
+                Logger.e(TAG, "Parsing error", err)
+                continue
+            }
+        }
+        Logger.e(TAG, "Server app link setup could not be verified")
+        printSampleAssetLinksFile(assetLinksUrl, packageName,
+            if (requireAllSigners) digests else setOf(digests.first()))
+        return false
+    }
+
+    private fun printSampleAssetLinksFile(
+        url: String,
+        packageName: String,
+        digests: Set<ByteString>
+    ) {
+        val jsonData = buildJsonArray {
+            add(buildJsonObject {
+                put("relation", buildJsonArray {
+                    add("delegate_permission/common.handle_all_urls")
+                })
+                put("target", buildJsonObject {
+                    put("namespace", "android_app")
+                    put("package_name", packageName)
+                    put("sha256_cert_fingerprints", buildJsonArray {
+                        for (digest in digests) {
+                            add(digest.toByteArray().joinToString(":") { byte ->
+                                (byte.toInt() and 0xFF).toString(16).padStart(2, '0')
+                            }.uppercase(Locale.ROOT))
+                        }
+                    })
+                })
+            })
+        }
+        val json = Json { prettyPrint = true }
+        val jsonText = json.encodeToString(JsonArray.serializer(), jsonData)
+        Logger.e(TAG, "Sample file to upload to (or merge into) '$url':\n$jsonText")
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAssertionMaker.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceAssertionMaker.kt
@@ -2,6 +2,6 @@ package org.multipaz.device
 
 fun interface DeviceAssertionMaker {
     suspend fun makeDeviceAssertion(
-        assertion: (attestationChallenge: String) -> Assertion
+        assertionFactory: (attestationChallenge: String) -> Assertion
     ): DeviceAssertion
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/NoopCipher.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/NoopCipher.kt
@@ -1,0 +1,9 @@
+package org.multipaz.rpc.handler
+
+/**
+ * [SimpleCipher] that does not encrypt or decrypt messages.
+ */
+object NoopCipher: SimpleCipher {
+    override fun encrypt(plaintext: ByteArray): ByteArray = plaintext
+    override fun decrypt(ciphertext: ByteArray): ByteArray = ciphertext
+}

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/RpcProcessorTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/RpcProcessorTest.kt
@@ -24,6 +24,7 @@ import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import org.multipaz.rpc.client.RpcNotifiable
+import org.multipaz.rpc.handler.NoopCipher
 import org.multipaz.rpc.handler.RpcNotifications
 import org.multipaz.rpc.handler.RpcNotificationsLocal
 import org.multipaz.rpc.handler.RpcNotificationsLocalPoll
@@ -264,10 +265,7 @@ private fun TestScope.buildLocalDispatcher(
     SolverFactoryState.register(builder)
     NotificationTestState.register(builder)
     val cipher = if (useNoopCipher) {
-        object : SimpleCipher {
-            override fun encrypt(plaintext: ByteArray): ByteArray = plaintext
-            override fun decrypt(ciphertext: ByteArray): ByteArray = ciphertext
-        }
+        NoopCipher
     } else {
         AesGcmCipher(Random.Default.nextBytes(16))
     }

--- a/samples/testapp/iosApp/TestApp/ContentView.swift
+++ b/samples/testapp/iosApp/TestApp/ContentView.swift
@@ -14,6 +14,9 @@ struct ContentView: View {
     var body: some View {
         ComposeView()
                 .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+                .onOpenURL(perform: { url in
+                    MainViewControllerKt.HandleUrl(url: url.absoluteString)
+                })
     }
 }
 

--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -50,11 +50,38 @@
         <activity
             android:exported="true"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
+            android:launchMode="singleTop"
             android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
+
+            <intent-filter android:autoVerify="true">
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+
+                <!--
+                Do not include other schemes, only https. If domain is changed here, it
+                also MUST be changed in ApplicationSupportLocal class.
+                 -->
+                <data
+                    android:scheme="https"
+                    android:host="apps.multipaz.org"
+                    android:pathPattern="/landing/.*"/>
+            </intent-filter>
+
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <!--  OpenId Credential Offer scheme (OID4VCI) -->
+                <data android:scheme="openid-credential-offer"/>
+                <!-- Accept all hosts for any of the defined schemes above -->
+                <data android:host="*"/>
+            </intent-filter>
+
         </activity>
 
         <activity

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NdefService.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NdefService.kt
@@ -5,6 +5,7 @@ import android.nfc.cardemulation.HostApduService
 import android.os.Bundle
 import android.os.VibrationEffect
 import android.os.Vibrator
+import android.util.Log
 import androidx.core.content.ContextCompat
 import org.multipaz.cbor.DataItem
 import org.multipaz.crypto.Crypto
@@ -34,12 +35,31 @@ import kotlinx.datetime.Clock
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.nfc.ResponseApdu
+import org.multipaz.util.Logger.LEVEL_D
+import org.multipaz.util.Logger.LEVEL_E
+import org.multipaz.util.Logger.LEVEL_I
+import org.multipaz.util.Logger.LEVEL_W
+import org.multipaz.util.Logger.LogPrinter
 import kotlin.time.Duration
 import kotlin.time.Duration.Companion.seconds
 
 class NdefService: HostApduService() {
     companion object {
         private val TAG = "NdefService"
+
+        init {
+            Logger.setLogPrinter(object: LogPrinter {
+                override fun printLn(level: Int, tag: String, msg: String, throwable: Throwable?) {
+                    when (level) {
+                        LEVEL_D -> throwable?.let { Log.d(tag, msg, it) } ?: Log.d(tag, msg)
+                        LEVEL_I -> throwable?.let { Log.i(tag, msg, it) } ?: Log.i(tag, msg)
+                        LEVEL_W -> throwable?.let { Log.w(tag, msg, it) } ?: Log.w(tag, msg)
+                        LEVEL_E -> throwable?.let { Log.e(tag, msg, it) } ?: Log.e(tag, msg)
+                        else -> throw IllegalArgumentException("Unknown log level: $level")
+                    }
+                }
+            })
+        }
 
         private var engagement: MdocNfcEngagementHelper? = null
         private var disableEngagementJob: Job? = null

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.android.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.android.kt
@@ -1,0 +1,41 @@
+package com.android.identity.testapp.provisioning.model
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.securearea.AndroidKeystoreCreateKeySettings
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.securearea.cloud.CloudCreateKeySettings
+import org.multipaz.securearea.config.SecureAreaConfiguration
+import org.multipaz.securearea.config.SecureAreaConfigurationAndroidKeystore
+import org.multipaz.securearea.config.SecureAreaConfigurationCloud
+import org.multipaz.securearea.config.SecureAreaConfigurationSoftware
+import org.multipaz.securearea.software.SoftwareCreateKeySettings
+
+actual suspend fun SecureAreaRepository.byConfiguration(
+    secureAreaConfiguration: SecureAreaConfiguration,
+    challenge: ByteString
+): Pair<SecureArea, CreateKeySettings> {
+    return when (secureAreaConfiguration) {
+        is SecureAreaConfigurationSoftware -> Pair(
+            getImplementation("SoftwareSecureArea")!!,
+            SoftwareCreateKeySettings.Builder()
+                .applyConfiguration(secureAreaConfiguration)
+                .build()
+        )
+
+        is SecureAreaConfigurationAndroidKeystore -> Pair(
+            getImplementation("AndroidKeystoreSecureArea")!!,
+            AndroidKeystoreCreateKeySettings.Builder(challenge)
+                .applyConfiguration(secureAreaConfiguration)
+                .build()
+        )
+
+        is SecureAreaConfigurationCloud -> Pair(
+            getImplementation(secureAreaConfiguration.cloudSecureAreaId)!!,
+            CloudCreateKeySettings.Builder(challenge)
+                .applyConfiguration(secureAreaConfiguration)
+                .build()
+        )
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -26,6 +27,11 @@ import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import com.android.identity.testapp.provisioning.backend.ApplicationSupportLocal
+import com.android.identity.testapp.provisioning.backend.ProvisioningBackendProviderLocal
+import com.android.identity.testapp.provisioning.backend.ProvisioningBackendProviderRemote
+import com.android.identity.testapp.provisioning.model.ProvisioningModel
+import com.android.identity.testapp.provisioning.openid4vci.extractCredentialIssuerData
 import com.android.identity.testapp.ui.AppTheme
 import com.android.identity.testapp.ui.CameraScreen
 import org.multipaz.models.digitalcredentials.DigitalCredentials
@@ -93,9 +99,11 @@ import io.ktor.http.decodeURLPart
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.IO
+import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.TimeZone
@@ -105,6 +113,8 @@ import org.jetbrains.compose.resources.ExperimentalResourceApi
 import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.multipaz.compose.prompt.PromptDialogs
+import org.multipaz.provisioning.WalletApplicationCapabilities
+import org.multipaz.provisioning.evidence.Openid4VciCredentialOffer
 import org.multipaz.storage.base.BaseStorageTable
 
 /**
@@ -118,6 +128,7 @@ class App private constructor(val promptModel: PromptModel) {
 
     lateinit var documentTypeRepository: DocumentTypeRepository
 
+    lateinit var secureAreaRepository: SecureAreaRepository
     lateinit var softwareSecureArea: SoftwareSecureArea
     lateinit var documentStore: DocumentStore
     lateinit var documentModel: DocumentModel
@@ -135,6 +146,12 @@ class App private constructor(val promptModel: PromptModel) {
 
     lateinit var readerTrustManager: TrustManager
 
+    private lateinit var provisioningModel: ProvisioningModel
+
+    private val credentialOffers = Channel<Openid4VciCredentialOffer>()
+
+    private val provisioningBackendProviderLocal = ProvisioningBackendProviderLocal()
+
     private suspend fun init() {
         val initFuncs = listOf<Pair<suspend () -> Unit, String>>(
             Pair(::platformInit, "platformInit"),
@@ -147,6 +164,7 @@ class App private constructor(val promptModel: PromptModel) {
             Pair(::readerRootInit, "readerRootInit"),
             Pair(::readerInit, "readerInit"),
             Pair(::trustManagersInit, "trustManagersInit"),
+            Pair(::provisioningModelInit, "provisioningModelInit")
         )
         val begin = Clock.System.now()
         for ((func, name) in initFuncs) {
@@ -173,7 +191,7 @@ class App private constructor(val promptModel: PromptModel) {
 
     private suspend fun documentStoreInit() {
         softwareSecureArea = SoftwareSecureArea.create(platformStorage())
-        val secureAreaRepository: SecureAreaRepository = SecureAreaRepository.build {
+        secureAreaRepository = SecureAreaRepository.build {
             add(softwareSecureArea)
             add(platformSecureAreaProvider().get())
             addFactory(CloudSecureArea.IDENTIFIER_PREFIX) { identifier ->
@@ -221,6 +239,32 @@ class App private constructor(val promptModel: PromptModel) {
 
     private suspend fun trustManagersInit() {
         generateTrustManagers()
+    }
+
+    private val useWalletServer = false
+
+    private suspend fun provisioningModelInit() {
+        val backendProvider = if (useWalletServer) {
+            ProvisioningBackendProviderRemote(
+                baseUrl = "http://localhost:8080/server"
+            ) {
+                WalletApplicationCapabilities(
+                    generatedAt = Clock.System.now(),
+                    androidKeystoreAttestKeyAvailable = true,
+                    androidKeystoreStrongBoxAvailable = true,
+                    androidIsEmulator = platformIsEmulator,
+                    directAccessSupported = false,
+                )
+            }
+        } else {
+            provisioningBackendProviderLocal
+        }
+        provisioningModel = ProvisioningModel(
+            backendProvider,
+            documentStore,
+            promptModel,
+            secureAreaRepository
+        )
     }
 
     private val certsValidFrom = LocalDate.parse("2024-12-01").atStartOfDayIn(TimeZone.UTC)
@@ -439,8 +483,37 @@ class App private constructor(val promptModel: PromptModel) {
         }
     }
 
+    /**
+     * Handle a link (either a app link, universal link, or custom URL schema link).
+     */
+    fun handleUrl(url: String) {
+        if (url.startsWith(OID4VCI_CREDENTIAL_OFFER_URL_SCHEME)) {
+            val queryIndex = url.indexOf('?')
+            if (queryIndex >= 0) {
+                val query = url.substring(queryIndex + 1)
+                CoroutineScope(Dispatchers.Default).launch {
+                    val offer = extractCredentialIssuerData(query)
+                    if (offer != null) {
+                        Logger.i(TAG, "Process credential offer '$query'")
+                        credentialOffers.send(offer)
+                    }
+                }
+            }
+        } else if (url.startsWith(ApplicationSupportLocal.APP_LINK_BASE_URL)) {
+            CoroutineScope(Dispatchers.Default).launch {
+                withContext(provisioningModel.coroutineContext) {
+                    provisioningBackendProviderLocal.getApplicationSupport()
+                        .onLandingUrlNavigated(url)
+                }
+            }
+        }
+    }
+
     companion object {
         private const val TAG = "App"
+
+        // OID4VCI url scheme used for filtering OID4VCI Urls from all incoming URLs (deep links or QR)
+        private const val OID4VCI_CREDENTIAL_OFFER_URL_SCHEME = "openid-credential-offer://"
 
         private var app: App? = null
         private val appLock = Mutex()
@@ -497,6 +570,15 @@ class App private constructor(val promptModel: PromptModel) {
         val currentDestination = appDestinations.find {
             it.route == routeWithoutArgs
         } ?: StartDestination
+
+        LaunchedEffect(true) {
+            while (true) {
+                val credentialOffer = credentialOffers.receive()
+                Logger.i(TAG, "Process credential offer from ${credentialOffer.issuerUri}")
+                provisioningModel.startProvisioning(credentialOffer)
+                navController.navigate(ProvisioningTestDestination.route)
+            }
+        }
 
         snackbarHostState = remember { SnackbarHostState() }
         AppTheme {
@@ -661,7 +743,10 @@ class App private constructor(val promptModel: PromptModel) {
                         PassphrasePromptScreen(showToast = { message -> showToast(message) })
                     }
                     composable(route = ProvisioningTestDestination.route) {
-                        ProvisioningTestScreen()
+                        ProvisioningTestScreen(
+                            promptModel = promptModel,
+                            provisioningModel = provisioningModel
+                        )
                     }
                     composable(route = ConsentModalBottomSheetListDestination.route) {
                         ConsentModalBottomSheetListScreen(

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ApplicationSupportLocal.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ApplicationSupportLocal.kt
@@ -1,0 +1,276 @@
+package com.android.identity.testapp.provisioning.backend
+
+import com.android.identity.testapp.provisioning.openid4vci.toJson
+import com.android.identity.testapp.provisioning.openid4vci.validateDeviceAssertionBindingKeys
+import kotlinx.coroutines.flow.FlowCollector
+import kotlinx.datetime.Clock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.decodeToString
+import kotlinx.io.bytestring.encodeToByteString
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.put
+import org.multipaz.asn1.OID
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.Crypto
+import org.multipaz.crypto.EcPrivateKey
+import org.multipaz.crypto.X509Cert
+import org.multipaz.device.AssertionDPoPKey
+import org.multipaz.device.DeviceAssertion
+import org.multipaz.device.DeviceAttestationAndroid
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.provisioning.LandingUrlNotification
+import org.multipaz.provisioning.LandingUrlUnknownException
+import org.multipaz.provisioning.ProvisioningBackendSettings
+import org.multipaz.rpc.annotation.RpcState
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.Configuration
+import org.multipaz.rpc.backend.getTable
+import org.multipaz.rpc.handler.RpcAuthInspectorAssertion
+import org.multipaz.securearea.KeyAttestation
+import org.multipaz.storage.NoRecordStorageException
+import org.multipaz.storage.StorageTableSpec
+import org.multipaz.util.Logger
+import org.multipaz.util.toBase64Url
+import org.multipaz.util.validateAndroidKeyAttestation
+import kotlin.time.Duration.Companion.hours
+import kotlin.time.Duration.Companion.minutes
+import kotlin.time.Duration.Companion.seconds
+
+/**
+ * [ApplicationSupport] implementation suitable for running in-app.
+ *
+ * NOTE: JWT assertion and attestations created on-device are not secure and suitable for testing
+ * or demo purposes only. This is because the private key used to sign them is not secret.
+ */
+@RpcState
+@CborSerializable
+class ApplicationSupportLocal(
+    val clientId: String
+): ApplicationSupport {
+    companion object {
+        const val TAG = "ApplicationSupportLocal"
+
+        // This must match what is specified in application's AndroidManifest.xml
+        // intent filter for app links for Android or in XCode universal link
+        // properties for iOS.
+        const val APP_LINK_SERVER = "https://apps.multipaz.org"
+        const val APP_LINK_BASE_URL = "$APP_LINK_SERVER/landing/"
+
+        private val urlTableSpec = StorageTableSpec(
+            name = "LandingUrls",
+            supportPartitions = false,
+            supportExpiration = true
+        )
+
+        private val localClientAssertionCertificate = X509Cert.fromPem("""
+                -----BEGIN CERTIFICATE-----
+                MIIBxTCCAUugAwIBAgIJAOQTL9qcQopZMAoGCCqGSM49BAMDMDgxNjA0BgNVBAMT
+                LXVybjp1dWlkOjYwZjhjMTE3LWI2OTItNGRlOC04ZjdmLTYzNmZmODUyYmFhNjAe
+                Fw0yNDA5MjMyMjUxMzFaFw0zNDA5MjMyMjUxMzFaMDgxNjA0BgNVBAMTLXVybjp1
+                dWlkOjYwZjhjMTE3LWI2OTItNGRlOC04ZjdmLTYzNmZmODUyYmFhNjB2MBAGByqG
+                SM49AgEGBSuBBAAiA2IABN4D7fpNMAv4EtxyschbITpZ6iNH90rGapa6YEO/uhKn
+                C6VpPt5RUrJyhbvwAs0edCPthRfIZwfwl5GSEOS0mKGCXzWdRv4GGX/Y0m7EYypo
+                x+tzfnRTmoVX3v6OxQiapKMhMB8wHQYDVR0OBBYEFPqAK5EjiQbxFAeWt//DCaWt
+                C57aMAoGCCqGSM49BAMDA2gAMGUCMEO01fJKCy+iOTpaVp9LfO7jiXcXksn2BA22
+                reiR9ahDRdGNCrH1E3Q2umQAssSQbQIxAIz1FTHbZPcEbA5uE5lCZlRG/DQxlZhk
+                /rZrkPyXFhqEgfMnQ45IJ6f8Utlg+4Wiiw==
+                -----END CERTIFICATE-----
+            """.trimIndent()
+        )
+
+        private val localClientAssertionPrivateKey = EcPrivateKey.fromPem("""
+            -----BEGIN PRIVATE KEY-----
+            ME4CAQAwEAYHKoZIzj0CAQYFK4EEACIENzA1AgEBBDBn7jeRC9u9de3kOkrt9lLT
+            Pvd1hflNq1FCgs7D+qbbwz1BQa4XXU0SjsV+R1GjnAY=
+            -----END PRIVATE KEY-----
+            """.trimIndent(),
+            localClientAssertionCertificate.ecPublicKey
+        )
+
+        // NB: this identifies the test app (not a specific instance of the test app)
+        private val localClientId =
+            localClientAssertionCertificate.subject.components[OID.COMMON_NAME.oid]?.value
+                ?: throw IllegalStateException("No common name (CN) in certificate's subject")
+    }
+
+    override suspend fun createLandingUrl(): String {
+        val table = BackendEnvironment.getTable(urlTableSpec)
+        val landingId = table.insert(
+            key = null,
+            data = ByteString(),
+            expiration = Clock.System.now() + 5.hours
+        )
+        return APP_LINK_BASE_URL + landingId
+    }
+
+    /**
+     * Should be called by the app when an app link / universal link is resolved.
+     */
+    suspend fun onLandingUrlNavigated(url: String) {
+        val index = url.indexOf('?')
+        if (index < 0) {
+            Logger.e(TAG, "Invalid landing url: '$url'")
+            return
+        }
+        val landingUrl = url.substring(0, index)
+        if (!landingUrl.startsWith(APP_LINK_BASE_URL)) {
+            Logger.e(TAG, "Not a landing url: '$url'")
+            return
+        }
+        val id = landingUrl.substring(APP_LINK_BASE_URL.length)
+        val query = url.substring(index + 1)
+        val table = BackendEnvironment.getTable(urlTableSpec)
+        try {
+            table.update(id, query.encodeToByteString())
+        } catch (err: NoRecordStorageException) {
+            Logger.e(TAG, "No record for landing url: '$url'")
+            return
+        }
+        Logger.e(TAG, "Emitting notification for landing url: '$url'")
+        emit(LandingUrlNotification(landingUrl))
+    }
+
+    override suspend fun getLandingUrlStatus(landingUrl: String): String? {
+        if (!landingUrl.startsWith(APP_LINK_BASE_URL)) {
+            throw IllegalArgumentException("Not a landing url: '$landingUrl'")
+        }
+        val id = landingUrl.substring(APP_LINK_BASE_URL.length)
+        val table = BackendEnvironment.getTable(urlTableSpec)
+        val record = table.get(id)
+            ?: throw LandingUrlUnknownException("Unknown landing url: '$landingUrl'")
+        if (record.size == 0) {
+            // Exists, but was not resolved
+            return null
+        }
+        return record.decodeToString()
+    }
+
+    override suspend fun getClientAssertionId(targetIssuanceUrl: String): String {
+        return localClientId
+    }
+
+    override suspend fun createJwtClientAssertion(
+        keyAttestation: KeyAttestation,
+        deviceAssertion: DeviceAssertion
+    ): String {
+        // Do all the checks locally that we would have to do on the server to avoid surprises.
+        val deviceAttestation = RpcAuthInspectorAssertion.getClientDeviceAttestation(clientId)!!
+        deviceAttestation.validateAssertion(deviceAssertion)
+        val assertion = deviceAssertion.assertion as AssertionDPoPKey
+        if (deviceAttestation is DeviceAttestationAndroid) {
+            val settings = ProvisioningBackendSettings(BackendEnvironment.getInterface(Configuration::class)!!)
+            val certChain = keyAttestation.certChain!!
+            check(assertion.publicKey == certChain.certificates.first().ecPublicKey)
+            validateAndroidKeyAttestation(
+                certChain,
+                null,  // no challenge check needed
+                settings.androidRequireGmsAttestation,
+                settings.androidRequireVerifiedBootGreen,
+                settings.androidRequireAppSignatureCertificateDigests
+            )
+        }
+        check(keyAttestation.certChain!!.certificates[0].ecPublicKey == keyAttestation.publicKey)
+
+        // Now, generate the client assertion.
+        val alg = localClientAssertionPrivateKey.curve.defaultSigningAlgorithm.joseAlgorithmIdentifier
+        val head = buildJsonObject {
+            put("typ", "JWT")
+            put("alg", alg)
+            put("jwk", localClientAssertionCertificate.ecPublicKey.toJson(null))
+        }.toString().encodeToByteArray().toBase64Url()
+
+        val now = Clock.System.now()
+        val notBefore = now - 1.seconds
+        // Expiration here is only for the client assertion to be presented to the issuing server
+        // in the given timeframe (which happens without user interaction). It does not imply that
+        // the key becomes invalid at that point in time.
+        val expiration = now + 5.minutes
+        val payload = buildJsonObject {
+            put("iss", localClientId)
+            put("sub", localClientId) // RFC 7523 Section 3, item 2.B
+            put("cnf", buildJsonObject {
+                put("jwk", keyAttestation.publicKey.toJson(clientId))
+            })
+            put("nbf", notBefore.epochSeconds)
+            put("exp", expiration.epochSeconds)
+            put("iat", now.epochSeconds)
+        }.toString().encodeToByteArray().toBase64Url()
+
+        val message = "$head.$payload"
+        val sig = Crypto.sign(
+            key = localClientAssertionPrivateKey,
+            signatureAlgorithm = localClientAssertionPrivateKey.curve.defaultSigningAlgorithm,
+            message = message.encodeToByteArray()
+        )
+        val signature = sig.toCoseEncoded().toBase64Url()
+
+        return "$message.$signature"
+    }
+
+    override suspend fun createJwtKeyAttestation(
+        keyAttestations: List<KeyAttestation>,
+        keysAssertion: DeviceAssertion
+    ): String {
+        // Do all the checks locally that we would have to do on the server to avoid surprises.
+        val deviceAttestation = RpcAuthInspectorAssertion.getClientDeviceAttestation(clientId)!!
+        val assertion = validateDeviceAssertionBindingKeys(
+            deviceAttestation = deviceAttestation,
+            keyAttestations = keyAttestations,
+            deviceAssertion = keysAssertion,
+            nonce = null,  // no check
+        )
+
+        // Generate key attestation
+        val nonce = assertion.nonce.decodeToString()
+        val keyList = assertion.publicKeys
+
+        val alg = localClientAssertionPrivateKey.curve.defaultSigningAlgorithm.joseAlgorithmIdentifier
+        val head = buildJsonObject {
+            put("typ", "keyattestation+jwt")
+            put("alg", alg)
+            put("jwk", localClientAssertionCertificate.ecPublicKey.toJson(null))  // TODO: use x5c instead here?
+        }.toString().encodeToByteArray().toBase64Url()
+
+        val now = Clock.System.now()
+        val notBefore = now - 1.seconds
+        val expiration = now + 5.minutes
+        val payload = buildJsonObject {
+            put("iss", localClientId)
+            put("attested_keys", JsonArray(keyList.map { it.toJson(null) }))
+            put("nonce", nonce)
+            put("nbf", notBefore.epochSeconds)
+            put("exp", expiration.epochSeconds)
+            put("iat", now.epochSeconds)
+            if (assertion.userAuthentication.isNotEmpty()) {
+                put("user_authentication",
+                    JsonArray(assertion.userAuthentication.map { JsonPrimitive(it) })
+                )
+            }
+            if (assertion.keyStorage.isNotEmpty()) {
+                put("key_storage",
+                    JsonArray(assertion.keyStorage.map { JsonPrimitive(it) })
+                )
+            }
+        }.toString().encodeToByteArray().toBase64Url()
+
+        val message = "$head.$payload"
+        val sig = Crypto.sign(
+            key = localClientAssertionPrivateKey,
+            signatureAlgorithm = localClientAssertionPrivateKey.curve.defaultSigningAlgorithm,
+            message = message.encodeToByteArray()
+        )
+        val signature = sig.toCoseEncoded().toBase64Url()
+
+        return "$message.$signature"
+    }
+
+    override suspend fun collect(collector: FlowCollector<LandingUrlNotification>) {
+        collectImpl(collector)
+    }
+
+    override suspend fun dispose() {
+        disposeImpl()
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/BackendEnvironmentLocal.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/BackendEnvironmentLocal.kt
@@ -1,0 +1,92 @@
+package com.android.identity.testapp.provisioning.backend
+
+import io.ktor.client.HttpClient
+import io.ktor.client.engine.config
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.device.DeviceAssertionMaker
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.Configuration
+import org.multipaz.rpc.backend.Resources
+import org.multipaz.rpc.handler.NoopCipher
+import org.multipaz.rpc.handler.RpcAuthInspector
+import org.multipaz.rpc.handler.RpcAuthInspectorAssertion
+import org.multipaz.rpc.handler.RpcNotifications
+import org.multipaz.rpc.handler.RpcNotificationsLocal
+import org.multipaz.rpc.handler.RpcNotifier
+import org.multipaz.securearea.SecureAreaProvider
+import org.multipaz.storage.Storage
+import org.multipaz.testapp.platformHttpClientEngineFactory
+import org.multipaz.testapp.platformSecureAreaProvider
+import org.multipaz.testapp.platformStorage
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
+
+/**
+ * [BackendEnvironment] implementation for running provisioning back-end locally in-app.
+ */
+class BackendEnvironmentLocal(
+    applicationSupportProvider: () -> ApplicationSupportLocal,
+    private val deviceAssertionMaker: DeviceAssertionMaker
+): BackendEnvironment {
+    private var configuration = ConfigurationImpl()
+    private val storage = platformStorage()
+    private val resources = ResourcesImpl()
+    private val notificationsLocal = RpcNotificationsLocal(NoopCipher)
+    private val httpClient = HttpClient(platformHttpClientEngineFactory()) {
+        followRedirects = false
+    }
+    private val applicationSupportLocal by lazy(applicationSupportProvider)
+
+    override fun <T : Any> getInterface(clazz: KClass<T>): T? {
+        return clazz.cast(when(clazz) {
+            Configuration::class -> configuration
+            Resources::class -> resources
+            Storage::class -> storage
+            RpcNotifications::class -> notificationsLocal
+            RpcNotifier::class -> notificationsLocal
+            HttpClient::class -> httpClient
+            SecureAreaProvider::class -> platformSecureAreaProvider()
+            DeviceAssertionMaker::class -> deviceAssertionMaker
+            ApplicationSupport::class -> applicationSupportLocal
+            RpcAuthInspector::class -> RpcAuthInspectorAssertion.Default
+            else -> return null
+        })
+    }
+
+    // TODO: this should interface with the testapp settings
+    class ConfigurationImpl: Configuration {
+        override fun getValue(key: String): String? {
+            val value = when (key) {
+                "developerMode" -> "true"
+                "waitForNotificationSupported" -> "false"
+                "androidRequireGmsAttestation" -> "false"
+                "androidRequireVerifiedBootGreen" -> "false"
+                "androidRequireAppSignatureCertificateDigests" -> ""
+                "cloudSecureAreaUrl" -> "http://localhost:8080/server/csa"
+                else -> null
+            }
+            return value
+        }
+
+    }
+
+    class ResourcesImpl: Resources {
+        override fun getRawResource(name: String): ByteString? {
+            return null
+        }
+
+        override fun getStringResource(name: String): String? {
+            return when (name) {
+                "generic/tos.html" ->
+                    """
+                        <h2>Provisioning ${'$'}ID_NAME credential</h2>
+                        <p>In the following screens, information will be collected
+                          to provision <b>${'$'}ID_NAME</b> from <b>${'$'}ISSUER_NAME</b>.</p>
+                        <p>The created <b>${'$'}ID_NAME</b> will be bound to this device.</p>
+                    """.trimIndent()
+                else -> null
+            }
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendLocal.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendLocal.kt
@@ -1,0 +1,46 @@
+package com.android.identity.testapp.provisioning.backend
+
+import com.android.identity.testapp.provisioning.openid4vci.Openid4VciIssuingAuthorityState
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.provisioning.IssuingAuthority
+import org.multipaz.provisioning.IssuingAuthorityConfiguration
+import org.multipaz.provisioning.ProvisioningBackend
+import org.multipaz.rpc.annotation.RpcState
+import org.multipaz.rpc.backend.BackendEnvironment
+
+@RpcState
+@CborSerializable
+class ProvisioningBackendLocal(
+    val clientId: String
+): ProvisioningBackend {
+    override suspend fun applicationSupport(): ApplicationSupport {
+        return ApplicationSupportLocal(clientId)
+    }
+
+    override suspend fun getIssuingAuthorityConfigurations(): List<IssuingAuthorityConfiguration> {
+        return listOf()
+    }
+
+    override suspend fun getIssuingAuthority(identifier: String): IssuingAuthority {
+        if (identifier.startsWith("openid4vci#")) {
+            val parts = identifier.split("#")
+            if (parts.size != 3) {
+                throw IllegalStateException("Invalid openid4vci id")
+            }
+            val credentialIssuerUri = parts[1]
+            val credentialConfigurationId = parts[2]
+            val applicationSupport = BackendEnvironment.getInterface(ApplicationSupport::class)!!
+            val issuanceClientId = applicationSupport.getClientAssertionId(credentialIssuerUri)
+            return Openid4VciIssuingAuthorityState(
+                clientId = clientId,
+                credentialIssuerUri = credentialIssuerUri,
+                credentialConfigurationId = credentialConfigurationId,
+                issuanceClientId = issuanceClientId
+            )
+        }
+        throw IllegalArgumentException("No such issuing authority: '$identifier'")
+    }
+
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendProvider.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendProvider.kt
@@ -1,0 +1,43 @@
+package com.android.identity.testapp.provisioning.backend
+
+import kotlinx.coroutines.withContext
+import org.multipaz.device.DeviceAssertionMaker
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.provisioning.IssuingAuthority
+import org.multipaz.provisioning.ProvisioningBackend
+import kotlin.coroutines.CoroutineContext
+
+/**
+ * Interface that acquires and manages an instance of [ProvisioningBackend].
+ *
+ * Note: currently a direct access to [ProvisioningBackend] is not required, so this interface
+ * proxies access to it, caching information as needed.
+ */
+interface ProvisioningBackendProvider: DeviceAssertionMaker {
+    /**
+     * Provides required [CoroutineContext] data to communicate with the objects returned by
+     * this interface or acquired through them.
+     *
+     * Use [withContext] function to add this to the existing coroutine context.
+     */
+    val extraCoroutineContext: CoroutineContext
+
+    suspend fun getApplicationSupport(): ApplicationSupport
+    suspend fun getIssuingAuthority(issuingAuthorityId: String): IssuingAuthority
+}
+
+/**
+ * Creates an Issuing Authority by the [credentialIssuerUri] and [credentialConfigurationId],
+ * caching instances. If unable to connect, suspend and wait until connecting is possible.
+ */
+suspend fun ProvisioningBackendProvider.createOpenid4VciIssuingAuthorityByUri(
+    credentialIssuerUri:String,
+    credentialConfigurationId: String
+): IssuingAuthority {
+    // Not allowed per spec, but double-check, so there are no surprises.
+    check(credentialIssuerUri.indexOf('#') < 0)
+    check(credentialConfigurationId.indexOf('#') < 0)
+    val id = "openid4vci#$credentialIssuerUri#$credentialConfigurationId"
+    return getIssuingAuthority(id)
+}
+

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendProviderLocal.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendProviderLocal.kt
@@ -1,0 +1,97 @@
+package com.android.identity.testapp.provisioning.backend
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.decodeToString
+import kotlinx.io.bytestring.encodeToByteString
+import org.multipaz.device.Assertion
+import org.multipaz.device.DeviceAssertion
+import org.multipaz.device.toCbor
+import org.multipaz.device.DeviceCheck
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.provisioning.IssuingAuthority
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.getTable
+import org.multipaz.rpc.handler.RpcAuthContext
+import org.multipaz.rpc.handler.RpcAuthInspectorAssertion
+import org.multipaz.storage.StorageTableSpec
+import org.multipaz.testapp.platformSecureAreaProvider
+import kotlin.coroutines.CoroutineContext
+
+class ProvisioningBackendProviderLocal: ProvisioningBackendProvider {
+    private val lock = Mutex()
+    private var backend: ProvisioningBackendLocal? = null
+    private var applicationSupport: ApplicationSupportLocal? = null
+    private var deviceAttestationId: String? = null
+    private val backendEnvironmentLocal = BackendEnvironmentLocal(
+        applicationSupportProvider = { applicationSupport!! },
+        deviceAssertionMaker = this
+    )
+    private val coroutineContext = backendEnvironmentLocal + RpcAuthContext(CLIENT_ID)
+
+    override val extraCoroutineContext: CoroutineContext get() = coroutineContext
+
+    override suspend fun getApplicationSupport(): ApplicationSupportLocal {
+        init()
+        return applicationSupport!!
+    }
+
+    override suspend fun getIssuingAuthority(issuingAuthorityId: String): IssuingAuthority {
+        init()
+        return backend!!.getIssuingAuthority(issuingAuthorityId)
+    }
+
+    override suspend fun makeDeviceAssertion(
+        assertionFactory: (clientId: String) -> Assertion
+    ): DeviceAssertion {
+        init()
+        return DeviceCheck.generateAssertion(
+            secureArea = platformSecureAreaProvider().get(),
+            deviceAttestationId = deviceAttestationId!!,
+            assertion = assertionFactory(CLIENT_ID)
+        )
+    }
+
+    private suspend fun init() {
+        lock.withLock {
+            if (backend != null) {
+                return
+            }
+            val deviceAttestationIdTable = BackendEnvironment.getTable(deviceAttestationLocalStore)
+            var deviceAttestation = RpcAuthInspectorAssertion.getClientDeviceAttestation(CLIENT_ID)
+            if (deviceAttestation != null) {
+                deviceAttestationId = deviceAttestationIdTable.get(CLIENT_ID)!!.decodeToString()
+            } else {
+                val clientTable =
+                    BackendEnvironment.getTable(RpcAuthInspectorAssertion.rpcClientTableSpec)
+                val newAttestationResult = DeviceCheck.generateAttestation(
+                    secureArea = platformSecureAreaProvider().get(),
+                    challenge = CLIENT_ID.encodeToByteString()
+                )
+                deviceAttestation = newAttestationResult.deviceAttestation
+                deviceAttestationId = newAttestationResult.deviceAttestationId
+                clientTable.insert(
+                    key = CLIENT_ID,
+                    data = ByteString(deviceAttestation.toCbor())
+                )
+                deviceAttestationIdTable.insert(
+                    key = CLIENT_ID,
+                    data = deviceAttestationId!!.encodeToByteString()
+                )
+            }
+            backend = ProvisioningBackendLocal(CLIENT_ID)
+            applicationSupport = ApplicationSupportLocal(CLIENT_ID)
+        }
+    }
+
+    companion object {
+        private val deviceAttestationLocalStore = StorageTableSpec(
+            name = "DeviceAttestationLocal",
+            supportPartitions = false,
+            supportExpiration = false
+        )
+
+        const val CLIENT_ID = "__LOCAL__"
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ServerData.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ServerData.kt
@@ -1,4 +1,4 @@
-package org.multipaz.testapp.provisioning
+package com.android.identity.testapp.provisioning.backend
 
 import org.multipaz.cbor.annotation.CborSerializable
 

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/WalletHttpTransport.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/WalletHttpTransport.kt
@@ -1,4 +1,4 @@
-package org.multipaz.testapp.provisioning
+package com.android.identity.testapp.provisioning.backend
 
 import org.multipaz.rpc.transport.HttpTransport
 import org.multipaz.util.Logger

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/model/ProvisioningModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/model/ProvisioningModel.kt
@@ -1,0 +1,339 @@
+package com.android.identity.testapp.provisioning.model
+
+import com.android.identity.testapp.provisioning.backend.ProvisioningBackendProvider
+import com.android.identity.testapp.provisioning.backend.createOpenid4VciIssuingAuthorityByUri
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.withContext
+import kotlinx.datetime.Clock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.multipaz.credential.Credential
+import org.multipaz.credential.SecureAreaBoundCredential
+import org.multipaz.device.AssertionBindingKeys
+import org.multipaz.document.Document
+import org.multipaz.document.DocumentStore
+import org.multipaz.mdoc.credential.MdocCredential
+import org.multipaz.prompt.PromptModel
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.provisioning.CredentialRequest
+import org.multipaz.provisioning.RegistrationResponse
+import org.multipaz.provisioning.evidence.EvidenceRequest
+import org.multipaz.provisioning.evidence.EvidenceRequestCredentialOffer
+import org.multipaz.provisioning.evidence.EvidenceRequestOpenid4Vp
+import org.multipaz.provisioning.evidence.EvidenceResponse
+import org.multipaz.provisioning.evidence.EvidenceResponseCredentialOffer
+import org.multipaz.provisioning.evidence.Openid4VciCredentialOffer
+import org.multipaz.sdjwt.credential.KeylessSdJwtVcCredential
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.testapp.TestAppDocumentMetadata
+import org.multipaz.util.Logger
+import org.multipaz.util.fromBase64Url
+
+class ProvisioningModel(
+    private val provisioningBackendProvider: ProvisioningBackendProvider,
+    private val documentStore: DocumentStore,
+    private val promptModel: PromptModel,
+    private val secureAreaRepository: SecureAreaRepository
+) {
+    private var pendingOffer: Openid4VciCredentialOffer? = null
+
+    private var mutableState = MutableSharedFlow<State>()
+
+    val state: SharedFlow<State> get() = mutableState
+
+    private var privateApplicationSupport: ApplicationSupport? = null
+
+    val applicationSupport: ApplicationSupport get() = privateApplicationSupport!!
+
+    private val evidenceResponseChannel = Channel<EvidenceResponse>()
+
+    fun startProvisioning(offer: Openid4VciCredentialOffer) {
+        pendingOffer = offer
+    }
+
+    suspend fun provideEvidence(evidence: EvidenceResponse) {
+        Logger.i(TAG, "Providing evidence: ${evidence::class.simpleName}")
+        evidenceResponseChannel.send(evidence)
+    }
+
+    val coroutineContext =
+        Dispatchers.Default + promptModel + provisioningBackendProvider.extraCoroutineContext
+
+
+    /**
+     * Run provisioning model.
+     *
+     * It must be run in a coroutine scope that is cancelled when provisioning UI is
+     * navigated away from.
+     */
+    suspend fun run(): Document? {
+        val offer = pendingOffer ?: return null
+        pendingOffer = null
+        return withContext(coroutineContext) {
+            try {
+                runProvisioning(offer)
+            } finally {
+                privateApplicationSupport = null
+            }
+        }
+    }
+
+    private suspend fun runProvisioning(offer: Openid4VciCredentialOffer): Document {
+        mutableState.emit(Initial)
+        privateApplicationSupport = provisioningBackendProvider.getApplicationSupport()
+        mutableState.emit(Connected)
+        val issuingAuthority = provisioningBackendProvider.createOpenid4VciIssuingAuthorityByUri(
+            offer.issuerUri,
+            offer.configurationId
+        )
+        val issuerConfiguration = issuingAuthority.getConfiguration()
+
+        Logger.i(TAG, "Start registration")
+        mutableState.emit(Registration)
+        val registration = issuingAuthority.register()
+        val documentRegistrationConfiguration =
+            registration.getDocumentRegistrationConfiguration()
+        val issuerDocumentIdentifier = documentRegistrationConfiguration.documentId
+        val response = RegistrationResponse(
+            developerModeEnabled = false
+        )
+        registration.sendDocumentRegistrationResponse(response)
+        issuingAuthority.completeRegistration(registration)
+        Logger.i(TAG, "Registration complete")
+
+        val pendingDocumentConfiguration = issuerConfiguration.pendingDocumentInformation
+        val document = documentStore.createDocument { metadata ->
+            val testMetadata = metadata as TestAppDocumentMetadata
+            testMetadata.initialize(
+                displayName = pendingDocumentConfiguration.displayName,
+                typeDisplayName = pendingDocumentConfiguration.typeDisplayName,
+                cardArt = ByteString(pendingDocumentConfiguration.cardArt)
+            )
+        }
+
+        Logger.i(TAG, "Start proofing")
+        val proofing = issuingAuthority.proof(issuerDocumentIdentifier)
+        var evidenceRequests = proofing.getEvidenceRequests()
+
+        // EvidenceRequestCredentialOffer (if requested at all) is always the first request.
+        if (evidenceRequests.isNotEmpty() &&
+            evidenceRequests[0] is EvidenceRequestCredentialOffer
+        ) {
+            Logger.i(TAG, "Sending credential offer")
+            proofing.sendEvidence(EvidenceResponseCredentialOffer(offer))
+            evidenceRequests = proofing.getEvidenceRequests()
+        }
+
+        while (evidenceRequests.isNotEmpty()) {
+            val requestsAsText = evidenceRequests.map { it::class.simpleName }.joinToString(" ")
+            Logger.i(TAG, "Requesting evidence: $requestsAsText")
+            mutableState.emit(selectViableEvidenceRequests(evidenceRequests))
+            val evidence = evidenceResponseChannel.receive()
+            Logger.i(TAG, "Sending evidence: ${evidence::class.simpleName}")
+            mutableState.emit(SendingEvidence)
+            proofing.sendEvidence(evidence)
+            Logger.i(TAG, "Processing evidence")
+            mutableState.emit(ProcessingEvidence)
+            evidenceRequests = proofing.getEvidenceRequests()
+        }
+
+        Logger.i(TAG, "Proofing complete")
+        mutableState.emit(ProofingComplete)
+
+        issuingAuthority.completeProof(proofing)
+
+        issuingAuthority.getState(issuerDocumentIdentifier)
+
+        val credentialCount = issuerConfiguration.numberOfCredentialsToRequest ?: 3
+        val documentConfiguration = issuingAuthority.getDocumentConfiguration(issuerDocumentIdentifier)
+        // get the initial set of credentials
+        val credentialWorkflow = issuingAuthority.requestCredentials(issuerDocumentIdentifier)
+        val mdocConfiguration = documentConfiguration.mdocConfiguration
+        val (pendingCredentials, credentialConfiguration) = if (mdocConfiguration != null) {
+            val credentialConfiguration =
+                credentialWorkflow.getCredentialConfiguration(CredentialFormat.MDOC_MSO)
+            val (secureArea, createKeySettings) = secureAreaRepository.byConfiguration(
+                credentialConfiguration.secureAreaConfiguration,
+                credentialConfiguration.challenge
+            )
+            val pending = (0..<credentialCount).map {
+                MdocCredential.create(
+                    document = document,
+                    asReplacementForIdentifier = null,
+                    domain = CREDENTIAL_DOMAIN_MDOC,
+                    secureArea = secureArea,
+                    docType = mdocConfiguration.docType,
+                    createKeySettings = createKeySettings
+                )
+            }
+            Pair(pending, credentialConfiguration)
+        } else {
+            throw IllegalArgumentException("not yet supported")
+        }
+
+        val credentialRequests = mutableListOf<CredentialRequest>()
+        for (pendingCredential in pendingCredentials) {
+            credentialRequests.add(
+                CredentialRequest(
+                    (pendingCredential as SecureAreaBoundCredential).getAttestation()
+                )
+            )
+        }
+        val keysAssertion = if (credentialConfiguration.keyAssertionRequired) {
+            provisioningBackendProvider.makeDeviceAssertion { clientId ->
+                AssertionBindingKeys(
+                    publicKeys = credentialRequests.map { request ->
+                        request.secureAreaBoundKeyAttestation.publicKey
+                    },
+                    nonce = credentialConfiguration.challenge,
+                    clientId = clientId,
+                    keyStorage = listOf(),
+                    userAuthentication = listOf(),
+                    issuedAt = Clock.System.now()
+                )
+            }
+        } else {
+            null
+        }
+
+        mutableState.emit(RequestingCredentials)
+
+        val challenges = credentialWorkflow.sendCredentials(
+            credentialRequests = credentialRequests,
+            keysAssertion = keysAssertion
+        )
+        if (challenges.isNotEmpty()) {
+            throw IllegalArgumentException("Not yet supported")
+        }
+        issuingAuthority.completeRequestCredentials(credentialWorkflow)
+
+        val documentState = issuingAuthority.getState(issuerDocumentIdentifier)
+        if (documentState.numAvailableCredentials > 0) {
+            for (credentialData in issuingAuthority.getCredentials(issuerDocumentIdentifier)) {
+                val pendingCredential = if (credentialData.secureAreaBoundKey == null) {
+                    // Keyless credential
+                    KeylessSdJwtVcCredential.create(
+                        document,
+                        null,
+                        CREDENTIAL_DOMAIN_SD_JWT_VC,
+                        documentConfiguration.sdJwtVcDocumentConfiguration!!.vct
+                    )
+                } else {
+                    pendingCredentials.find {
+                        val attestation = (it as SecureAreaBoundCredential).getAttestation()
+                        attestation.publicKey == credentialData.secureAreaBoundKey
+                    }
+                }
+                if (pendingCredential == null) {
+                    Logger.w(TAG, "No pending Credential for pubkey ${credentialData.secureAreaBoundKey}")
+                    continue
+                }
+                pendingCredential.certify(
+                    credentialData.data,
+                    credentialData.validFrom,
+                    credentialData.validUntil
+                )
+            }
+        }
+
+        mutableState.emit(CredentialsIssued)
+
+        return document
+    }
+
+    private suspend fun selectViableEvidenceRequests(
+        evidenceRequests: List<EvidenceRequest>
+    ): EvidenceRequested {
+        val viableRequests = mutableListOf<EvidenceRequest>()
+        val viableCredentials = mutableListOf<Credential>()
+        for (request in evidenceRequests) {
+            if (request is EvidenceRequestOpenid4Vp) {
+                if (viableCredentials.isEmpty()) {
+                    val credentials = selectCredentials(request.request)
+                    if (credentials.isNotEmpty()) {
+                        viableRequests.add(request)
+                        viableCredentials.addAll(credentials)
+                    }
+                }
+            } else {
+                viableRequests.add(request)
+            }
+        }
+        return EvidenceRequested(viableRequests.toList(), viableCredentials.toList())
+    }
+
+    private suspend fun selectCredentials(request: String): List<Credential> {
+        val parts = request.split('.')
+        val openid4vpRequest =
+            Json.parseToJsonElement(parts[1].fromBase64Url().decodeToString()).jsonObject
+        val presentationDefinition = openid4vpRequest["presentation_definition"]!!.jsonObject
+        val inputDescriptors = presentationDefinition["input_descriptors"]!!.jsonArray
+        if (inputDescriptors.size != 1) {
+            throw IllegalArgumentException("Only support a single input input_descriptor")
+        }
+        val inputDescriptor = inputDescriptors[0].jsonObject
+        val docType = inputDescriptor["id"]!!.jsonPrimitive.content
+
+        // For now, we only respond to the first credential being requested.
+        //
+        // NOTE: openid4vp spec gives a non-normative example of multiple input descriptors
+        // as "alternatives credentials", see
+        //
+        //  https://openid.net/specs/openid-4-verifiable-presentations-1_0.html#section-5.1-6
+        //
+        // Also note identity.foundation says all input descriptors MUST be satisfied, see
+        //
+        //  https://identity.foundation/presentation-exchange/spec/v2.0.0/#input-descriptor
+        //
+        return selectMatchingCredentials(docType)
+    }
+
+    private suspend fun selectMatchingCredentials(
+        docType: String
+    ): List<Credential> {
+        val credentials = mutableListOf<Credential>()
+        val now = Clock.System.now()
+        for (documentId in documentStore.listDocuments()) {
+            val document = documentStore.lookupDocument(documentId) ?: continue
+            for (credential in document.getCertifiedCredentials()) {
+                if (credential is MdocCredential && credential.validUntil > now) {
+                    if (credential.docType == docType) {
+                        credentials.add(credential)
+                        break
+                    }
+                }
+            }
+        }
+        return credentials.toList()
+    }
+
+    sealed class State
+
+    object Initial: State()
+    object Connected: State()
+    object Registration: State()
+    object SendingEvidence: State()
+    object ProcessingEvidence: State()
+    object ProofingComplete: State()
+    object RequestingCredentials: State()
+    object CredentialsIssued: State()
+
+    data class EvidenceRequested(
+        val evidenceRequests: List<EvidenceRequest>,
+        val credentials: List<Credential>
+    ): State()
+
+    companion object {
+        const val CREDENTIAL_DOMAIN_MDOC = "mdoc/MSO"
+        const val CREDENTIAL_DOMAIN_SD_JWT_VC = "SD-JWT"
+
+        const val TAG = "ProvisioningModel"
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.kt
@@ -1,0 +1,12 @@
+package com.android.identity.testapp.provisioning.model
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.securearea.config.SecureAreaConfiguration
+
+expect suspend fun SecureAreaRepository.byConfiguration(
+    secureAreaConfiguration: SecureAreaConfiguration,
+    challenge: ByteString
+): Pair<SecureArea, CreateKeySettings>

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/AbstractRequestCredentials.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/AbstractRequestCredentials.kt
@@ -1,0 +1,10 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.provisioning.CredentialConfiguration
+import org.multipaz.provisioning.CredentialFormat
+
+interface AbstractRequestCredentials {
+    val documentId: String
+    val credentialConfiguration: CredentialConfiguration
+    var format: CredentialFormat?
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/CredentialRequestSet.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/CredentialRequestSet.kt
@@ -1,0 +1,15 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.device.DeviceAssertion
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.securearea.KeyAttestation
+
+@CborSerializable
+class CredentialRequestSet(
+    val format: CredentialFormat,
+    val keyAttestations: List<KeyAttestation>,
+    val keysAssertion: DeviceAssertion  // holds AssertionBindingKeys
+) {
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/FormUrlEncoder.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/FormUrlEncoder.kt
@@ -1,0 +1,30 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import io.ktor.http.encodeURLParameter
+
+class FormUrlEncoder(block: FormUrlEncoder.() -> Unit) {
+    private val buffer = StringBuilder()
+
+    init {
+        this.block()
+    }
+
+    fun add(name: String, value: String) {
+        if (buffer.isNotEmpty()) {
+            buffer.append("&")
+        }
+        buffer.append(encode(name))
+        buffer.append("=")
+        buffer.append(encode(value))
+    }
+
+    override fun toString(): String {
+        return buffer.toString()
+    }
+
+    companion object {
+        fun encode(text: String): String {
+            return text.encodeURLParameter()
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/JwtUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/JwtUtils.kt
@@ -1,0 +1,16 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.sdjwt.util.JsonWebKey
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+internal fun EcPublicKey.toJson(keyId: String?): JsonObject {
+    return JsonWebKey(this).toRawJwk {
+        if (keyId != null) {
+            put("kid", JsonPrimitive(keyId))
+        }
+        put("alg", JsonPrimitive(curve.defaultSigningAlgorithm.joseAlgorithmIdentifier))
+        put("use", JsonPrimitive("sig"))
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/KeyAttestationCredentialRequest.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/KeyAttestationCredentialRequest.kt
@@ -1,0 +1,14 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.provisioning.CredentialRequest
+
+@CborSerializable
+data class KeyAttestationCredentialRequest(
+    val request: MutableList<CredentialRequest>,
+    val format: CredentialFormat,
+    val jwtKeyAttestation: String
+) {
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/Openid4VciIssuerDocument.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/Openid4VciIssuerDocument.kt
@@ -1,0 +1,19 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.provisioning.CredentialData
+import org.multipaz.provisioning.DocumentCondition
+import org.multipaz.provisioning.DocumentConfiguration
+import org.multipaz.provisioning.RegistrationResponse
+
+@CborSerializable
+data class Openid4VciIssuerDocument(
+    val registrationResponse: RegistrationResponse,
+    var state: DocumentCondition = DocumentCondition.PROOFING_REQUIRED,
+    var access: OpenidAccess? = null,
+    var documentConfiguration: DocumentConfiguration? = null,
+    var secureAreaIdentifier: String? = null,
+    val credentials: MutableList<CredentialData> = mutableListOf()
+) {
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/Openid4VciIssuingAuthorityState.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/Openid4VciIssuingAuthorityState.kt
@@ -1,0 +1,696 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.Cbor
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.crypto.EcPublicKey
+import org.multipaz.document.NameSpacedData
+import org.multipaz.documenttype.DocumentType
+import org.multipaz.documenttype.DocumentTypeRepository
+import org.multipaz.documenttype.knowntypes.DrivingLicense
+import org.multipaz.documenttype.knowntypes.EUCertificateOfResidence
+import org.multipaz.documenttype.knowntypes.EUPersonalID
+import org.multipaz.documenttype.knowntypes.PhotoID
+import org.multipaz.documenttype.knowntypes.UtopiaMovieTicket
+import org.multipaz.documenttype.knowntypes.UtopiaNaturalization
+import org.multipaz.rpc.annotation.RpcState
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.provisioning.CredentialConfiguration
+import org.multipaz.provisioning.CredentialData
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.provisioning.DocumentCondition
+import org.multipaz.provisioning.DocumentConfiguration
+import org.multipaz.provisioning.DocumentState
+import org.multipaz.provisioning.IssuingAuthority
+import org.multipaz.provisioning.IssuingAuthorityConfiguration
+import org.multipaz.provisioning.IssuingAuthorityException
+import org.multipaz.provisioning.IssuingAuthorityNotification
+import org.multipaz.provisioning.MdocDocumentConfiguration
+import org.multipaz.provisioning.RegistrationResponse
+import org.multipaz.provisioning.SdJwtVcDocumentConfiguration
+import org.multipaz.securearea.config.SecureAreaConfigurationAndroidKeystore
+import org.multipaz.securearea.config.SecureAreaConfigurationCloud
+import org.multipaz.rpc.backend.getTable
+import org.multipaz.mdoc.mso.MobileSecurityObjectParser
+import org.multipaz.mdoc.mso.StaticAuthDataParser
+import org.multipaz.sdjwt.SdJwtVerifiableCredential
+import org.multipaz.sdjwt.vc.JwtBody
+import org.multipaz.storage.StorageTableSpec
+import org.multipaz.util.Logger
+import org.multipaz.util.fromBase64Url
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.io.bytestring.ByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.multipaz.crypto.Algorithm
+import org.multipaz.provisioning.Proofing
+import org.multipaz.provisioning.Registration
+import org.multipaz.provisioning.RequestCredentials
+import org.multipaz.rpc.backend.RpcAuthBackendDelegate
+import org.multipaz.rpc.handler.RpcAuthContext
+import org.multipaz.rpc.handler.RpcAuthInspector
+import kotlin.time.Duration.Companion.seconds
+
+@RpcState(endpoint = "openid4vci")
+@CborSerializable
+class Openid4VciIssuingAuthorityState(
+    // NB: since this object is used to emit notifications, it cannot change, as its state
+    // serves as notification key. So it generally should not have var members, only val.
+    // This is also a reason to keep clientId here (so that different clients get different keys)
+    val clientId: String,
+    val credentialIssuerUri: String, // credential offer issuing authority path
+    val credentialConfigurationId: String,
+    val issuanceClientId: String // client id in OpenID4VCI protocol
+) : IssuingAuthority, RpcAuthInspector by RpcAuthBackendDelegate {
+
+    init {
+        // It should not be possible, but double-check.
+        check(credentialIssuerUri.indexOf('#') < 0)
+        check(credentialConfigurationId.indexOf('#') < 0)
+    }
+
+    companion object {
+        private const val TAG = "Openid4VciIssuingAuthorityState"
+
+        val documentTableSpec = StorageTableSpec(
+            name = "Openid4VciIssuerDocument",
+            supportExpiration = false,
+            supportPartitions = true
+        )
+
+        suspend fun getConfiguration(
+            issuerUrl: String,
+            credentialConfigurationId: String
+        ): IssuingAuthorityConfiguration {
+            val id = "openid4vci#$issuerUrl#$credentialConfigurationId"
+            return BackendEnvironment.cache(IssuingAuthorityConfiguration::class, id) { _, resources ->
+                val metadata = Openid4VciIssuerMetadata.get(issuerUrl)
+                val config = metadata.credentialConfigurations[credentialConfigurationId]
+                    ?: throw IllegalArgumentException("Unknown configuration '$credentialConfigurationId' at '$issuerUrl'")
+                if (!config.isSupported) {
+                    throw IllegalArgumentException("Unsupported configuration '$credentialConfigurationId' at '$issuerUrl'")
+                }
+                val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+                val display = if (metadata.display.isEmpty()) null else metadata.display[0]
+                val configDisplay = if (config.display.isEmpty()) null else config.display[0]
+                var logo: ByteArray? = null
+                if (display?.logoUrl != null) {
+                    val logoRequest = httpClient.get(display.logoUrl) {}
+                    if (logoRequest.status == HttpStatusCode.OK &&
+                        logoRequest.contentType()?.contentType == "image") {
+                        logo = logoRequest.readBytes()
+                    } else {
+                        Logger.e(TAG, "Could not fetch logo from '${display.logoUrl}")
+                    }
+                }
+
+                val docType = documentTypeRepository.documentTypes.firstOrNull { documentType ->
+                    return@firstOrNull when (config.format) {
+                        is Openid4VciFormatMdoc ->
+                            documentType.mdocDocumentType?.docType == config.format.docType
+                        is Openid4VciFormatSdJwt ->
+                            documentType.vcDocumentType?.type == config.format.vct
+                        null -> false
+                    }
+                }
+
+                val documentType = docType?.displayName ?: "Generic EAA"
+                val documentDescription = configDisplay?.text ?: documentType
+                val issuingAuthorityDescription = "$documentDescription (${config.format?.id})"
+
+                var cardArt: ByteArray? = null
+                if (configDisplay?.logoUrl != null) {
+                    val artRequest = httpClient.get(configDisplay.logoUrl) {}
+                    if (artRequest.status == HttpStatusCode.OK &&
+                        artRequest.contentType()?.contentType == "image") {
+                        cardArt = artRequest.readBytes()
+                    } else {
+                        Logger.e(TAG,
+                            "Could not fetch credential image from '${configDisplay.logoUrl}")
+                    }
+                }
+                if (logo == null) {
+                    val artPath = "generic/logo.png"
+                    logo = resources.getRawResource(artPath)!!.toByteArray()
+                }
+                if (cardArt == null) {
+                    val artPath = "generic/card_art.png"
+                    cardArt = resources.getRawResource(artPath)!!.toByteArray()
+                }
+                val requireUserAuthenticationToViewDocument = false
+                val keyAttestation = config.proofType is Openid4VciProofTypeKeyAttestation
+                IssuingAuthorityConfiguration(
+                    identifier = id,
+                    issuingAuthorityName = display?.text ?: issuerUrl,
+                    issuingAuthorityLogo = logo,
+                    issuingAuthorityDescription = issuingAuthorityDescription,
+                    pendingDocumentInformation = DocumentConfiguration(
+                        displayName = documentDescription,
+                        typeDisplayName = documentType,
+                        cardArt = cardArt,
+                        requireUserAuthenticationToViewDocument = requireUserAuthenticationToViewDocument,
+                        mdocConfiguration = null,
+                        sdJwtVcDocumentConfiguration = null,
+                        directAccessConfiguration = null
+                    ),
+                    // Without key attestation user has to do biometrics approval for every
+                    // credential being issued, so request only one. With key attestation we can
+                    // use batch issuance (useful for unlinkability).
+                    numberOfCredentialsToRequest =
+                        if (keyAttestation) { 3 } else { 1 },
+                    // With key attestation credentials can be requested in the background as they
+                    // are used up, so direct wallet to avoid reusing them (for unlinkability).
+                    maxUsesPerCredentials =
+                        if (keyAttestation) { 1 } else { Int.MAX_VALUE },
+                    minCredentialValidityMillis = 30 * 24 * 3600L,
+                )
+            }
+        }
+
+        val documentTypeRepository = DocumentTypeRepository().apply {
+            addDocumentType(EUPersonalID.getDocumentType())
+            addDocumentType(DrivingLicense.getDocumentType())
+            addDocumentType(PhotoID.getDocumentType())
+            addDocumentType(EUCertificateOfResidence.getDocumentType())
+            addDocumentType(UtopiaNaturalization.getDocumentType())
+            addDocumentType(UtopiaMovieTicket.getDocumentType())
+        }
+    }
+
+    override suspend fun getConfiguration(): IssuingAuthorityConfiguration {
+        checkClientId()
+        return getConfiguration(credentialIssuerUri, credentialConfigurationId)
+    }
+
+    override suspend fun register(): Registration {
+        checkClientId()
+        val documentId = createIssuerDocument(
+            Openid4VciIssuerDocument(RegistrationResponse(false))
+        )
+        return Openid4VciRegistrationState(documentId)
+    }
+
+    override suspend fun completeRegistration(registration: Registration) {
+        checkClientId()
+        val registrationState = registration as Openid4VciRegistrationState
+        updateIssuerDocument(
+            registrationState.documentId,
+            Openid4VciIssuerDocument(registrationState.response!!))
+    }
+
+    override suspend fun getState(documentId: String): DocumentState {
+        checkClientId()
+        val now = Clock.System.now()
+
+        if (!issuerDocumentExists(documentId)) {
+            return DocumentState(
+                now,
+                DocumentCondition.NO_SUCH_DOCUMENT,
+                0,
+                0
+            )
+        }
+
+        val issuerDocument = loadIssuerDocument(documentId)
+
+        if (issuerDocument.state == DocumentCondition.PROOFING_PROCESSING) {
+            issuerDocument.state = if (issuerDocument.access != null) {
+                DocumentCondition.CONFIGURATION_AVAILABLE
+            } else {
+                DocumentCondition.PROOFING_FAILED
+            }
+            updateIssuerDocument(documentId, issuerDocument)
+        }
+
+        // This information is helpful for when using the admin web interface.
+        Logger.i(
+            TAG, "Returning state for clientId=$clientId documentId=$documentId")
+
+        // We create and sign Credential requests immediately so numPendingCredentialRequests is
+        // always 0
+        return DocumentState(
+            now,
+            issuerDocument.state,
+            0,
+            issuerDocument.credentials.size
+        )
+    }
+
+    override suspend fun proof(documentId: String): Openid4VciProofingState {
+        checkClientId()
+        return Openid4VciProofingState(
+            clientId = clientId,
+            credentialConfigurationId = credentialConfigurationId,
+            issuanceClientId = issuanceClientId,
+            documentId = documentId,
+            credentialIssuerUri = credentialIssuerUri
+        )
+    }
+
+    override suspend fun completeProof(proofing: Proofing) {
+        checkClientId()
+        val state = proofing as Openid4VciProofingState
+        val issuerDocument = loadIssuerDocument(state.documentId)
+        issuerDocument.state = DocumentCondition.PROOFING_PROCESSING
+        issuerDocument.access = state.access
+        issuerDocument.secureAreaIdentifier = state.secureAreaIdentifier
+        updateIssuerDocument(state.documentId, issuerDocument)
+    }
+
+    override suspend fun getDocumentConfiguration(
+        documentId: String
+    ): DocumentConfiguration {
+        checkClientId()
+        val issuerDocument = loadIssuerDocument(documentId)
+        check(issuerDocument.state == DocumentCondition.CONFIGURATION_AVAILABLE)
+        issuerDocument.state = DocumentCondition.READY
+        if (issuerDocument.documentConfiguration == null) {
+            issuerDocument.documentConfiguration = generateGenericDocumentConfiguration()
+            val metadata = Openid4VciIssuerMetadata.get(credentialIssuerUri)
+            val credentialConfiguration =
+                metadata.credentialConfigurations[credentialConfigurationId]!!
+            // For keyless credentials, just obtain them right away
+            if (credentialConfiguration.proofType == Openid4VciNoProof &&
+                issuerDocument.credentials.isEmpty()) {
+                obtainCredentialsKeyless(documentId, issuerDocument)
+            }
+        }
+        updateIssuerDocument(documentId, issuerDocument)
+        return issuerDocument.documentConfiguration!!
+    }
+
+    override suspend fun requestCredentials(
+        documentId: String
+    ): RequestCredentials {
+        checkClientId()
+        val document = loadIssuerDocument(documentId)
+        val metadata = Openid4VciIssuerMetadata.get(credentialIssuerUri)
+        val credentialConfiguration = metadata.credentialConfigurations[credentialConfigurationId]!!
+
+        refreshAccessIfNeeded(documentId, document)
+
+        val cNonce = document.access!!.cNonce!!
+        val configuration = if (document.secureAreaIdentifier!!.startsWith("CloudSecureArea?")) {
+            CredentialConfiguration(
+                challenge = ByteString(cNonce.encodeToByteArray()),
+                keyAssertionRequired = true,
+                secureAreaConfiguration = SecureAreaConfigurationCloud(
+                    algorithm = Algorithm.ESP256.name,
+                    cloudSecureAreaId = document.secureAreaIdentifier!!,
+                    passphraseRequired = true,
+                    useStrongBox = true,
+                    userAuthenticationRequired = true,
+                    userAuthenticationTimeoutMillis = 0,
+                    userAuthenticationTypes = 3, // LSKF + Biometrics
+                )
+            )
+        } else {
+            CredentialConfiguration(
+                challenge = ByteString(cNonce.encodeToByteArray()),
+                keyAssertionRequired = true,
+                secureAreaConfiguration = SecureAreaConfigurationAndroidKeystore(
+                    algorithm = Algorithm.ESP256.name,
+                    useStrongBox = true,
+                    userAuthenticationRequired = true,
+                    userAuthenticationTimeoutMillis = 0,
+                    userAuthenticationTypes = 3 // LSKF + Biometrics
+                )
+            )
+        }
+        return when (credentialConfiguration.proofType) {
+            is Openid4VciProofTypeKeyAttestation ->
+                RequestCredentialsUsingKeyAttestation(clientId, documentId, configuration)
+            is Openid4VciProofTypeJwt ->
+                RequestCredentialsUsingProofOfPossession(
+                    clientId = clientId,
+                    issuanceClientId = issuanceClientId,
+                    documentId = documentId,
+                    credentialConfiguration = configuration,
+                    credentialIssuerUri = credentialIssuerUri
+                )
+            Openid4VciNoProof ->
+                throw IllegalStateException("requestCredentials call is unexpected for keyless credentials")
+            null -> throw IllegalStateException("Unexpected state")
+        }
+    }
+
+    override suspend fun completeRequestCredentials(requestCredentials: RequestCredentials) {
+        checkClientId()
+        val state = requestCredentials as AbstractRequestCredentials
+        // Create appropriate request to OpenID4VCI issuer to issue credential(s)
+        val metadata = Openid4VciIssuerMetadata.get(credentialIssuerUri)
+        val credentialConfiguration = metadata.credentialConfigurations[credentialConfigurationId]!!
+
+        val credentialTasks = when (state) {
+            is RequestCredentialsUsingProofOfPossession ->
+                listOf(createRequestUsingProofOfPossession(state, credentialConfiguration))
+            is RequestCredentialsUsingKeyAttestation ->
+                createRequestUsingKeyAttestation(state, credentialConfiguration)
+            else -> throw IllegalStateException("Unsupported RequestCredential type")
+        }
+
+        val document = loadIssuerDocument(state.documentId)
+
+        for ((request, publicKeys) in credentialTasks) {
+            // Send the request
+            val credentials = obtainCredentials(metadata, request, state.documentId, document)
+
+            check(credentials.size == publicKeys.size)
+            document.credentials.addAll(credentials.zip(publicKeys).map {
+                val credential = it.first.jsonPrimitive.content
+                val publicKey = it.second
+                when (credentialConfiguration.format) {
+                    is Openid4VciFormatSdJwt -> {
+                        val sdJwt = SdJwtVerifiableCredential.fromString(credential)
+                        val jwtBody = JwtBody.fromString(sdJwt.body)
+                        CredentialData(
+                            publicKey,
+                            jwtBody.timeValidityBegin ?: jwtBody.timeSigned ?: Clock.System.now(),
+                            jwtBody.timeValidityEnd ?: Instant.DISTANT_FUTURE,
+                            CredentialFormat.SD_JWT_VC,
+                            credential.encodeToByteArray()
+                        )
+                    }
+
+                    is Openid4VciFormatMdoc -> {
+                        val credentialBytes = credential.fromBase64Url()
+                        val credentialData = StaticAuthDataParser(credentialBytes).parse()
+                        val issuerAuthCoseSign1 = Cbor.decode(credentialData.issuerAuth).asCoseSign1
+                        val encodedMsoBytes = Cbor.decode(issuerAuthCoseSign1.payload!!)
+                        val encodedMso = Cbor.encode(encodedMsoBytes.asTaggedEncodedCbor)
+                        val mso = MobileSecurityObjectParser(encodedMso).parse()
+                        CredentialData(
+                            publicKey,
+                            mso.validFrom,
+                            mso.validUntil,
+                            CredentialFormat.MDOC_MSO,
+                            credentialBytes
+                        )
+                    }
+
+                    null -> throw IllegalStateException("Unexpected credential format")
+                }
+            })
+        }
+
+        updateIssuerDocument(state.documentId, document, true)
+    }
+
+    private suspend fun obtainCredentialsKeyless(
+        documentId: String,
+        issuerDocument: Openid4VciIssuerDocument,
+    ) {
+        val metadata = Openid4VciIssuerMetadata.get(credentialIssuerUri)
+        val credentialConfiguration = metadata.credentialConfigurations[credentialConfigurationId]!!
+        val request = buildJsonObject {
+            putFormat(credentialConfiguration.format!!)
+        }
+        val credentials = obtainCredentials(
+            metadata,
+            request,
+            documentId,
+            issuerDocument
+        )
+        check(credentials.size == 1)
+        val credential = credentials[0].jsonPrimitive.content
+        val sdJwt = SdJwtVerifiableCredential.fromString(credential)
+        val jwtBody = JwtBody.fromString(sdJwt.body)
+        issuerDocument.credentials.add(
+            CredentialData(
+                null,
+                jwtBody.timeValidityBegin ?: jwtBody.timeSigned ?: Clock.System.now(),
+                jwtBody.timeValidityEnd ?: Instant.DISTANT_FUTURE,
+                CredentialFormat.SD_JWT_VC,
+                credential.encodeToByteArray()
+            )
+        )
+    }
+
+    private suspend fun obtainCredentials(
+        metadata: Openid4VciIssuerMetadata,
+        request: JsonObject,
+        documentId: String,
+        document: Openid4VciIssuerDocument
+    ): JsonArray {
+        val access = document.access!!
+        val dpop = OpenidUtil.generateDPoP(
+            clientId,
+            metadata.credentialEndpoint,
+            access.dpopNonce,
+            access.accessToken
+        )
+        Logger.e(TAG,"Credential request: $request")
+
+        val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+        val credentialResponse = httpClient.post(metadata.credentialEndpoint) {
+            headers {
+                append("Authorization", "DPoP ${access.accessToken}")
+                append("DPoP", dpop)
+                append("Content-Type", "application/json")
+            }
+            setBody(request.toString())
+        }
+        access.cNonce = null  // used up
+
+        if (credentialResponse.headers.contains("DPoP-Nonce")) {
+            access.dpopNonce = credentialResponse.headers["DPoP-Nonce"]!!
+        }
+
+        if (credentialResponse.status != HttpStatusCode.OK) {
+            val errResponseText = credentialResponse.readBytes().decodeToString()
+            Logger.e(TAG,"Credential request error: ${credentialResponse.status} $errResponseText")
+
+            // In some issuers this gets document in permanent bad state, notification
+            // is not needed as an exception will generate notification on the client side.
+            document.state = DocumentCondition.DELETION_REQUESTED
+            updateIssuerDocument(documentId, document, false)
+
+            throw IssuingAuthorityException("Error getting a credential issued")
+        }
+        Logger.i(TAG, "Got successful response for credential request")
+        val responseText = credentialResponse.readBytes().decodeToString()
+
+        val response = Json.parseToJsonElement(responseText) as JsonObject
+        return if (response.contains("credential")) {
+            JsonArray(listOf(response["credential"]!!))
+        } else {
+            response["credentials"] as JsonArray
+        }
+    }
+
+    private fun createRequestUsingProofOfPossession(
+        state: RequestCredentialsUsingProofOfPossession,
+        configuration: Openid4VciCredentialConfiguration
+    ): Pair<JsonObject, List<EcPublicKey>> {
+        val proofs = state.credentialRequests!!.map {
+            JsonPrimitive(it.proofOfPossessionJwtHeaderAndBody + "." + it.proofOfPossessionJwtSignature)
+        }
+        val publicKeys = state.credentialRequests!!.map {
+            it.request.secureAreaBoundKeyAttestation.publicKey
+        }
+
+        val request = buildJsonObject {
+            if (proofs.size == 1) {
+                put("proof", buildJsonObject {
+                    put("jwt", proofs[0])
+                    put("proof_type", JsonPrimitive("jwt"))
+                })
+            } else {
+                put("proofs", buildJsonObject {
+                    put("jwt", JsonArray(proofs))
+                })
+            }
+            putFormat(configuration.format!!)
+        }
+
+        return Pair(request, publicKeys)
+    }
+
+    private suspend fun createRequestUsingKeyAttestation(
+        state: RequestCredentialsUsingKeyAttestation,
+        configuration: Openid4VciCredentialConfiguration
+    ): List<Pair<JsonObject, List<EcPublicKey>>> {
+        val applicationSupport = BackendEnvironment.getInterface(ApplicationSupport::class)!!
+        return state.credentialRequestSets.map { credentialRequestSet ->
+            val jwtKeyAttestation = applicationSupport.createJwtKeyAttestation(
+                keyAttestations = credentialRequestSet.keyAttestations,
+                keysAssertion = credentialRequestSet.keysAssertion
+            )
+            val request = buildJsonObject {
+                put("proof", buildJsonObject {
+                    put("attestation", JsonPrimitive(jwtKeyAttestation))
+                    put("proof_type", JsonPrimitive("attestation"))
+                })
+                putFormat(configuration.format!!)
+            }
+            Pair(request, credentialRequestSet.keyAttestations.map { it.publicKey })
+        }
+    }
+
+    override suspend fun getCredentials(documentId: String): List<CredentialData> {
+        checkClientId()
+        val document = loadIssuerDocument(documentId)
+        val credentials = mutableListOf<CredentialData>()
+        credentials.addAll(document.credentials)
+        document.credentials.clear()
+        updateIssuerDocument(documentId, document, false)
+        return credentials
+    }
+
+    override suspend fun developerModeRequestUpdate(
+        documentId: String,
+        requestRemoteDeletion: Boolean,
+        notifyApplicationOfUpdate: Boolean
+    ) {
+        checkClientId()
+    }
+
+    private suspend fun issuerDocumentExists(documentId: String): Boolean {
+        val storage = BackendEnvironment.getTable(documentTableSpec)
+        val encodedCbor = storage.get(partitionId = clientId, key = documentId)
+        return encodedCbor != null
+    }
+
+    private suspend fun loadIssuerDocument(documentId: String): Openid4VciIssuerDocument {
+        val storage = BackendEnvironment.getTable(documentTableSpec)
+        val encodedCbor = storage.get(partitionId = clientId, key = documentId)
+            ?: throw Error("No such document")
+        return Openid4VciIssuerDocument.fromCbor(encodedCbor.toByteArray())
+    }
+
+    private suspend fun createIssuerDocument(document: Openid4VciIssuerDocument): String {
+        val storage = BackendEnvironment.getTable(documentTableSpec)
+        val bytes = document.toCbor()
+        return storage.insert(key = null, partitionId = clientId, data = ByteString(bytes))
+    }
+
+    private suspend fun deleteIssuerDocument(
+        documentId: String,
+        emitNotification: Boolean = true
+    ) {
+        val storage = BackendEnvironment.getTable(documentTableSpec)
+        storage.delete(partitionId = clientId, key = documentId)
+        if (emitNotification) {
+            emit(IssuingAuthorityNotification(documentId))
+        }
+    }
+
+    private suspend fun updateIssuerDocument(
+        documentId: String,
+        document: Openid4VciIssuerDocument,
+        emitNotification: Boolean = true,
+    ) {
+        val storage = BackendEnvironment.getTable(documentTableSpec)
+        val bytes = document.toCbor()
+        storage.update(partitionId = clientId, key = documentId, data = ByteString(bytes))
+        if (emitNotification) {
+            Logger.i(TAG, "Emitting notification for $documentId")
+            emit(IssuingAuthorityNotification(documentId))
+        }
+    }
+
+    private suspend fun generateGenericDocumentConfiguration(): DocumentConfiguration {
+        val metadata = Openid4VciIssuerMetadata.get(credentialIssuerUri)
+        val config = metadata.credentialConfigurations[credentialConfigurationId]!!
+        val base = getConfiguration().pendingDocumentInformation
+        return when (config.format) {
+            is Openid4VciFormatSdJwt -> {
+                DocumentConfiguration(
+                    base.displayName,
+                    base.typeDisplayName,
+                    base.cardArt,
+                    base.requireUserAuthenticationToViewDocument,
+                    null,
+                    SdJwtVcDocumentConfiguration(
+                        vct = config.format.vct,
+                        keyBound = config.proofType != Openid4VciNoProof
+                    ),
+                    null
+                )
+            }
+            is Openid4VciFormatMdoc -> {
+                val documentType = documentTypeRepository.getDocumentTypeForMdoc(config.format.docType)
+                val staticData = if (documentType != null) {
+                    fillInSampleData(documentType).build()
+                } else {
+                    NameSpacedData.Builder().build()
+                }
+                DocumentConfiguration(
+                    base.displayName,
+                    base.typeDisplayName,
+                    base.cardArt,
+                    base.requireUserAuthenticationToViewDocument,
+                    MdocDocumentConfiguration(
+                        config.format.docType,
+                        staticData = staticData
+                    ),
+                    null,
+                    null
+                )
+            }
+            else -> throw IllegalStateException("Invalid credential format")
+        }
+    }
+
+    private fun fillInSampleData(documentType: DocumentType): NameSpacedData.Builder {
+        val builder = NameSpacedData.Builder()
+        for ((namespaceName, namespace) in documentType.mdocDocumentType!!.namespaces) {
+            for ((dataElementName, dataElement) in namespace.dataElements) {
+                if (dataElement.attribute.sampleValueMdoc != null) {
+                    builder.putEntry(
+                        namespaceName,
+                        dataElementName,
+                        Cbor.encode(dataElement.attribute.sampleValueMdoc!!)
+                    )
+                }
+            }
+        }
+        return builder
+    }
+
+    private suspend fun refreshAccessIfNeeded(
+        documentId: String,
+        document: Openid4VciIssuerDocument
+    ) {
+        var access = document.access!!
+        val nowPlusSlack = Clock.System.now() + 30.seconds
+        if (access.cNonce != null && nowPlusSlack < access.accessTokenExpiration) {
+            // No need to refresh.
+            return
+        }
+
+        val refreshToken = access.refreshToken
+        access = OpenidUtil.obtainToken(
+            clientId = clientId,
+            issuanceClientId = issuanceClientId,
+            tokenUrl = access.tokenEndpoint,
+            refreshToken = refreshToken,
+            accessToken = access.accessToken
+        )
+        check(access.cNonce != null)
+        document.access = access
+        Logger.i(TAG, "Refreshed access tokens")
+        if (access.refreshToken == null) {
+            Logger.w(TAG, "Kept original refresh token (no updated refresh token received)")
+            access.refreshToken = refreshToken
+        }
+        updateIssuerDocument(documentId, document, false)
+    }
+
+    private suspend fun checkClientId() {
+        check(clientId == RpcAuthContext.getClientId())
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/Openid4VciRegistrationState.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/Openid4VciRegistrationState.kt
@@ -1,0 +1,26 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.rpc.annotation.RpcState
+import org.multipaz.provisioning.RegistrationConfiguration
+import org.multipaz.provisioning.Registration
+import org.multipaz.provisioning.RegistrationResponse
+import org.multipaz.rpc.backend.RpcAuthBackendDelegate
+import org.multipaz.rpc.handler.RpcAuthInspector
+
+@RpcState(endpoint = "openid4vci.registration")
+@CborSerializable
+class Openid4VciRegistrationState(
+    val documentId: String,
+    var response: RegistrationResponse? = null
+): Registration, RpcAuthInspector by RpcAuthBackendDelegate {
+    override suspend fun getDocumentRegistrationConfiguration(): RegistrationConfiguration {
+        return RegistrationConfiguration(documentId)
+    }
+
+    override suspend fun sendDocumentRegistrationResponse(response: RegistrationResponse) {
+        this.response = response
+    }
+
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/OpenidAccess.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/OpenidAccess.kt
@@ -1,0 +1,47 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.readBytes
+import kotlinx.datetime.Clock
+import kotlinx.datetime.Instant
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.long
+import kotlin.time.Duration.Companion.seconds
+
+@CborSerializable
+class OpenidAccess(
+    val accessToken: String,
+    val accessTokenExpiration: Instant,
+    var dpopNonce: String?,
+    var cNonce: String?,
+    var tokenEndpoint: String,
+    var refreshToken: String?,
+) {
+    companion object {
+        suspend fun parseResponse(tokenEndpoint: String, tokenResponse: HttpResponse): OpenidAccess {
+            val dpopNonce = tokenResponse.headers["DPoP-Nonce"]
+            val tokenString = tokenResponse.readBytes().decodeToString()
+            val token = Json.parseToJsonElement(tokenString) as JsonObject
+            val accessToken = getField(token, "access_token").content
+            val cNonce = getField(token, "c_nonce").content
+            val duration = getField(token, "expires_in").long
+            val accessTokenExpiration = Clock.System.now() + duration.seconds
+            val refreshToken = token["refresh_token"]?.jsonPrimitive?.content
+            return OpenidAccess(accessToken, accessTokenExpiration, dpopNonce,
+                cNonce, tokenEndpoint, refreshToken)
+        }
+
+        private fun getField(jsonElement: JsonObject, name: String): JsonPrimitive {
+            val jsonValue =  jsonElement[name]
+                ?: throw IllegalArgumentException("No $name in token response")
+            if (jsonValue !is JsonPrimitive) {
+                throw IllegalArgumentException("Field $name is not primitive")
+            }
+            return jsonValue
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/OpenidUtil.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/OpenidUtil.kt
@@ -1,0 +1,166 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.crypto.Algorithm
+import org.multipaz.crypto.Crypto
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.provisioning.IssuingAuthorityException
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.KeyInfo
+import org.multipaz.securearea.SecureAreaProvider
+import org.multipaz.util.Logger
+import org.multipaz.util.toBase64Url
+import io.ktor.client.HttpClient
+import io.ktor.client.request.headers
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.datetime.Clock
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlin.random.Random
+
+internal object OpenidUtil {
+    const val TAG = "OpenidUtil"
+
+    private val keyCreationMutex = Mutex()
+
+    suspend fun communicationKey(clientId: String): KeyInfo {
+        val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
+        val alias = "OpenidComm_" + clientId
+        return try {
+            secureArea.getKeyInfo(alias)
+        } catch (_: Exception) {
+            keyCreationMutex.withLock {
+                try {
+                    secureArea.getKeyInfo(alias)
+                } catch (_: Exception) {
+                    secureArea.createKey(alias, CreateKeySettings())
+                    secureArea.getKeyInfo(alias)
+                }
+            }
+        }
+    }
+
+    suspend fun communicationSign(clientId: String, message: ByteArray): ByteArray {
+        val secureArea = BackendEnvironment.getInterface(SecureAreaProvider::class)!!.get()
+        val alias = "OpenidComm_" + clientId
+        val sig = secureArea.sign(alias, message, null)
+        return sig.toCoseEncoded()
+    }
+
+    suspend fun generateDPoP(
+        clientId: String,
+        requestUrl: String,
+        dpopNonce: String?,
+        accessToken: String? = null
+    ): String {
+        val keyInfo = communicationKey(clientId)
+        val header = buildJsonObject {
+            put("typ", JsonPrimitive("dpop+jwt"))
+            put("alg", JsonPrimitive(keyInfo.publicKey.curve.defaultSigningAlgorithm.joseAlgorithmIdentifier))
+            put("jwk", keyInfo.publicKey.toJson(clientId))
+        }.toString().encodeToByteArray().toBase64Url()
+        val bodyObj = buildJsonObject {
+            put("htm", JsonPrimitive("POST"))
+            put("htu", JsonPrimitive(requestUrl))
+            put("iat", JsonPrimitive(Clock.System.now().epochSeconds))
+            if (dpopNonce != null) {
+                put("nonce", JsonPrimitive(dpopNonce))
+            }
+            put("jti", JsonPrimitive(Random.Default.nextBytes(15).toBase64Url()))
+            if (accessToken != null) {
+                put("ath", JsonPrimitive(
+                    Crypto.digest(
+                        Algorithm.SHA256,
+                        accessToken.encodeToByteArray()
+                    ).toBase64Url()))
+            }
+        }
+        val body = bodyObj.toString().encodeToByteArray().toBase64Url()
+        val message = "$header.$body"
+        val signature = communicationSign(clientId, message.encodeToByteArray()).toBase64Url()
+        return "$message.$signature"
+    }
+
+    suspend fun obtainToken(
+        tokenUrl: String,
+        clientId: String,
+        issuanceClientId: String,
+        refreshToken: String? = null,
+        accessToken: String? = null,
+        authorizationCode: String? = null,
+        preauthorizedCode: String? = null,
+        txCode: String? = null,  // pin or other transaction code
+        codeVerifier: String? = null,
+        dpopNonce: String? = null
+    ): OpenidAccess {
+        if (refreshToken == null && authorizationCode == null && preauthorizedCode == null) {
+            throw IllegalArgumentException("No authorizations provided")
+        }
+        val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+        var currentDpopNonce = dpopNonce
+        // When dpop nonce is null, this loop will run twice, first request will return with error,
+        // but will provide fresh, dpop nonce and the second request will get fresh access data.
+        while (true) {
+            val dpop = generateDPoP(clientId, tokenUrl, currentDpopNonce, null)
+            val tokenRequest = FormUrlEncoder {
+                if (refreshToken != null) {
+                    add("grant_type", "refresh_token")
+                    add("refresh_token", refreshToken)
+                }
+                if (authorizationCode != null) {
+                    add("grant_type", "authorization_code")
+                    add("code", authorizationCode)
+                } else if (preauthorizedCode != null) {
+                    add("grant_type", "urn:ietf:params:oauth:grant-type:pre-authorized_code")
+                    add("pre-authorized_code", preauthorizedCode)
+                    if (txCode != null) {
+                        add("tx_code", txCode)
+                    }
+                }
+                if (codeVerifier != null) {
+                    add("code_verifier", codeVerifier)
+                }
+                add("client_id", issuanceClientId)
+                // TODO: It's arbitrary in our case, right?
+                add("redirect_uri", "https://secure.redirect.com")
+            }
+            val tokenResponse = httpClient.post(tokenUrl) {
+                headers {
+                    if (currentDpopNonce != null && accessToken != null) {
+                        append("Authorization", "DPoP $accessToken")
+                    }
+                    append("DPoP", dpop)
+                    append("Content-Type", "application/x-www-form-urlencoded")
+                }
+                setBody(tokenRequest.toString())
+            }
+            if (tokenResponse.status != HttpStatusCode.OK) {
+                val errResponseText = tokenResponse.readBytes().decodeToString()
+                if (currentDpopNonce == null && tokenResponse.headers.contains("DPoP-Nonce")) {
+                    Logger.e(TAG, "DPoP nonce refreshed: $errResponseText")
+                    currentDpopNonce = tokenResponse.headers["DPoP-Nonce"]!!
+                    continue
+                }
+                Logger.e(TAG, "Token request error: ${tokenResponse.status} $errResponseText")
+                throw IssuingAuthorityException(
+                    if (authorizationCode != null) {
+                        "Authorization code rejected by the issuer"
+                    } else {
+                        "Refresh token (seed credential) rejected by the issuer"
+                    }
+                )
+            }
+            return try {
+                OpenidAccess.parseResponse(tokenUrl, tokenResponse)
+            } catch (err: IllegalArgumentException) {
+                val tokenString = tokenResponse.readBytes().decodeToString()
+                Logger.e(TAG, "Invalid token response: ${err.message}: $tokenString")
+                throw IssuingAuthorityException("Invalid response from the issuer")
+            }
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/ProofOfPossessionCredentialRequest.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/ProofOfPossessionCredentialRequest.kt
@@ -1,0 +1,13 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.provisioning.CredentialRequest
+
+@CborSerializable
+data class ProofOfPossessionCredentialRequest(
+    val request: CredentialRequest,
+    val format: CredentialFormat,
+    val proofOfPossessionJwtHeaderAndBody: String,
+    var proofOfPossessionJwtSignature: String? = null
+)

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/ProofingInfo.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/ProofingInfo.kt
@@ -1,0 +1,12 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+
+@CborSerializable
+data class ProofingInfo(
+    val requestUri: String?,
+    val pkceCodeVerifier: String,
+    val landingUrl: String,
+    val authSession: String?,
+    val openid4VpPresentation: String?,
+)

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/RequestCredentialsUsingKeyAttestation.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/RequestCredentialsUsingKeyAttestation.kt
@@ -1,0 +1,55 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.device.DeviceAssertion
+import org.multipaz.rpc.annotation.RpcState
+import org.multipaz.provisioning.CredentialConfiguration
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.provisioning.CredentialRequest
+import org.multipaz.provisioning.KeyPossessionChallenge
+import org.multipaz.provisioning.KeyPossessionProof
+import org.multipaz.provisioning.RequestCredentials
+import org.multipaz.rpc.backend.RpcAuthBackendDelegate
+import org.multipaz.rpc.handler.RpcAuthContext
+import org.multipaz.rpc.handler.RpcAuthInspector
+
+@RpcState(endpoint = "openid4vci.cred.keyatt")
+@CborSerializable
+class RequestCredentialsUsingKeyAttestation(
+    val clientId: String,
+    override val documentId: String,
+    override val credentialConfiguration: CredentialConfiguration,
+    override var format: CredentialFormat? = null,
+    val credentialRequestSets: MutableList<CredentialRequestSet> = mutableListOf()
+) : AbstractRequestCredentials, RequestCredentials, RpcAuthInspector by RpcAuthBackendDelegate {
+    override suspend fun getCredentialConfiguration(
+        format: CredentialFormat
+    ): CredentialConfiguration {
+        checkClientId()
+        this.format = format
+        return credentialConfiguration
+    }
+
+    override suspend fun sendCredentials(
+        credentialRequests: List<CredentialRequest>,
+        keysAssertion: DeviceAssertion? // holds AssertionBingingKeys
+    ): List<KeyPossessionChallenge> {
+        checkClientId()
+        credentialRequestSets.add(CredentialRequestSet(
+            format = format!!,
+            keyAttestations = credentialRequests.map { it.secureAreaBoundKeyAttestation },
+            keysAssertion = keysAssertion!!
+        ))
+        return emptyList()
+    }
+
+    override suspend fun sendPossessionProofs(keyPossessionProofs: List<KeyPossessionProof>) {
+        throw UnsupportedOperationException("Should not be called")
+    }
+
+    private suspend fun checkClientId() {
+        check(clientId == RpcAuthContext.getClientId())
+    }
+
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/RequestCredentialsUsingProofOfPossession.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/RequestCredentialsUsingProofOfPossession.kt
@@ -1,0 +1,93 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.device.DeviceAssertion
+import org.multipaz.rpc.annotation.RpcState
+import org.multipaz.provisioning.CredentialConfiguration
+import org.multipaz.provisioning.CredentialFormat
+import org.multipaz.provisioning.CredentialRequest
+import org.multipaz.provisioning.KeyPossessionChallenge
+import org.multipaz.provisioning.KeyPossessionProof
+import org.multipaz.provisioning.RequestCredentials
+import org.multipaz.util.toBase64Url
+import kotlinx.datetime.Clock
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.decodeToString
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import org.multipaz.rpc.backend.RpcAuthBackendDelegate
+import org.multipaz.rpc.handler.RpcAuthContext
+import org.multipaz.rpc.handler.RpcAuthInspector
+import org.multipaz.rpc.handler.RpcAuthInspectorAssertion
+
+@RpcState(endpoint = "openid4vci.cred.pofp")
+@CborSerializable
+class RequestCredentialsUsingProofOfPossession(
+    val clientId: String,
+    val issuanceClientId: String,
+    override val documentId: String,
+    override val credentialConfiguration: CredentialConfiguration,
+    val credentialIssuerUri: String,
+    override var format: CredentialFormat? = null,
+    var credentialRequests: List<ProofOfPossessionCredentialRequest>? = null,
+) : AbstractRequestCredentials, RequestCredentials, RpcAuthInspector by RpcAuthBackendDelegate {
+    override suspend fun getCredentialConfiguration(
+        format: CredentialFormat
+    ): CredentialConfiguration {
+        checkClientId()
+        this.format = format
+        return credentialConfiguration
+    }
+
+    override suspend fun sendCredentials(
+        credentialRequests: List<CredentialRequest>,
+        keysAssertion: DeviceAssertion?
+    ): List<KeyPossessionChallenge> {
+        checkClientId()
+        if (this.credentialRequests != null) {
+            throw IllegalStateException("Credentials were already sent")
+        }
+        val deviceAttestation = RpcAuthInspectorAssertion.getClientDeviceAttestation(clientId)!!
+        validateDeviceAssertionBindingKeys(
+            deviceAttestation = deviceAttestation,
+            keyAttestations = credentialRequests.map { it.secureAreaBoundKeyAttestation },
+            deviceAssertion = keysAssertion!!,
+            nonce = credentialConfiguration.challenge
+        )
+        val nonce = JsonPrimitive(credentialConfiguration.challenge.decodeToString())
+        val requests = credentialRequests.map { request ->
+            val header = JsonObject(mapOf(
+                "typ" to JsonPrimitive("openid4vci-proof+jwt"),
+                "alg" to JsonPrimitive("ES256"),
+                "jwk" to request.secureAreaBoundKeyAttestation.publicKey.toJson(null)
+            )).toString().encodeToByteArray().toBase64Url()
+            val body = JsonObject(mapOf(
+                "iss" to JsonPrimitive(issuanceClientId),
+                "aud" to JsonPrimitive(credentialIssuerUri),
+                "iat" to JsonPrimitive(Clock.System.now().epochSeconds),
+                "nonce" to nonce
+            )).toString().encodeToByteArray().toBase64Url()
+            ProofOfPossessionCredentialRequest(request, format!!, "$header.$body")
+        }
+        this.credentialRequests = requests
+        return requests.map {
+            KeyPossessionChallenge(ByteString(it.proofOfPossessionJwtHeaderAndBody.encodeToByteArray()))
+        }
+    }
+
+    override suspend fun sendPossessionProofs(keyPossessionProofs: List<KeyPossessionProof>) {
+        checkClientId()
+        if (keyPossessionProofs.size != credentialRequests?.size) {
+            throw IllegalStateException("wrong number of key possession proofs: ${keyPossessionProofs.size}")
+        }
+        credentialRequests!!.zip(keyPossessionProofs).map {
+            it.first.proofOfPossessionJwtSignature = it.second.signature.toByteArray().toBase64Url()
+        }
+    }
+
+    private suspend fun checkClientId() {
+        check(clientId == RpcAuthContext.getClientId())
+    }
+
+    companion object
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/attestation.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/attestation.kt
@@ -1,19 +1,20 @@
-package org.multipaz.provisioning
+package com.android.identity.testapp.provisioning.openid4vci
 
+import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
 import org.multipaz.crypto.X509Cert
 import org.multipaz.device.AssertionBindingKeys
 import org.multipaz.device.DeviceAssertion
 import org.multipaz.device.DeviceAttestation
 import org.multipaz.device.DeviceAttestationIos
-import org.multipaz.rpc.backend.Configuration
+import org.multipaz.provisioning.ApplicationSupport
+import org.multipaz.provisioning.ProvisioningBackendSettings
 import org.multipaz.rpc.backend.BackendEnvironment
-import org.multipaz.rpc.cache
+import org.multipaz.rpc.backend.Configuration
 import org.multipaz.securearea.KeyAttestation
 import org.multipaz.util.isCloudKeyAttestation
 import org.multipaz.util.validateAndroidKeyAttestation
 import org.multipaz.util.validateCloudKeyAttestation
-import kotlinx.io.bytestring.ByteString
 
 suspend fun validateDeviceAssertionBindingKeys(
     deviceAttestation: DeviceAttestation,

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/cache.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/cache.kt
@@ -1,0 +1,74 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.backend.Configuration
+import org.multipaz.rpc.backend.Resources
+import kotlin.coroutines.coroutineContext
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
+
+/**
+ * Lazily create and memoize an object that is defined by the given class and a key.
+ *
+ * If/when configuration or resource objects change in the environment, object is created
+ * anew.
+ *
+ * This method is thread/coroutine-safe. The same object is returned for all threads,
+ * however, when the object is being created, multiple copies might be created if there
+ * is a race condition.
+ */
+suspend fun<ResourceT : Any> BackendEnvironment.cache(
+    clazz: KClass<ResourceT>,
+    key: Any = "",
+    factory: suspend (Configuration, Resources) -> ResourceT
+): ResourceT {
+    val configuration = getInterface(Configuration::class)!!
+    val resources = getInterface(Resources::class)!!
+    return cache
+        .getOrPut(configuration) {
+            mutableMapOf<Resources, EnvironmentCache>()
+        }
+        .getOrPut(resources) {
+            EnvironmentCache()
+        }
+        .obtain(configuration, resources, clazz, key, factory)
+}
+
+suspend fun<ResourceT : Any> BackendEnvironment.Companion.cache(
+    clazz: KClass<ResourceT>,
+    key: Any = "",
+    factory: suspend (Configuration, Resources) -> ResourceT
+): ResourceT =
+    get(coroutineContext).cache(clazz, key, factory)
+
+private val cache = mutableMapOf<Configuration, MutableMap<Resources, EnvironmentCache>>()
+
+private class EnvironmentCache {
+    val map = mutableMapOf<KClass<out Any>, MutableMap<Any, Any>>()
+    val lock = Mutex()
+
+    suspend fun<ResourceT : Any> obtain(
+        configuration: Configuration,
+        resources: Resources,
+        clazz: KClass<ResourceT>,
+        key: Any,
+        factory: suspend (Configuration, Resources) -> ResourceT
+    ): ResourceT {
+        lock.withLock {
+            val submap = map[clazz]
+            if (submap != null) {
+                val cached = submap[key]
+                if (cached != null) {
+                    return clazz.cast(cached)
+                }
+            }
+        }
+        val resource = factory(configuration, resources)
+        lock.withLock {
+            (map.getOrPut(clazz) { mutableMapOf() })[key] = resource
+        }
+        return resource
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/landingUrl.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/landingUrl.kt
@@ -1,0 +1,50 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.SendChannel
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import org.multipaz.util.Logger
+import org.multipaz.util.toBase64Url
+import kotlin.random.Random
+
+private const val TAG = "LangingUrl"
+
+private val lock = Mutex()
+val callbacks = mutableMapOf<String, SendChannel<String>>()
+
+const val baseUrl = "https://sorotokin.com/multipaz/landing/"
+
+private fun createUniqueUrl(): String {
+    while (true) {
+        val provisionalUrl = baseUrl + Random.Default.nextBytes(15).toBase64Url()
+        if (!callbacks.contains(provisionalUrl)) {
+            return provisionalUrl
+        }
+    }
+}
+
+suspend fun waitForNavigation(block: suspend (landingUrl: String) -> Unit): String {
+    val channel = Channel<String>()
+    val ladingUrl = lock.withLock {
+        val url = createUniqueUrl()
+        callbacks[url] = channel
+        url
+    }
+    block(ladingUrl)
+    return channel.receive()
+}
+
+suspend fun landingUrlNavigated(url: String) {
+    val index = url.indexOf('?')
+    val base = url.substring(0, index)
+    val channel = lock.withLock {
+        callbacks.remove(base)
+    }
+    if (channel == null) {
+        Logger.w(TAG, "No callback registered for url '$url'")
+    } else {
+        Logger.w(TAG, "Handling callback for url '$url'")
+        channel.send(url.substring(index + 1))
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/openid4VciIssuerMetadata.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/openid4VciIssuerMetadata.kt
@@ -1,0 +1,272 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.util.Logger
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonObjectBuilder
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+// from .well-known/openid-credential-issuer
+internal data class Openid4VciIssuerMetadata(
+    val credentialIssuer: String,
+    val credentialEndpoint: String,
+    val display: List<Openid4VciIssuerDisplay>,
+    val credentialConfigurations: Map<String, Openid4VciCredentialConfiguration>,
+    val authorizationServerList: List<Openid4VciAuthorizationMetadata>
+) {
+    companion object {
+        const val TAG = "Openid4VciIssuerMetadata"
+
+        suspend fun get(issuerUrl: String): Openid4VciIssuerMetadata {
+            return BackendEnvironment.cache(Openid4VciIssuerMetadata::class, issuerUrl) { _, _ ->
+                val httpClient = BackendEnvironment.getInterface(HttpClient::class)!!
+
+                // Fetch issuer metadata
+                val issuerMetadataUrl = "$issuerUrl/.well-known/openid-credential-issuer"
+                val issuerMetadataRequest = httpClient.get(issuerMetadataUrl) {}
+                if (issuerMetadataRequest.status != HttpStatusCode.OK) {
+                    throw IllegalStateException("Invalid issuer, no $issuerMetadataUrl")
+                }
+                val credentialMetadataText = issuerMetadataRequest.readBytes().decodeToString()
+                val credentialMetadata = Json.parseToJsonElement(credentialMetadataText).jsonObject
+
+                // Fetch authorization metadata
+                val authorizationServers = credentialMetadata["authorization_servers"]?.jsonArray
+                val authorizationServerUrls =
+                    authorizationServers?.map { it.jsonPrimitive.content } ?: listOf(issuerUrl)
+                val authorizationMetadataList = mutableListOf<Openid4VciAuthorizationMetadata>()
+                for (authorizationServerUrl in authorizationServerUrls) {
+                    val authorizationMetadataUrl =
+                        "$authorizationServerUrl/.well-known/oauth-authorization-server"
+                    val authorizationMetadataRequest = httpClient.get(authorizationMetadataUrl) {}
+                    if (authorizationMetadataRequest.status != HttpStatusCode.OK) {
+                        if (authorizationServerUrl != issuerUrl) {
+                            Logger.e(TAG, "Invalid authorization server '$authorizationServerUrl'")
+                        }
+                        continue
+                    }
+                    val authorizationMetadataText = authorizationMetadataRequest.readBytes().decodeToString()
+                    val authorizationMetadata =
+                        extractAuthorizationServerMetadata(
+                            url = authorizationServerUrl,
+                            jsonObject = Json.parseToJsonElement(authorizationMetadataText).jsonObject
+                        )
+                    if (authorizationMetadata != null) {
+                        authorizationMetadataList.add(authorizationMetadata)
+                    }
+                }
+                Openid4VciIssuerMetadata(
+                    credentialIssuer = credentialMetadata["credential_issuer"]?.jsonPrimitive?.content ?: issuerUrl,
+                    credentialEndpoint = credentialMetadata["credential_endpoint"]!!.jsonPrimitive.content,
+                    display = extractDisplay(credentialMetadata["display"]),
+                    authorizationServerList = authorizationMetadataList.toList(),
+                    credentialConfigurations =
+                        credentialMetadata["credential_configurations_supported"]!!.jsonObject.mapValues {
+                            val obj = it.value.jsonObject
+                            val credentialSigningAlgorithms =
+                                obj["credential_signing_alg_values_supported"]
+                                    ?: obj["cryptographic_suites_supported"]!!  // Deprecated name
+                            Openid4VciCredentialConfiguration(
+                                id = it.key,
+                                scope = obj["scope"]?.jsonPrimitive?.content,
+                                cryptographicBindingMethod = preferred(
+                                    obj["cryptographic_binding_methods_supported"]?.jsonArray,
+                                    SUPPORTED_BINDING_METHODS
+                                ),
+                                credentialSigningAlgorithm = preferred(
+                                    credentialSigningAlgorithms.jsonArray,
+                                    SUPPORTED_SIGNATURE_ALGORITHMS
+                                ),
+                                proofType = extractProofType(obj["proof_types_supported"]?.jsonObject),
+                                format = extractFormat(obj),
+                                display = extractDisplay(obj["display"])
+                            )
+                        }
+                )
+            }
+        }
+
+        private fun preferred(available: JsonArray?, supported: List<String>): String? {
+            if (available == null) {
+                return "none"
+            }
+            val availableSet = available?.map { it.jsonPrimitive.content }?.toSet() ?: return null
+            return supported.firstOrNull { availableSet.contains(it) }
+        }
+
+        private fun extractDisplay(displayJson: JsonElement?): List<Openid4VciIssuerDisplay> {
+            if (displayJson == null) {
+                return listOf()
+            }
+            return displayJson.jsonArray.map {
+                val displayObj = it.jsonObject
+                Openid4VciIssuerDisplay(
+                    text = displayObj["name"]!!.jsonPrimitive.content,
+                    locale = displayObj["locale"]?.jsonPrimitive?.content ?: "en",
+                    logoUrl = displayObj["logo"]?.jsonObject?.get("uri")?.jsonPrimitive?.content
+                )
+            }
+        }
+
+        // Returns null if no compatible configuration could be created
+        private fun extractAuthorizationServerMetadata(
+            url: String,
+            jsonObject: JsonObject
+        ): Openid4VciAuthorizationMetadata? {
+            val responseType = preferred(
+                jsonObject["response_types_supported"]?.jsonArray,
+                SUPPORTED_RESPONSE_TYPES
+            ) ?: return null
+            val codeChallengeMethod = preferred(
+                jsonObject["code_challenge_methods_supported"]?.jsonArray,
+                SUPPORTED_CODE_CHALLENGE_METHODS
+            ) ?: return null
+            val dpopSigningAlgorithm = preferred(
+                jsonObject["dpop_signing_alg_values_supported"]?.jsonArray,
+                SUPPORTED_SIGNATURE_ALGORITHMS
+            ) ?: return null
+            val authorizationEndpoint = jsonObject["authorization_endpoint"]?.jsonPrimitive?.content
+            val authorizationChallengeEndpoint =
+                jsonObject["authorization_challenge_endpoint"]?.jsonPrimitive?.content
+            return Openid4VciAuthorizationMetadata(
+                baseUrl = url,
+                pushedAuthorizationRequestEndpoint = jsonObject["pushed_authorization_request_endpoint"]?.jsonPrimitive?.content,
+                authorizationEndpoint = authorizationEndpoint,
+                authorizationChallengeEndpoint = authorizationChallengeEndpoint,
+                tokenEndpoint = jsonObject["token_endpoint"]!!.jsonPrimitive.content,
+                responseType = responseType,
+                codeChallengeMethod = codeChallengeMethod,
+                dpopSigningAlgorithm = dpopSigningAlgorithm,
+            )
+        }
+
+        private fun extractProofType(jsonObject: JsonObject?): Openid4VciProofType? {
+            if (jsonObject == null) {
+                return Openid4VciNoProof
+            }
+            val attestation = jsonObject["attestation"]?.jsonObject
+            if (attestation != null) {
+                val alg = preferred(
+                    attestation["proof_signing_alg_values_supported"]?.jsonArray,
+                    SUPPORTED_SIGNATURE_ALGORITHMS
+                )
+                if (alg != null) {
+                    return Openid4VciProofTypeKeyAttestation(alg)
+                }
+            }
+            val jwt = jsonObject["jwt"]?.jsonObject
+            if (jwt != null) {
+                val alg = preferred(
+                    jwt["proof_signing_alg_values_supported"]?.jsonArray,
+                    SUPPORTED_SIGNATURE_ALGORITHMS
+                )
+                if (alg != null) {
+                    return Openid4VciProofTypeJwt(alg)
+                }
+            }
+            return null
+        }
+
+        private fun extractFormat(jsonObject: JsonObject): Openid4VciFormat? {
+            return when (jsonObject["format"]?.jsonPrimitive?.content) {
+                "vc+sd-jwt" -> Openid4VciFormatSdJwt(jsonObject["vct"]!!.jsonPrimitive.content)
+                "mso_mdoc" -> Openid4VciFormatMdoc(jsonObject["doctype"]!!.jsonPrimitive.content)
+                else -> null
+            }
+        }
+
+        // Supported methods/algorithms in the order of preference
+        private val SUPPORTED_BINDING_METHODS = listOf("cose_key", "jwk")
+        private val SUPPORTED_SIGNATURE_ALGORITHMS = listOf("ES256")
+        private val SUPPORTED_RESPONSE_TYPES = listOf("code")
+        private val SUPPORTED_CODE_CHALLENGE_METHODS = listOf("S256")
+    }
+}
+
+// from .well-known/oauth-authorization-server
+internal data class Openid4VciAuthorizationMetadata(
+    val baseUrl: String,
+    val pushedAuthorizationRequestEndpoint: String?,
+    val authorizationEndpoint: String?,
+    val authorizationChallengeEndpoint: String?,
+    val tokenEndpoint: String,
+    val responseType: String,
+    val codeChallengeMethod: String,
+    val dpopSigningAlgorithm: String,
+)
+
+internal data class Openid4VciIssuerDisplay(
+    val text: String,
+    val locale: String,
+    val logoUrl: String?
+)
+
+// Create a configuration object even if it is not fully supported (unsupported fields will have
+// null values), so that we can have clear error messages.
+internal data class Openid4VciCredentialConfiguration(
+    val id: String,
+    val scope: String?,
+    val cryptographicBindingMethod: String?,
+    val credentialSigningAlgorithm: String?,
+    val proofType: Openid4VciProofType?,
+    val format: Openid4VciFormat?,
+    val display: List<Openid4VciIssuerDisplay>
+) {
+    val isSupported: Boolean get() = cryptographicBindingMethod != null &&
+            credentialSigningAlgorithm != null && proofType != null && format != null
+}
+
+internal sealed class Openid4VciFormat {
+    abstract val id: String
+}
+
+internal data class Openid4VciFormatMdoc(val docType: String) : Openid4VciFormat() {
+    override val id: String get() = "mso_mdoc"
+}
+
+internal data class Openid4VciFormatSdJwt(val vct: String) : Openid4VciFormat() {
+    override val id: String get() = "vc+sd-jwt"
+}
+
+internal sealed class Openid4VciProofType {
+    abstract val id: String
+}
+
+internal object Openid4VciNoProof : Openid4VciProofType() {
+    override val id: String get() = "none"
+}
+
+internal data class Openid4VciProofTypeJwt(
+    val signingAlgorithm: String
+) : Openid4VciProofType() {
+    override val id: String get() = "jwt"
+}
+
+internal data class Openid4VciProofTypeKeyAttestation(
+    val signingAlgorithm: String
+) : Openid4VciProofType() {
+    override val id: String get() = "attestation"
+}
+
+internal fun JsonObjectBuilder.putFormat(format: Openid4VciFormat) {
+    put("format", JsonPrimitive(format.id))
+    when (format) {
+        is Openid4VciFormatSdJwt -> {
+            put("vct", JsonPrimitive(format.vct))
+        }
+
+        is Openid4VciFormatMdoc -> {
+            put("doctype", JsonPrimitive(format.docType))
+        }
+    }
+}

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/utils.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/utils.kt
@@ -1,0 +1,118 @@
+package com.android.identity.testapp.provisioning.openid4vci
+
+import io.ktor.client.HttpClient
+import io.ktor.client.request.get
+import io.ktor.client.statement.readBytes
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.decodeURLPart
+import kotlinx.coroutines.CancellationException
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.intOrNull
+import kotlinx.serialization.json.jsonArray
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import org.multipaz.provisioning.evidence.Openid4VciCredentialOffer
+import org.multipaz.provisioning.evidence.Openid4VciCredentialOfferAuthorizationCode
+import org.multipaz.provisioning.evidence.Openid4VciCredentialOfferPreauthorizedCode
+import org.multipaz.provisioning.evidence.Openid4VciTxCode
+import org.multipaz.util.Logger
+
+// TODO: this is useful function, find a good home for it
+private fun String.decodeUrlQuery(): Map<String, String> {
+    return split('&').associate {
+        val index = it.indexOf('=')
+        val name = if (index < 0) "" else it.substring(0, index)
+        Pair(
+            name.decodeURLPart(),
+            it.decodeURLPart(index + 1)
+        )
+    }
+}
+
+/**
+ * Parse the Url Query component of an OID4VCI credential offer Url (from a deep link or Qr scan)
+ * and return a [Openid4VciCredentialOffer] containing the
+ * Credential Issuer Uri and Credential (Config) Id that are used for initiating the
+ * OpenId4VCI Credential Offer Issuance flow using [ProvisioningModel.start] call.
+ */
+suspend fun extractCredentialIssuerData(
+    urlQueryComponent: String
+): Openid4VciCredentialOffer? {
+    try {
+        val params = urlQueryComponent.decodeUrlQuery()
+        var credentialOfferString = params["credential_offer"]
+        if (credentialOfferString == null) {
+            val url = params["credential_offer_uri"]
+            if (url == null) {
+                Logger.e("CredentialOffer", "Could not parse offer")
+                return null
+            }
+            val response = HttpClient().get(url) {}
+            if (response.status != HttpStatusCode.OK) {
+                Logger.e("CredentialOffer", "Error retrieving '$url'")
+                return null
+            }
+            credentialOfferString = response.readBytes().decodeToString()
+        }
+        val json = Json.parseToJsonElement(credentialOfferString).jsonObject
+        return Openid4VciCredentialOffer.parse(json)
+    } catch (err: CancellationException) {
+        throw err
+    } catch (err: Exception) {
+        Logger.e("CredentialOffer", "Parsing error", err)
+        return null
+    }
+}
+
+fun Openid4VciCredentialOffer.Companion.parse(json: JsonObject): Openid4VciCredentialOffer {
+    val credentialIssuerUri = json["credential_issuer"]!!.jsonPrimitive.content
+    val credentialConfigurationIds = json["credential_configuration_ids"]!!.jsonArray
+    // Right now only use the first configuration id
+    val credentialConfigurationId = credentialConfigurationIds[0].jsonPrimitive.content
+    if (json.containsKey("grants")) {
+        val grants = json["grants"]!!.jsonObject
+        val preAuthGrant = grants["urn:ietf:params:oauth:grant-type:pre-authorized_code"]
+        if (preAuthGrant != null) {
+            val grant = preAuthGrant.jsonObject
+            val preauthorizedCode = grant["pre-authorized_code"]!!.jsonPrimitive.content
+            val authorizationServer = grant["authorization_server"]?.jsonPrimitive?.content
+            val txCode = extractTxCode(grant["tx_code"])
+            return Openid4VciCredentialOfferPreauthorizedCode(
+                issuerUri = credentialIssuerUri,
+                configurationId = credentialConfigurationId,
+                authorizationServer = authorizationServer,
+                preauthorizedCode = preauthorizedCode,
+                txCode = txCode
+            )
+        } else {
+            val grant = grants["authorization_code"]?.jsonObject
+            if (grant != null) {
+                val issuerState = grant["issuer_state"]?.jsonPrimitive?.content
+                val authorizationServer = grant["authorization_server"]?.jsonPrimitive?.content
+                return Openid4VciCredentialOfferAuthorizationCode(
+                    issuerUri = credentialIssuerUri,
+                    configurationId = credentialConfigurationId,
+                    authorizationServer = authorizationServer,
+                    issuerState = issuerState
+                )
+            }
+        }
+    }
+    throw IllegalArgumentException("Could not parse credential offer")
+}
+
+private fun extractTxCode(txCodeJson: JsonElement?): Openid4VciTxCode? {
+    return if (txCodeJson == null) {
+        null
+    } else {
+        val obj = txCodeJson.jsonObject
+        Openid4VciTxCode(
+            description = obj["description"]?.jsonPrimitive?.content ?:
+            "Enter transaction code that was previously communicated to you",
+            length = obj["length"]?.jsonPrimitive?.intOrNull ?: Int.MAX_VALUE,
+            isNumeric = obj["input_mode"]?.jsonPrimitive?.content != "text"
+        )
+    }
+}

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/MainViewController.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/MainViewController.kt
@@ -8,3 +8,5 @@ private val app = App.getInstanceAndInitializeInBackground(IosPromptModel())
 fun MainViewController() = ComposeUIViewController {
     app.Content()
 }
+
+fun HandleUrl(url: String) = app.handleUrl(url)

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.ios.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.ios.kt
@@ -1,0 +1,41 @@
+package com.android.identity.testapp.provisioning.model
+
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.securearea.CreateKeySettings
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.SecureAreaRepository
+import org.multipaz.securearea.SecureEnclaveCreateKeySettings
+import org.multipaz.securearea.cloud.CloudCreateKeySettings
+import org.multipaz.securearea.config.SecureAreaConfiguration
+import org.multipaz.securearea.config.SecureAreaConfigurationAndroidKeystore
+import org.multipaz.securearea.config.SecureAreaConfigurationCloud
+import org.multipaz.securearea.config.SecureAreaConfigurationSoftware
+import org.multipaz.securearea.software.SoftwareCreateKeySettings
+import org.multipaz.testapp.platformSecureAreaProvider
+
+actual suspend fun SecureAreaRepository.byConfiguration(
+    secureAreaConfiguration: SecureAreaConfiguration,
+    challenge: ByteString
+): Pair<SecureArea, CreateKeySettings> {
+    return when(secureAreaConfiguration) {
+        is SecureAreaConfigurationSoftware -> Pair(
+            getImplementation("SoftwareSecureArea")!!,
+            SoftwareCreateKeySettings.Builder()
+                .applyConfiguration(secureAreaConfiguration)
+                .build()
+        )
+
+        is SecureAreaConfigurationAndroidKeystore -> Pair(
+            platformSecureAreaProvider().get(),
+            SecureEnclaveCreateKeySettings.Builder()
+                .build()
+        )
+
+        is SecureAreaConfigurationCloud -> Pair(
+            getImplementation(secureAreaConfiguration.cloudSecureAreaId)!!,
+            CloudCreateKeySettings.Builder(challenge)
+                .applyConfiguration(secureAreaConfiguration)
+                .build()
+        )
+    }
+}

--- a/server/src/main/java/com/android/identity/wallet/server/CloudSecureAreaServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/CloudSecureAreaServlet.kt
@@ -16,7 +16,7 @@ import org.multipaz.rpc.backend.Configuration
 import org.multipaz.rpc.backend.BackendEnvironment
 import org.multipaz.rpc.backend.Resources
 import org.multipaz.rpc.backend.getTable
-import org.multipaz.provisioning.WalletServerSettings
+import org.multipaz.provisioning.ProvisioningBackendSettings
 import org.multipaz.securearea.cloud.CloudSecureAreaServer
 import org.multipaz.securearea.cloud.SimplePassphraseFailureEnforcer
 import org.multipaz.server.BaseHttpServlet
@@ -186,7 +186,7 @@ class CloudSecureAreaServlet : BaseHttpServlet() {
 
         private fun createCloudSecureArea(serverEnvironment: BackendEnvironment): CloudSecureAreaServer {
             Security.addProvider(BouncyCastleProvider())
-            val settings = WalletServerSettings(serverEnvironment.getInterface(Configuration::class)!!)
+            val settings = ProvisioningBackendSettings(serverEnvironment.getInterface(Configuration::class)!!)
             return CloudSecureAreaServer(
                 serverSecureAreaBoundKey = keyMaterial.serverSecureAreaBoundKey,
                 attestationKey = keyMaterial.attestationKey,

--- a/server/src/main/java/com/android/identity/wallet/server/RpcServlet.kt
+++ b/server/src/main/java/com/android/identity/wallet/server/RpcServlet.kt
@@ -2,7 +2,7 @@ package org.multipaz.wallet.server
 
 import org.multipaz.rpc.handler.RpcDispatcherLocal
 import org.multipaz.rpc.handler.RpcExceptionMap
-import org.multipaz.provisioning.wallet.WalletServerState
+import org.multipaz.provisioning.wallet.ProvisioningBackendState
 import org.multipaz.server.BaseRpcHttpServlet
 
 // To run this servlet for development, use this command:
@@ -14,10 +14,10 @@ import org.multipaz.server.BaseRpcHttpServlet
 //
 class RpcServlet : BaseRpcHttpServlet() {
     override fun buildExceptionMap(exceptionMapBuilder: RpcExceptionMap.Builder) {
-        WalletServerState.registerExceptions(exceptionMapBuilder)
+        ProvisioningBackendState.registerExceptions(exceptionMapBuilder)
     }
 
     override fun buildDispatcher(dispatcherBuilder: RpcDispatcherLocal.Builder) {
-        WalletServerState.registerAll(dispatcherBuilder)
+        ProvisioningBackendState.registerAll(dispatcherBuilder)
     }
 }


### PR DESCRIPTION
 - Forked openid4vci provisioning "back-end" code to run it inside the testapp.
 - Added simple ProvisioningModel to drive the provisioning and fetching the initial batch of credentials.
 - Added infrastructure to run "back-end" code in-app directly (without RPC layer).
 - Added app links infrastructure on Android only, universal links (iOS) are not hooked up yet.

Test: successfully ran provisioning on Android using our own OpenId4VCI issuing authority server, both in-app and through existing wallet server. Unit tests passed. Note: I've used my own private server for app links testing, app.multipaz.org is not set up yet.
