### PR TITLE
Uploading logcat logs after unit tests

### DIFF
--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -40,4 +40,13 @@ jobs:
       with:
         api-level: 34
         arch: x86_64
-        script: ./gradlew connectedCheck
+        script: |
+          ./gradlew connectedCheck
+          mkdir -p build/reports/logcat
+          adb logcat -d > build/reports/logcat/logcat.txt || touch build/reports/logcat/logcat.txt
+    - name: Upload Logcat Output
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: android-logcat
+        path: build/reports/logcat/logcat.txt


### PR DESCRIPTION
Upload the logcat from the device after connectedCheck test to allow debugging.

- [x] Tests pass
- [x] Appropriate changes to README are included in PR
- _none needed_