### PR TITLE
More changes to clean up lint warnings and prep for other build systems.

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -62,6 +62,7 @@ androidx-sqlite = "2.5.0-alpha12"
 play-services-identity-credentials = "16.0.0-alpha05"
 androidx-credentials = "1.5.0-rc01"
 androidx-credentials-registry-provider = "1.0.0-alpha01"
+errorprone = "2.38.0"
 
 [libraries]
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "uiToolingPreview" }
@@ -141,6 +142,7 @@ postgresql = { module="org.postgresql:postgresql", version.ref = "postgresql" }
 play-services-identity-credentials = {module = "com.google.android.gms:play-services-identity-credentials", version.ref = "play-services-identity-credentials"}
 androidx-credentials = { module = "androidx.credentials:credentials", version.ref="androidx-credentials" }
 androidx-credentials-registry-provider = { module = "androidx.credentials.registry:registry-provider", version.ref = "androidx-credentials-registry-provider" }
+errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref="errorprone"}
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/multipaz-android-legacy/build.gradle.kts
+++ b/multipaz-android-legacy/build.gradle.kts
@@ -50,6 +50,7 @@ dependencies {
     implementation(libs.kotlinx.io.bytestring)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.cbor)
+    implementation(libs.errorprone.annotations)
 
     testImplementation(libs.junit)
     androidTestImplementation(libs.androidx.test.junit)

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfile.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfile.java
@@ -19,6 +19,8 @@ package com.android.identity.android.legacy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.security.cert.X509Certificate;
 
 /**
@@ -90,6 +92,7 @@ public class AccessControlProfile {
          *                                   false otherwise.
          * @return The builder.
          */
