### PR TITLE
Move DEVELOPMENT_TEAM into separate configuration file.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ captures
 !*.xcodeproj/project.xcworkspace/
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
+samples/testapp/iosApp/DeveloperConfig.xcconfig

--- a/DEVELOPER-ENVIRONMENT.md
+++ b/DEVELOPER-ENVIRONMENT.md
@@ -1,0 +1,27 @@
+# Developer Environment
+
+We use Android Studio for development which can be downloaded from
+https://developer.android.com/studio.
+
+# Mac OS
+
+The preferred developer environment is Mac OS since this also allows building the iOS variant
+of our Kotlin Multiplatform codebase. You will need a recent version of XCode installed along
+with XCode command-line tools. See https://developer.apple.com/xcode/resources/ for more
+information. XCode is used mainly just to launch and debug Testapp, all development usually
+happens in Android Studio.
+
+To build Testapp in XCode you will need to create the `samples/testapp/iosApp/DeveloperConfig.xcconfig`
+file with the Team ID assigned to you by Apple. The project includes a template which can
+be used for this in the `samples/testapp/iosApp/DeveloperConfig.xcconfig.template`
+file.
+
+```shell
+cp samples/testapp/iosApp/DeveloperConfig.xcconfig.template samples/testapp/iosApp/DeveloperConfig.xcconfig && \
+$EDITOR samples/testapp/iosApp/DeveloperConfig.xcconfig
+```
+
+# Linux and Windows
+
+We also support building on Linux and Windows. In this setup, iOS libraries are not built
+but non-iOS artifacts for other platforms will work fine.

--- a/README.md
+++ b/README.md
@@ -49,10 +49,16 @@ for example conversion from `ByteArray` to `ByteString` and similar things.
 
 ## Getting involved
 
-We have resources for people already involved and people wishing to get involved
+We have resources for people already involved and people wishing to contribute
+to the Multipaz project
 - [CONTRIBUTING.md](CONTRIBUTING.md) for how to get involved with the project and send PRs.
 - [CODING-STYLE.md](CODING-STYLE.md) for guidelines on writing code to be included in the project.
 - [TESTING.md](TESTING.md) explains our approach to unit and manual testing.
+- [DEVELOPER-ENVIRONMENT.md](DEVELOPER-ENVIRONMENT.md) for how to set up your system for building Multipaz.
+
+Note: If you're just looking to use the Multipaz libraries you do not need to build
+the entire Multipaz project from source. Instead, just use our released libraries,
+see the next section for an example of this.
 
 ## Examples / Samples
 

--- a/samples/testapp/iosApp/DeveloperConfig.xcconfig.template
+++ b/samples/testapp/iosApp/DeveloperConfig.xcconfig.template
@@ -1,0 +1,3 @@
+// Set this to ID for your XCode Development Team, without quotes
+//
+DEVELOPMENT_TEAM = 

--- a/samples/testapp/iosApp/TestApp.xcodeproj/project.pbxproj
+++ b/samples/testapp/iosApp/TestApp.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 058557D8273AAEEB004C7B11 /* Preview Assets.xcassets */; };
 		2152FB042600AC8F00CF470E /* iOSApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2152FB032600AC8F00CF470E /* iOSApp.swift */; };
 		7555FF83242A565900829871 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7555FF82242A565900829871 /* ContentView.swift */; };
+		7BAB1AC82DB687B000CAC98C /* DeveloperConfig.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -21,6 +22,7 @@
 		7555FF82242A565900829871 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		7555FF8C242A565B00829871 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		7B39212C2C27D97A00A18AB5 /* TestApp.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TestApp.entitlements; sourceTree = "<group>"; };
+		7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = DeveloperConfig.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -52,6 +54,7 @@
 		7555FF72242A565900829871 = {
 			isa = PBXGroup;
 			children = (
+				7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */,
 				7555FF7D242A565900829871 /* TestApp */,
 				7555FF7C242A565900829871 /* Products */,
 				42799AB246E5F90AF97AA0EF /* Frameworks */,
@@ -145,6 +148,7 @@
 			files = (
 				058557D9273AAEEB004C7B11 /* Preview Assets.xcassets in Resources */,
 				058557BB273AAA24004C7B11 /* Assets.xcassets in Resources */,
+				7BAB1AC82DB687B000CAC98C /* DeveloperConfig.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -309,6 +313,7 @@
 		};
 		7555FFA6242A565B00829871 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */;
 			buildSettings = {
 				APP_NAME = "Test App";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -317,7 +322,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"testApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -340,6 +345,7 @@
 		};
 		7555FFA7242A565B00829871 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = 7BAB1AC72DB687B000CAC98C /* DeveloperConfig.xcconfig */;
 			buildSettings = {
 				APP_NAME = "Test App";
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
@@ -348,7 +354,7 @@
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_ASSET_PATHS = "\"testApp/Preview Content\"";
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = "$(inherited)";
 				ENABLE_PREVIEWS = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This new configuration file is in .gitignore so with this change developers will need to set it only once and won't need to unset it before committing.

Also add DEVELOPER-ENVIRONMENT.md file to help explain what needs to be done to set up a developer environment.
