### PR TITLE
More fixes for issues found during interop testing.

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ see the next section for an example of this.
 For a fully-fledged mDL wallet or reader application, the current answer is to use
 the `samples/testapp` module which works on both Android and iOS. This application
 is intended for developers and as such has a lot of options and settings. It's
-intended to exercise all code in the libraries.
+intended to exercise all code in the libraries. Prebuilt APKs are available
+from https://apps.multipaz.org.
 
 To see how to use the Multipaz libraries from another project, see
 [MpzSecureAreaSample](https://github.com/davidz25/MpzSecureAreaSample) for a

--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustManagerUtil.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustManagerUtil.kt
@@ -49,10 +49,10 @@ internal object TrustManagerUtil {
         // NOTE does not check if it is valid within the validity period of
         // the issuing CA
         check(atTime >= certificate.validityNotBefore) {
-            "Certificate is not yet valid"
+            "Certificate is not yet valid ($atTime < ${certificate.validityNotBefore}"
         }
         check(atTime <= certificate.validityNotAfter) {
-            "Certificate is no longer valid"
+            "Certificate is no longer valid ($atTime > ${certificate.validityNotAfter})"
         }
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustPoint.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustPoint.kt
@@ -1,6 +1,7 @@
 package org.multipaz.trustmanagement
 
 import org.multipaz.crypto.X509Cert
+import org.multipaz.util.toHex
 
 /**
  * Class used for the representation of a trusted CA [X509Cert], a name
@@ -36,5 +37,17 @@ data class TrustPoint(
         result = 31 * result + (displayName?.hashCode() ?: 0)
         result = 31 * result + (displayIcon?.contentHashCode() ?: 0)
         return result
+    }
+
+    override fun toString(): String {
+        val sb = StringBuilder("TrustPoint(certificate=$certificate")
+        if (displayName != null) {
+            sb.append(" displayName=${displayName}")
+        }
+        if (displayIcon != null) {
+            sb.append(" displayIcon=${displayIcon.size} bytes")
+        }
+        sb.append(")")
+        return sb.toString()
     }
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/trustmanagement/TrustManagerTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/trustmanagement/TrustManagerTest.kt
@@ -166,7 +166,7 @@ class TrustManagerTest {
         trustManager.addTrustPoint(TrustPoint(caCertificate))
 
         trustManager.verify(listOf(dsValidInThePastCertificate)).let {
-            assertEquals("Certificate is no longer valid", it.error?.message)
+            assertTrue(it.error!!.message!!.startsWith("Certificate is no longer valid"))
             assertFalse(it.isTrusted)
             assertEquals(3, it.trustChain!!.certificates.size)
             assertEquals(caCertificate, it.trustChain.certificates.last())
@@ -181,7 +181,7 @@ class TrustManagerTest {
         trustManager.addTrustPoint(TrustPoint(caCertificate))
 
         trustManager.verify(listOf(dsValidInTheFutureCertificate)).let {
-            assertEquals("Certificate is not yet valid", it.error?.message)
+            assertTrue(it.error!!.message!!.startsWith("Certificate is not yet valid"))
             assertFalse(it.isTrusted)
             assertEquals(3, it.trustChain!!.certificates.size)
             assertEquals(caCertificate, it.trustChain.certificates.last())

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
@@ -299,7 +299,7 @@ class App private constructor(val promptModel: PromptModel) {
         MdocUtil.generateIacaCertificate(
             iacaKey = iacaKey,
             subject = X500Name.fromName("C=US,CN=OWF Multipaz TEST IACA"),
-            serial = ASN1Integer("26457B125F0AD75217A98EE6CFDEA7FC486221".fromHex()),
+            serial = ASN1Integer.fromRandom(numBits = 128),
             validFrom = certsValidFrom,
             validUntil = certsValidUntil,
             issuerAltNameUrl = "https://github.com/openwallet-foundation-labs/identity-credential",
@@ -334,8 +334,8 @@ class App private constructor(val promptModel: PromptModel) {
     private val bundledReaderRootCert: X509Cert by lazy {
         MdocUtil.generateReaderRootCertificate(
             readerRootKey = bundledReaderRootKey,
-            subject = X500Name.fromName("CN=OWF IC TestApp Reader Root"),
-            serial = ASN1Integer(1L),
+            subject = X500Name.fromName("CN=OWF Multipaz TestApp Reader Root"),
+            serial = ASN1Integer.fromRandom(numBits = 128),
             validFrom = certsValidFrom,
             validUntil = certsValidUntil,
         )
@@ -393,7 +393,7 @@ class App private constructor(val promptModel: PromptModel) {
                     readerRootKey = readerRootKey,
                     readerKey = readerKey.publicKey,
                     subject = X500Name.fromName("CN=OWF IC TestApp Reader Cert"),
-                    serial = ASN1Integer(1L),
+                    serial = ASN1Integer.fromRandom(numBits = 128),
                     validFrom = certsValidFrom,
                     validUntil = certsValidUntil,
                 )
@@ -418,7 +418,7 @@ class App private constructor(val promptModel: PromptModel) {
         issuerTrustManager.addTrustPoint(
             TrustPoint(
                 certificate = iacaCert,
-                displayName = "OWF IC TestApp Issuer",
+                displayName = "OWF Multipaz TestApp",
                 displayIcon = null
             )
         )
@@ -462,7 +462,7 @@ class App private constructor(val promptModel: PromptModel) {
         readerTrustManager.addTrustPoint(
             TrustPoint(
                 certificate = readerRootCert,
-                displayName = "OWF IC TestApp",
+                displayName = "OWF Multipaz TestApp",
                 displayIcon = Res.readBytes("files/utopia-brewery.png")
             )
         )

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppPresentmentSource.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppPresentmentSource.kt
@@ -14,10 +14,15 @@ import org.multipaz.trustmanagement.TrustPoint
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
 import org.multipaz.models.presentment.CredentialForPresentment
+import org.multipaz.util.Logger
 
 class TestAppPresentmentSource(
     val app: App
 ): PresentmentSource {
+
+    companion object {
+        private const val TAG = "PresentmentSource"
+    }
 
     override val documentTypeRepository: DocumentTypeRepository
         get() = app.documentTypeRepository
@@ -28,6 +33,9 @@ class TestAppPresentmentSource(
             if (trustResult.isTrusted) {
                 trustResult.trustPoints[0]
             } else {
+                trustResult.error?.let {
+                    Logger.w(TAG, "Trust-result error", it)
+                }
                 null
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/DocumentStoreScreen.kt
@@ -328,8 +328,8 @@ private fun generateDsKeyAndCert(
         iacaCert = iacaCert,
         iacaKey = iacaKey,
         dsKey = dsKey.publicKey,
-        subject = X500Name.fromName("C=ZZ,CN=OWF Identity Credential TEST DS"),
-        serial = ASN1Integer("26457B125F0AD75217A98EE6CFDEA7FC486221".fromHex()),
+        subject = X500Name.fromName("C=US,CN=OWF Multipaz TEST DS"),
+        serial = ASN1Integer.fromRandom(numBits = 128),
         validFrom = dsCertValidFrom,
         validUntil = dsCertsValidUntil,
     )


### PR DESCRIPTION
- Introduce ASN1Integer.fromRandom() and use this for serial numbers instead of hard-coding a serial number (!).
- Add helpful debug information in TrustManager errors.
- Log the TrustManager error if set.
- Add more helpful toString() method for TrustPoint.
- Change the displayName for our built-in TrustPoints for own certificates.
- Update DS subject name.
- Mention https://apps.multipaz.org in README.md.

Test: Manually tested.