+        @CanIgnoreReturnValue
         public @NonNull Builder setUserAuthenticationRequired(boolean userAuthenticationRequired) {
             mProfile.mUserAuthenticationRequired = userAuthenticationRequired;
             return this;
@@ -111,6 +114,7 @@ public class AccessControlProfile {
          * @param userAuthenticationTimeoutMillis the authentication timeout, in milliseconds.
          * @return The builder.
          */
+        @CanIgnoreReturnValue
         public @NonNull Builder setUserAuthenticationTimeout(long userAuthenticationTimeoutMillis) {
             mProfile.mUserAuthenticationTimeoutMillis = userAuthenticationTimeoutMillis;
             return this;
@@ -130,6 +134,7 @@ public class AccessControlProfile {
          * @param readerCertificate the certificate to use for the access control check.
          * @return The builder.
          */
+        @CanIgnoreReturnValue
         public @NonNull Builder setReaderCertificate(@NonNull X509Certificate readerCertificate) {
             mProfile.mReaderCertificate = readerCertificate;
             return this;

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/CredentialData.java
@@ -30,6 +30,8 @@ import android.util.Pair;
 
 import androidx.annotation.NonNull;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.io.File;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -347,6 +349,7 @@ class CredentialData {
         }
     }
 
+    @CanIgnoreReturnValue
     static CredentialData createCredentialData(@NonNull Context context,
                                                @NonNull File storageDirectory,
                                                @NonNull String docType,

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreWritableIdentityCredential.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreWritableIdentityCredential.java
@@ -23,6 +23,8 @@ import android.util.Log;
 
 import androidx.annotation.NonNull;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
@@ -84,6 +86,7 @@ class KeystoreWritableIdentityCredential extends WritableIdentityCredential {
      * @throws CipherSuiteNotSupportedException if the cipher suite is not supported
      * @throws IdentityCredentialException      if unable to communicate with secure hardware.
      */
+    @CanIgnoreReturnValue
     private Collection<X509Certificate> ensureCredentialKey(byte[] challenge) {
 
         if (mKeyPair != null) {

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/PersonalizationData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/PersonalizationData.java
@@ -21,6 +21,8 @@ import android.icu.util.Calendar;
 
 import androidx.annotation.NonNull;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -135,6 +137,7 @@ public class PersonalizationData {
          * @return The builder.
          */
         @SuppressLint("BuilderSetStyle")
+        @CanIgnoreReturnValue
         public @NonNull Builder putEntry(@NonNull String namespace, @NonNull String name,
                 @NonNull Collection<AccessControlProfileId> accessControlProfileIds,
                 @NonNull byte[] value) {
@@ -162,6 +165,7 @@ public class PersonalizationData {
          * @return The builder.
          */
         @SuppressLint("BuilderSetStyle")
+        @CanIgnoreReturnValue
         public @NonNull Builder putEntryString(@NonNull String namespace, @NonNull String name,
                 @NonNull Collection<AccessControlProfileId> accessControlProfileIds,
                 @NonNull String value) {
@@ -183,6 +187,7 @@ public class PersonalizationData {
          * @return The builder.
          */
         @SuppressLint("BuilderSetStyle")
+        @CanIgnoreReturnValue
         public @NonNull Builder putEntryBytestring(@NonNull String namespace, @NonNull String name,
                 @NonNull Collection<AccessControlProfileId> accessControlProfileIds,
                 @NonNull byte[] value) {
@@ -205,6 +210,7 @@ public class PersonalizationData {
          * @return The builder.
          */
         @SuppressLint("BuilderSetStyle")
+        @CanIgnoreReturnValue
         public @NonNull Builder putEntryInteger(@NonNull String namespace, @NonNull String name,
                 @NonNull Collection<AccessControlProfileId> accessControlProfileIds,
                 long value) {
@@ -227,6 +233,7 @@ public class PersonalizationData {
          * @return The builder.
          */
         @SuppressLint("BuilderSetStyle")
+        @CanIgnoreReturnValue
         public @NonNull Builder putEntryBoolean(@NonNull String namespace, @NonNull String name,
                 @NonNull Collection<AccessControlProfileId> accessControlProfileIds,
                 boolean value) {
@@ -253,6 +260,7 @@ public class PersonalizationData {
          * @return The builder.
          */
         @SuppressLint("BuilderSetStyle")
+        @CanIgnoreReturnValue
         public @NonNull Builder putEntryCalendar(@NonNull String namespace, @NonNull String name,
                 @NonNull Collection<AccessControlProfileId> accessControlProfileIds,
                 @NonNull Calendar value) {
@@ -267,6 +275,7 @@ public class PersonalizationData {
          * @param profile The access control profile.
          * @return The builder.
          */
+        @CanIgnoreReturnValue
         public @NonNull Builder addAccessControlProfile(@NonNull AccessControlProfile profile) {
             mData.mProfiles.add(profile);
             return this;

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/SimpleResultData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/SimpleResultData.java
@@ -19,6 +19,8 @@ package com.android.identity.android.legacy;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
+
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -135,21 +137,25 @@ class SimpleResultData extends ResultData {
             this.mResultData = new SimpleResultData();
         }
 
+        @CanIgnoreReturnValue
         Builder setStaticAuthenticationData(byte[] staticAuthenticationData) {
             this.mResultData.mStaticAuthenticationData = staticAuthenticationData;
             return this;
         }
 
+        @CanIgnoreReturnValue
         Builder setAuthenticatedData(byte[] authenticatedData) {
             this.mResultData.mAuthenticatedData = authenticatedData;
             return this;
         }
 
+        @CanIgnoreReturnValue
         Builder setEcdsaSignature(byte[] ecdsaSignature) {
             this.mResultData.mEcdsaSignature = ecdsaSignature;
             return this;
         }
 
+        @CanIgnoreReturnValue
         Builder setMessageAuthenticationCode(byte [] messageAuthenticationCode) {
             this.mResultData.mMessageAuthenticationCode = messageAuthenticationCode;
             return this;
@@ -164,12 +170,14 @@ class SimpleResultData extends ResultData {
             return innerMap;
         }
 
+        @CanIgnoreReturnValue
         Builder addEntry(String namespaceName, String name, byte[] value) {
             Map<String, EntryData> innerMap = getOrCreateInnerMap(namespaceName);
             innerMap.put(name, new EntryData(value, STATUS_OK));
             return this;
         }
 
+        @CanIgnoreReturnValue
         Builder addErrorStatus(String namespaceName, String name, @Status int status) {
             Map<String, EntryData> innerMap = getOrCreateInnerMap(namespaceName);
             innerMap.put(name, new EntryData(null, status));

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Util.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Util.kt
@@ -280,7 +280,7 @@ object Util {
         val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss", Locale.US)
         df.timeZone = parsedTz
         val date = try {
-            df.parse(dateString)
+            df.parse(dateString)!!
         } catch (e: ParseException) {
             throw RuntimeException("Error parsing string", e)
         }

--- a/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/graphhash/EdgeKind.kt
+++ b/multipaz-cbor-rpc/src/main/kotlin/org/multipaz/graphhash/EdgeKind.kt
@@ -2,6 +2,8 @@ package org.multipaz.graphhash
 
 import kotlinx.io.bytestring.ByteString
 
+// ErrorProne doesn't understand that all values here are immutable. Suppress its warning.
+@Suppress("ImmutableEnum")
 enum class EdgeKind(
     val mark: ByteString
 ) {

--- a/multipaz/src/androidMain/AndroidManifest.xml
+++ b/multipaz/src/androidMain/AndroidManifest.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2025 The Android Open Source Project
+
+     Licensed under the Apache License, Version 2.0 (the "License");
+     you may not use this file except in compliance with the License.
+     You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+     Unless required by applicable law or agreed to in writing, software
+     distributed under the License is distributed on an "AS IS" BASIS,
+     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     See the License for the specific language governing permissions and
+     limitations under the License.
+-->
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    android:exported="true">
+</manifest>

--- a/multipaz/src/androidMain/kotlin/org/multipaz/device/DeviceCheck.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/device/DeviceCheck.android.kt
@@ -9,7 +9,6 @@ import kotlinx.io.bytestring.ByteString
  * Generates statements validating device/app/OS integrity. Details of these
  * statements are inherently platform-specific.
  */
-@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 actual object DeviceCheck {
     actual suspend fun generateAttestation(
         secureArea: SecureArea,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceCheck.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/device/DeviceCheck.kt
@@ -7,7 +7,6 @@ import kotlinx.io.bytestring.ByteString
  * Generates statements validating device/OS/app integrity. Details of these
  * statements are inherently platform-specific.
  */
-@Suppress("EXPECT_ACTUAL_CLASSIFIERS_ARE_IN_BETA_WARNING")
 expect object DeviceCheck {
     /**
      * Generates a device attestation that proves the integrity of the device/OS/wallet app


### PR DESCRIPTION
The main change is integrating errorprone annotations (in particular, CanIgnoreReturnValue). These fix some of the last remaining errorprone warnings, though we still don't have errorprone set up to check this repository (there are some challenges setting it up for Gradle + Android, but maybe an upcoming PR can address these).

In addition, the other build system needs a (minimal) AndroidManifest.xml for the multipaz library, and there are a few other minor warnings this addresses.

Test: Android Studio: Make Project
Test: ./gradlew check
Test: ./gradlew connecedCheck

- [X] Tests pass
