### PR TITLE
Fix some more ErrorProne lint warnings.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
@@ -603,7 +603,11 @@ class CredentialData {
         CredentialData data = new CredentialData(context, storageDirectory, credentialName);
         String dataKeyAlias = getDataKeyAliasFromCredentialName(credentialName);
         try {
-            data.loadFromDisk(dataKeyAlias);
+            if (!data.loadFromDisk(dataKeyAlias)) {
+                Log.e(TAG, "Error loading file from disk. Deleting anyway.");
+                file.delete();
+                return null;
+            }
         } catch (RuntimeException e) {
             Log.e(TAG, "Error parsing file on disk (old version?). Deleting anyway.");
             file.delete();
@@ -666,7 +670,7 @@ class CredentialData {
         CredentialData data = new CredentialData(context, storageDirectory, credentialName);
         String dataKeyAlias = getDataKeyAliasFromCredentialName(credentialName);
         try {
-            data.loadFromDisk(dataKeyAlias);
+            var unused = data.loadFromDisk(dataKeyAlias);
         } catch (RuntimeException e) {
             Log.e(TAG, "Error parsing file on disk (old version?). Deleting anyway.");
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1BitString.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1BitString.kt
@@ -23,7 +23,7 @@ class ASN1BitString(
 
     override fun equals(other: Any?): Boolean = other is ASN1BitString && other.value contentEquals value
 
-    override fun hashCode(): Int = value.hashCode()
+    override fun hashCode(): Int = value.contentHashCode()
 
     override fun toString(): String {
         return "ASN1BitString(${renderBitString()})"

--- a/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1OctetString.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1OctetString.kt
@@ -14,7 +14,7 @@ class ASN1OctetString(
 
     override fun equals(other: Any?): Boolean = other is ASN1OctetString && other.value contentEquals value
 
-    override fun hashCode(): Int = value.hashCode()
+    override fun hashCode(): Int = value.contentHashCode()
 
     override fun toString(): String {
         return "ASN1OctetString(${value.toHex()})"

--- a/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1RawObject.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/asn1/ASN1RawObject.kt
@@ -21,7 +21,7 @@ class ASN1RawObject(
             other.tag == tag &&
             other.content contentEquals content
 
-    override fun hashCode(): Int = content.hashCode()
+    override fun hashCode(): Int = content.contentHashCode()
 
     override fun toString(): String {
         return "ASN1RawObject($cls, $enc, $tag, ${content.toHex()})"

--- a/multipaz/src/commonMain/kotlin/org/multipaz/prompt/SinglePromptModel.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/prompt/SinglePromptModel.kt
@@ -77,7 +77,9 @@ class SinglePromptModel<ParametersT, ResultT>(
                     try {
                         delay(lingerDuration)
                     } finally {
-                        mutableDialogState.emit(NoDialogState(false))
+                        withContext(NonCancellable) {
+                            mutableDialogState.emit(NoDialogState(false))
+                        }
                     }
                 }
             } else {


### PR DESCRIPTION
This ports some fixes upstream so we don't need to reapply them whenever we mirror this to an environment that uses ErrorProne.

There are 3 different warnings this fixes:
- Unused return values.
- Hashing an array object instead of the contents of the array (fixed this by using contentHashCode() instead).
- Calling a suspend function in a finally block (fixed this by wrapping in a withContext(NonCancellable) block).

Test: ./gradlew check && ./gradlew connectedCheck
Test: testapp, creating documents
Test: testapp, mdoc sharing an mdl using NFC
Test: testapp, mdoc sharing an mdl a QR code

- [X] Tests pass