### PR TITLE
Tweaks to RPC authorization protocol and API

### DIFF
--- a/multipaz-provisioning/src/main/java/org/multipaz/provisioning/openid4vci/Openid4VciRegistrationState.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/provisioning/openid4vci/Openid4VciRegistrationState.kt
@@ -1,7 +1,6 @@
 package org.multipaz.provisioning.openid4vci
 
 import org.multipaz.cbor.annotation.CborSerializable
-import org.multipaz.rpc.annotation.RpcMethod
 import org.multipaz.rpc.annotation.RpcState
 import org.multipaz.provisioning.RegistrationConfiguration
 import org.multipaz.provisioning.Registration

--- a/multipaz-provisioning/src/main/java/org/multipaz/provisioning/openid4vci/RequestCredentialsUsingProofOfPossession.kt
+++ b/multipaz-provisioning/src/main/java/org/multipaz/provisioning/openid4vci/RequestCredentialsUsingProofOfPossession.kt
@@ -3,8 +3,6 @@ package org.multipaz.provisioning.openid4vci
 import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.device.DeviceAssertion
 import org.multipaz.rpc.annotation.RpcState
-import org.multipaz.rpc.backend.BackendEnvironment
-import org.multipaz.rpc.backend.getTable
 import org.multipaz.provisioning.CredentialConfiguration
 import org.multipaz.provisioning.CredentialFormat
 import org.multipaz.provisioning.CredentialRequest

--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/rpc/RpcAuthAssertionTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/rpc/RpcAuthAssertionTest.kt
@@ -1,0 +1,185 @@
+package org.multipaz.rpc
+
+import androidx.test.platform.app.InstrumentationRegistry
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.encodeToByteString
+import org.junit.Before
+import org.multipaz.context.initializeApplication
+import org.multipaz.device.DeviceCheck
+import org.multipaz.device.toCbor
+import org.multipaz.rpc.handler.RpcAuthClientSession
+import org.multipaz.rpc.handler.RpcAuthInspector
+import org.multipaz.rpc.handler.RpcAuthInspectorAssertion
+import org.multipaz.rpc.handler.RpcAuthIssuerAssertion
+import org.multipaz.rpc.backend.BackendEnvironment
+import org.multipaz.rpc.handler.AesGcmCipher
+import org.multipaz.rpc.handler.RpcAuthError
+import org.multipaz.rpc.handler.RpcAuthException
+import org.multipaz.rpc.handler.RpcDispatcher
+import org.multipaz.rpc.handler.RpcDispatcherAuth
+import org.multipaz.rpc.handler.RpcDispatcherLocal
+import org.multipaz.rpc.handler.RpcExceptionMap
+import org.multipaz.rpc.handler.RpcNotifier
+import org.multipaz.rpc.test.TestInterfaceStub
+import org.multipaz.rpc.test.TestState
+import org.multipaz.rpc.test.register
+import org.multipaz.securearea.AndroidKeystoreSecureArea
+import org.multipaz.securearea.SecureArea
+import org.multipaz.securearea.SecureAreaProvider
+import org.multipaz.storage.Storage
+import org.multipaz.storage.ephemeral.EphemeralStorage
+import kotlin.random.Random
+import kotlin.reflect.KClass
+import kotlin.reflect.cast
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
+import kotlin.test.assertTrue
+import kotlin.test.fail
+
+fun getPlatformSecureAreaProvider(storage: Storage): SecureAreaProvider<SecureArea> {
+    return SecureAreaProvider(Dispatchers.Default) {
+        AndroidKeystoreSecureArea.create(storage)
+    }
+}
+
+class TestBackendEnvironment: BackendEnvironment {
+    val storage = EphemeralStorage()
+    val secureAreaProvider = getPlatformSecureAreaProvider(storage)
+
+    override fun <T : Any> getInterface(clazz: KClass<T>): T {
+        return clazz.cast(when (clazz) {
+            Storage::class -> storage
+            SecureAreaProvider::class -> secureAreaProvider
+            RpcAuthInspector::class -> RpcAuthInspectorAssertion.Default
+            else -> throw IllegalArgumentException("no such class available: ${clazz.simpleName}")
+        })
+    }
+}
+
+class RpcAuthAssertionTest {
+    private suspend fun buildDispatcher(authClientId: String? = "clientId"): RpcDispatcher {
+        val builder = RpcDispatcherLocal.Builder()
+        TestState.register(builder)
+        val cipher = AesGcmCipher(Random.Default.nextBytes(16))
+        val environment = TestBackendEnvironment()
+        val local = builder.build(environment, cipher, RpcExceptionMap.Builder().build())
+        val secureArea = environment.secureAreaProvider.get()
+        val challenge = "clientId".encodeToByteString()
+        val deviceAttestation = DeviceCheck.generateAttestation(secureArea, challenge)
+        val deviceAttestationId = deviceAttestation.deviceAttestationId
+        val clientTable = environment.storage.getTable(RpcAuthInspectorAssertion.rpcClientTableSpec)
+        clientTable.insert(
+            key = "clientId",
+            data = ByteString(deviceAttestation.deviceAttestation.toCbor())
+        )
+        return if (authClientId != null) {
+            val rpcAuth = RpcAuthIssuerAssertion(authClientId, secureArea, deviceAttestationId)
+            RpcDispatcherAuth(local, rpcAuth)
+        } else {
+            local
+        }
+    }
+
+    @Before
+    fun setup() {
+        initializeApplication(InstrumentationRegistry.getInstrumentation().context)
+    }
+
+    @Test
+    fun testValidAuth() = runTest {
+        val dispatcher = buildDispatcher()
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        val session1 = withContext(RpcAuthClientSession()) {
+            val result0 = target.test("foo")
+            assertTrue(result0.startsWith("foo@clientId."))
+            val session = result0.substring(4)
+            val result1 = target.test("bar")
+            assertTrue(result1.startsWith("bar@clientId."))
+            assertEquals(session, result1.substring(4))
+            val result2 = target.test("buz")
+            assertTrue(result2.startsWith("buz@clientId."))
+            assertEquals(session, result2.substring(4))
+            session
+        }
+        val session2 = withContext(RpcAuthClientSession()) {
+            target.test("foobar").substring(7)
+        }
+        assertNotEquals(session1, session2)
+    }
+
+    @Test
+    fun testNoSession() = runTest {
+        val dispatcher = buildDispatcher()
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        try {
+            target.test("foo")
+            fail()
+        } catch(err: IllegalStateException) {
+            // noop
+        }
+    }
+
+    @Test
+    fun testBadClient() = runTest {
+        val dispatcher = buildDispatcher("badClientId")
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        withContext(RpcAuthClientSession()) {
+            try {
+                target.test("foo")
+                fail()
+            } catch (err: RpcAuthException) {
+                assertEquals(RpcAuthError.UNKNOWN_CLIENT_ID, err.rpcAuthError)
+            }
+        }
+    }
+
+    @Test
+    fun testShortFakeNonce() = runTest {
+        val dispatcher = buildDispatcher()
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        val session = RpcAuthClientSession()
+        session.nonce = "badNonce".encodeToByteString()
+        withContext(session) {
+            try {
+                target.test("foo")
+                fail()
+            } catch (err: RpcAuthException) {
+                assertEquals(RpcAuthError.FAILED, err.rpcAuthError)
+            }
+        }
+    }
+
+    @Test
+    fun testLongFakeNonce() = runTest {
+        val dispatcher = buildDispatcher()
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        val session = RpcAuthClientSession()
+        session.nonce = "badNonce-MustBeRelativelyLongToTestAnotherPath".encodeToByteString()
+        withContext(session) {
+            try {
+                target.test("foo")
+                fail()
+            } catch (err: RpcAuthException) {
+                assertEquals(RpcAuthError.FAILED, err.rpcAuthError)
+            }
+        }
+    }
+
+    @Test
+    fun testNoAuth() = runTest {
+        val dispatcher = buildDispatcher(null)
+        val target = TestInterfaceStub("test", dispatcher, RpcNotifier.SILENT)
+        withContext(RpcAuthClientSession()) {
+            try {
+                target.test("foo")
+                fail()
+            } catch(err: RpcAuthException) {
+                assertEquals(RpcAuthError.REQUIRED, err.rpcAuthError)
+            }
+        }
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/device/AssertionRpcAuth.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/device/AssertionRpcAuth.kt
@@ -13,7 +13,7 @@ import org.multipaz.rpc.handler.RpcAuthIssuerAssertion
 class AssertionRpcAuth(
     val target: String,
     val method: String,
-    val nonce: String,
+    val nonce: ByteString,
     val timestamp: Instant,
     val clientId: String,
     val payloadHash: ByteString

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/backend/RpcAuthBackendDelegate.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/backend/RpcAuthBackendDelegate.kt
@@ -17,7 +17,7 @@ object RpcAuthBackendDelegate: RpcAuthInspector {
         method: String,
         payload: Bstr,
         authMessage: DataItem
-    ): CoroutineContext? =
+    ): CoroutineContext =
         BackendEnvironment.getInterface(RpcAuthInspector::class)!!.authCheck(
             target,
             method,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/client/RpcStub.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/client/RpcStub.kt
@@ -6,6 +6,7 @@ import org.multipaz.cbor.buildCborArray
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.rpc.handler.RpcDispatcher
 import org.multipaz.rpc.handler.RpcNotifier
+import kotlin.concurrent.Volatile
 
 /**
  * Base class for generated RPC stubs.
@@ -16,7 +17,7 @@ abstract class RpcStub(
     val rpcEndpoint: String, // RPC endpoint name from `RpcState` annotation endpoint parameter
     val rpcDispatcher: RpcDispatcher,
     val rpcNotifier: RpcNotifier,
-    var rpcState: DataItem  // Opaque back-end data.
+    @Volatile var rpcState: DataItem  // Opaque back-end data.
 ) {
     fun toCbor(): ByteArray = Cbor.encode(toDataItem())
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/AesGcmCipher.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/AesGcmCipher.kt
@@ -23,6 +23,10 @@ class AesGcmCipher(val key: ByteArray) : SimpleCipher {
     }
 
     override fun decrypt(ciphertext: ByteArray): ByteArray {
+        if (ciphertext.size <= 12) {
+            // Cannot be valid.
+            throw SimpleCipher.DataTamperedException()
+        }
         val iv = ByteArray(12)
         ciphertext.copyInto(iv, endIndex = iv.size)
         try {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthClientSession.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthClientSession.kt
@@ -1,0 +1,18 @@
+package org.multipaz.rpc.handler
+
+import kotlinx.io.bytestring.ByteString
+import kotlin.coroutines.CoroutineContext
+
+class RpcAuthClientSession: CoroutineContext.Element {
+    object Key : CoroutineContext.Key<RpcAuthClientSession>
+
+    override val key: CoroutineContext.Key<RpcAuthClientSession>
+        get() = Key
+
+    var nonce: ByteString = EMPTY_NONCE
+        internal set
+
+    companion object {
+        val EMPTY_NONCE = ByteString()
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthContext.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthContext.kt
@@ -1,5 +1,6 @@
 package org.multipaz.rpc.handler
 
+import kotlinx.io.bytestring.ByteString
 import kotlin.coroutines.CoroutineContext
 import kotlin.coroutines.coroutineContext
 
@@ -7,10 +8,18 @@ import kotlin.coroutines.coroutineContext
  * An object added to the current coroutine context based on the successful processing of RPC
  * call authorization.
  *
+ * @param [clientId] client instance identifier; could be device, user, or authorization context
+ *     identifier, depending on the specific authorization method.
+ * @param [sessionId] session identifier for the RPC call sequence, empty string indicates
+ *     that the authorization method does not maintain a session.
+ * @param [nextNonce] nonce to be used by the client in next call in the session (if any).
+ *
  * See [RpcAuthInspector].
  */
 class RpcAuthContext(
-    private val clientId: String
+    private val clientId: String,
+    private val sessionId: String,
+    internal val nextNonce: ByteString? = null
 ): CoroutineContext.Element {
     object Key: CoroutineContext.Key<RpcAuthContext>
 
@@ -20,6 +29,10 @@ class RpcAuthContext(
     companion object {
         suspend fun getClientId(): String {
             return coroutineContext[Key]!!.clientId
+        }
+
+        suspend fun getSessionId(): String {
+            return coroutineContext[Key]!!.sessionId
         }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthError.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthError.kt
@@ -16,4 +16,8 @@ enum class RpcAuthError {
     REPLAY,
     /** Authorization validation failed. */
     FAILED,
+    /**
+     * RPC authorization layer mismatch between the server and the client
+     */
+    CONFIG,
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthInspector.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthInspector.kt
@@ -16,14 +16,16 @@ interface RpcAuthInspector {
      * Before an RPC call is made this method is called to do authorization check. Cbor-serialized
      * RPC call parameters (back-end state and call arguments) are passed as [payload].
      * [authMessage] contains fields that are specific for a particular authorization type.
-     * If authorization check succeeds, this method can optionally return [CoroutineContext] data
-     * that will be added to the coroutine context for the RPC call. If authorization check fails,
-     * an exception (typically [RpcAuthException]) __must__ be thrown.
+     * If authorization check succeeds, this method must return an authorization context
+     * containing authorization-related data (it typically should include [RpcAuthContext]).
+     * This context is added to the coroutine context for the RPC call. If authorization check
+     * fails, an exception (typically [RpcAuthException] or [RpcAuthNonceException])
+     * __must__ be thrown.
      */
     suspend fun authCheck(
         target: String,
         method: String,
         payload: Bstr,
-        authMessage: DataItem
-    ): CoroutineContext?
+        authMessage: DataItem,
+    ): CoroutineContext
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthNonceException.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcAuthNonceException.kt
@@ -1,0 +1,10 @@
+package org.multipaz.rpc.handler
+
+import kotlinx.io.bytestring.ByteString
+
+/**
+ * RPC authorization failure with nonce for retry.
+ */
+class RpcAuthNonceException(
+    val nonce: ByteString
+) : RuntimeException()

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcDispatcherAuth.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcDispatcherAuth.kt
@@ -1,8 +1,12 @@
 package org.multipaz.rpc.handler
 
+import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.DataItem
+import org.multipaz.cbor.Simple
+import org.multipaz.util.Logger
+import kotlin.coroutines.coroutineContext
 
 /**
  * [RpcDispatcher] implementation that dispatches RPC call to a [base] dispatcher
@@ -16,12 +20,35 @@ class RpcDispatcherAuth(
         get() = base.exceptionMap
 
     override suspend fun dispatch(target: String, method: String, args: DataItem): List<DataItem> {
-        val payload = Bstr(Cbor.encode(args))
-        val message = rpcAuthIssuer.auth(target, method, payload).also {
-            check(it["payload"] === payload) {
-                "Authenticated message 'payload' field must contain raw RPC message"
+        var retried = false
+        while (true) {
+            val payload = Bstr(Cbor.encode(args))
+            val message = rpcAuthIssuer.auth(target, method, payload).also {
+                check(it["payload"] === payload) {
+                    "Authenticated message 'payload' field must contain raw RPC message"
+                }
             }
+            val result = base.dispatch(target, method, message)
+            val nonce = result[1]
+            if (nonce != Simple.NULL) {
+                val sessionContext = coroutineContext[RpcAuthClientSession.Key]
+                    ?: throw IllegalStateException("RpcAuthClientSessionContext must be provided")
+                sessionContext.nonce = ByteString(nonce.asBstr)
+                if (result[2].asNumber == RpcReturnCode.NONCE_RETRY.ordinal.toLong()) {
+                    if (retried) {
+                        throw RpcAuthException("Nonce error", RpcAuthError.FAILED)
+                    }
+                    Logger.i(TAG, "Nonce rejected, retrying with a fresh nonce")
+                    retried = true
+                    continue
+                }
+            }
+            return result
         }
-        return base.dispatch(target, method, message)
     }
+
+    companion object {
+        const val TAG = "RpcDispatchAuth"
+    }
+
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcReturnCode.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/handler/RpcReturnCode.kt
@@ -2,6 +2,7 @@ package org.multipaz.rpc.handler
 
 /** Constants to determine the result kind in Cbor serialization of the method call response. */
 enum class RpcReturnCode {
-    RESULT,  // followed by DataItem representing result (either flow or serializable)
-    EXCEPTION  // Followed by exceptionId, then DataItem representing exception
+    RESULT,  // Followed by DataItem representing result (either flow or serializable)
+    EXCEPTION,  // Followed by exceptionId, then DataItem representing exception
+    NONCE_RETRY  // Nothing to follow, request to retry request with refreshed nonce
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/test/TestInterface.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/test/TestInterface.kt
@@ -1,0 +1,13 @@
+package org.multipaz.rpc.test
+
+import org.multipaz.rpc.annotation.RpcInterface
+import org.multipaz.rpc.annotation.RpcMethod
+
+/**
+ * Test interface, added purely to be able to test against.
+ */
+@RpcInterface
+interface TestInterface {
+    @RpcMethod
+    suspend fun test(param: String): String
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/rpc/test/TestState.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/rpc/test/TestState.kt
@@ -1,0 +1,23 @@
+package org.multipaz.rpc.test
+
+import org.multipaz.cbor.annotation.CborSerializable
+import org.multipaz.rpc.annotation.RpcState
+import org.multipaz.rpc.handler.RpcAuthContext
+import org.multipaz.rpc.handler.RpcAuthInspector
+import org.multipaz.rpc.backend.RpcAuthBackendDelegate
+
+/**
+ * Test class, added purely to be able to test against.
+ */
+@RpcState(
+    endpoint = "test",
+    creatable = true
+)
+@CborSerializable
+class TestState: TestInterface, RpcAuthInspector by RpcAuthBackendDelegate {
+    override suspend fun test(param: String): String {
+        return "$param@${RpcAuthContext.getClientId()}.${RpcAuthContext.getSessionId()}"
+    }
+
+    companion object
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/storage/StorageTable.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/storage/StorageTable.kt
@@ -57,8 +57,9 @@ interface StorageTable {
      *   at any moment.
      * - [data] the data to store.
      *
-     * Returns the key for the newly-inserted record. Generated keys only contain ASCII
-     * alphanumeric characters.
+     * Returns the key for the newly-inserted record. Generated keys only contain letters, digits,
+     * and characters '_' and '-' (base64url character set). This restriction does not apply to
+     * the user-provided keys.
      */
     suspend fun insert(
         key: String?,

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/RpcAuthTest.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/rpc/RpcAuthTest.kt
@@ -55,7 +55,7 @@ class TestState: TestInterface, RpcAuthInspector {
         if (expected != actual) {
             throw RpcAuthException("Failed", RpcAuthError.FAILED)
         }
-        return RpcAuthContext("validClient")
+        return RpcAuthContext("validClient", "")
     }
 
     companion object

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendProviderLocal.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/backend/ProvisioningBackendProviderLocal.kt
@@ -28,7 +28,8 @@ class ProvisioningBackendProviderLocal: ProvisioningBackendProvider {
         applicationSupportProvider = { applicationSupport!! },
         deviceAssertionMaker = this
     )
-    private val coroutineContext = backendEnvironmentLocal + RpcAuthContext(CLIENT_ID)
+    private val coroutineContext = backendEnvironmentLocal +
+            RpcAuthContext(CLIENT_ID, SESSION_ID)
 
     override val extraCoroutineContext: CoroutineContext get() = coroutineContext
 
@@ -93,5 +94,6 @@ class ProvisioningBackendProviderLocal: ProvisioningBackendProvider {
         )
 
         const val CLIENT_ID = "__LOCAL__"
+        const val SESSION_ID = "__SESSION__"
     }
 }

--- a/server-env/src/main/java/com/android/identity/server/BaseRpcHttpServlet.kt
+++ b/server-env/src/main/java/com/android/identity/server/BaseRpcHttpServlet.kt
@@ -8,14 +8,12 @@ import org.multipaz.rpc.handler.RpcNotificationsLocalPoll
 import org.multipaz.rpc.handler.HttpHandler
 import org.multipaz.rpc.handler.SimpleCipher
 import org.multipaz.rpc.backend.BackendEnvironment
-import org.multipaz.rpc.backend.getTable
 import org.multipaz.rpc.transport.HttpTransport
 import org.multipaz.storage.StorageTableSpec
 import org.multipaz.util.Logger
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import kotlinx.coroutines.runBlocking
-import kotlinx.coroutines.withContext
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.storage.Storage
 import java.lang.UnsupportedOperationException
@@ -92,12 +90,10 @@ abstract class BaseRpcHttpServlet : BaseHttpServlet() {
         val requestData = req.inputStream.readNBytes(requestLength)
         try {
             val bytes = runBlocking {
-                withContext(environment) {
-                    httpHandler.post(
-                        url = "$target/$action",
-                        data = ByteString(requestData)
-                    )
-                }
+                httpHandler.post(
+                    url = "$target/$action",
+                    data = ByteString(requestData)
+                )
             }
             Logger.i(TAG, "$prefix: POST response status 200 (${bytes.size} bytes)")
             resp.outputStream.write(bytes.toByteArray())

--- a/wallet/src/main/java/org/multipaz/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/org/multipaz/wallet/WalletApplication.kt
@@ -148,7 +148,7 @@ class WalletApplication : Application() {
 
         // warm up Direct Access transport to prevent delays later
         initializeApplication(applicationContext)
-        DirectAccess.warmupTransport()
+        //DirectAccess.warmupTransport()
 
         // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
         // based implementation included in the OS itself.
@@ -339,6 +339,7 @@ class WalletApplication : Application() {
                 workRequest
             )
 
+        /*
         CoroutineScope(Dispatchers.IO).launch {
             val allocatedSlots = DirectAccess.enumerateAllocatedSlots();
             if (allocatedSlots.isNotEmpty()) {
@@ -359,6 +360,7 @@ class WalletApplication : Application() {
                 }
             }
         }
+        */
 
         powerOffReceiver = PowerOffReceiver()
         registerReceiver(powerOffReceiver, IntentFilter(Intent.ACTION_SHUTDOWN))
@@ -492,7 +494,7 @@ class WalletApplication : Application() {
             androidKeystoreAttestKeyAvailable = keystoreCapabilities.attestKeySupported,
             androidKeystoreStrongBoxAvailable = keystoreCapabilities.strongBoxSupported,
             androidIsEmulator = isProbablyRunningOnEmulator,
-            directAccessSupported = DirectAccess.isDirectAccessSupported,
+            directAccessSupported = false //DirectAccess.isDirectAccessSupported,
         )
     }
 

--- a/wallet/src/main/java/org/multipaz/wallet/ui/destination/addtowallet/AddToWalletScreen.kt
+++ b/wallet/src/main/java/org/multipaz/wallet/ui/destination/addtowallet/AddToWalletScreen.kt
@@ -40,7 +40,9 @@ import org.multipaz.wallet.util.getUrlQueryFromCustomSchemeUrl
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.multipaz.compose.qrcode.ScanQrCodeDialog
+import org.multipaz.rpc.handler.RpcAuthClientSession
 
 private const val TAG = "AddToWalletScreen"
 
@@ -83,15 +85,17 @@ fun AddToWalletScreen(
     // force a navigation recomposition after processing the Qr code and onNavigate(route) does not work
     val navigateToOnComposable = remember { mutableStateOf<String?>(null) }
     LaunchedEffect(Unit) {
-        issuerDisplayDatas.clear()
-        try {
-            for (data in getIssuerDisplayDatas(walletServerProvider)) {
-                issuerDisplayDatas.add(data)
+        withContext(RpcAuthClientSession()) {
+            issuerDisplayDatas.clear()
+            try {
+                for (data in getIssuerDisplayDatas(walletServerProvider)) {
+                    issuerDisplayDatas.add(data)
+                }
+            } catch (e: Throwable) {
+                loadingIssuerDisplayError.value = e
             }
-        } catch (e: Throwable) {
-            loadingIssuerDisplayError.value = e
+            loadingIssuerDisplayDatas.value = false
         }
-        loadingIssuerDisplayDatas.value = false
     }
 
     // perform a navigateTo (hoisted navigation) from ScanQrDialog to run now after being requested


### PR DESCRIPTION
Tweaks to RPC authorization protocol and API
 - new concept of the RPC session
 - server-generated (rather than just random) nonces
 - automatic retry on stale nonce
 - hooked these to `DeviceAssertion`-based auth

This tightens the security level of our RPC mechanism, but more importantly, we now have all the building blocks that we may need no matter how much we decide to tweak the client authorization mechanics.

Test: added a new unit test, existing tests pass. Tested existing RPC workflows manually.

Signed-off-by: Peter Sorotokin <sorotokin@gmail.com>