### PR TITLE
Upstreamed differences in g3 between the imported version and the latest.

### DIFF
--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfile.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfile.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import java.security.cert.X509Certificate;
+import java.util.Objects;
 
 /**
  * A class used to specify access controls.
@@ -148,5 +149,25 @@ public class AccessControlProfile {
         public @NonNull AccessControlProfile build() {
             return mProfile;
         }
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AccessControlProfile)) {
+            return false;
+        }
+        AccessControlProfile that = (AccessControlProfile) o;
+        return Objects.equals(mAccessControlProfileId, that.mAccessControlProfileId)
+                && mUserAuthenticationRequired == that.mUserAuthenticationRequired
+                && mUserAuthenticationTimeoutMillis == that.mUserAuthenticationTimeoutMillis;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(
+                mAccessControlProfileId, mUserAuthenticationRequired, mUserAuthenticationTimeoutMillis);
     }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfileId.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/AccessControlProfileId.java
@@ -16,6 +16,9 @@
 
 package com.android.identity.android.legacy;
 
+import androidx.annotation.Nullable;
+import java.util.Objects;
+
 /**
  * A class used to wrap an access control profile identifiers.
  */
@@ -38,5 +41,22 @@ public class AccessControlProfileId {
      */
     public int getId() {
         return this.mId;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof AccessControlProfileId)) {
+            return false;
+        }
+        AccessControlProfileId that = (AccessControlProfileId) o;
+        return mId == that.mId;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mId);
     }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/IdentityCredential.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/IdentityCredential.java
@@ -579,4 +579,15 @@ public abstract class IdentityCredential {
     List<Calendar> getAuthenticationDataExpirations() {
         throw new UnsupportedOperationException();
     }
+
+    /**
+     * Looks up the next static authentication key to use. This may be null if no valid key is
+     * available.
+     *
+     * @return the next static authentication key to use.
+     */
+    @Nullable
+    public byte[] peekNextAuthenticationKey() {
+        throw new UnsupportedOperationException();
+    }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/KeystoreIdentityCredential.java
@@ -852,4 +852,18 @@ class KeystoreIdentityCredential extends IdentityCredential {
         }
         return mData.getCredentialKeyAlias();
     }
+
+    @Override
+    @Nullable
+    public byte[] peekNextAuthenticationKey() {
+        Pair<PrivateKey, byte[]> authKeyPair =
+            mData.selectAuthenticationKey(
+                /* allowUsingExhaustedKeys= */ false,
+                /* allowUsingExpiredKeys= */ false,
+                /* incrementKeyUsageCount= */ false);
+        if (authKeyPair != null) {
+          return authKeyPair.second;
+        }
+        return null;
+    }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/PersonalizationData.java
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/PersonalizationData.java
@@ -18,15 +18,17 @@ package com.android.identity.android.legacy;
 
 import android.annotation.SuppressLint;
 import android.icu.util.Calendar;
-
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashMap;
+import java.util.Objects;
 
 /**
  * An object that holds personalization data.
@@ -95,6 +97,23 @@ public class PersonalizationData {
             }
             return null;
         }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof NamespaceData)) {
+                return false;
+            }
+            NamespaceData that = (NamespaceData) o;
+            return mNamespace.equals(that.mNamespace) && Objects.equals(mEntries, that.mEntries);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(mNamespace, mEntries);
+        }
     }
 
     static class EntryData {
@@ -104,6 +123,24 @@ public class PersonalizationData {
         EntryData(byte[] value, Collection<AccessControlProfileId> accessControlProfileIds) {
             this.mValue = value;
             this.mAccessControlProfileIds = accessControlProfileIds;
+        }
+
+        @Override
+        public boolean equals(@Nullable Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (!(o instanceof EntryData)) {
+                return false;
+            }
+            EntryData that = (EntryData) o;
+            return Arrays.equals(mValue, that.mValue)
+                    && Objects.equals(mAccessControlProfileIds, that.mAccessControlProfileIds);
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(Arrays.hashCode(mValue), mAccessControlProfileIds.hashCode());
         }
     }
 
@@ -291,4 +328,20 @@ public class PersonalizationData {
         }
     }
 
+    @Override
+    public boolean equals(@Nullable Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (!(o instanceof PersonalizationData)) {
+            return false;
+        }
+        PersonalizationData that = (PersonalizationData) o;
+        return mProfiles.equals(that.mProfiles) && Objects.equals(mNamespaces, that.mNamespaces);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(mProfiles.hashCode(), mNamespaces);
+    }
 }

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelper.kt
@@ -302,19 +302,25 @@ class DeviceRetrievalHelper internal constructor(
             return
         }
 
-        val decryptedMessage =
-        try {
+        val decryptedMessage = try {
             sessionEncryption!!.decryptMessage(data)
-        } catch(e: IllegalStateException) {
-            Logger.d(TAG, "Decryption failed!")
-            transport!!.sendMessage(
-                sessionEncryption!!.encryptMessage(
-                    null, Constants.SESSION_DATA_STATUS_ERROR_SESSION_ENCRYPTION
-                )
-            )
-            transport!!.close()
-            reportError(Error("Error decrypting message from reader"))
-            return
+        } catch(e: Exception) {
+            when (e) {
+                is IllegalArgumentException,
+                is IllegalStateException,
+                is NullPointerException -> {
+                    Logger.d(TAG, "Decryption failed!")
+                    transport!!.sendMessage(
+                        sessionEncryption!!.encryptMessage(
+                            null, Constants.SESSION_DATA_STATUS_SESSION_TERMINATION
+                        )
+                    )
+                    transport!!.close()
+                    reportError(Error("Error decrypting message from reader"))
+                    return
+                }
+                else -> throw e
+            }
         }
 
         // If there's data in the message, assume it's DeviceRequest (ISO 18013-5

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/mdoc/transport/GattClient.kt
@@ -264,8 +264,9 @@ internal class GattClient(
             // TODO: Don't even request IDENT since it cannot work w/ reverse engagement (there's
             //   no way the mdoc reader knows EDeviceKeyBytes at this point) and it's also optional.
             if (!Arrays.equals(identValue, this.identValue)) {
-                Logger.w(TAG, "Received ident '${identValue.toHex()}' does not match " +
-                            "expected ident '${this.identValue!!.toHex()}'")
+                reportError(Error("Received ident '${identValue.toHex()}' does not match " +
+                        "expected ident '${this.identValue!!.toHex()}'"));
+                return;
             }
             afterIdentObtained(gatt)
         } else if (characteristic.uuid == characteristicL2CAPUuid) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseGenerator.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/response/DeviceResponseGenerator.kt
@@ -37,6 +37,7 @@ import org.multipaz.cbor.putCborMap
  */
 class DeviceResponseGenerator(private val mStatusCode: Long) {
     private val mDocumentsBuilder = CborArray.builder()
+    private var mDocumentsAdded = false;
 
     /**
      * Adds a new document to the device response.
@@ -142,6 +143,7 @@ class DeviceResponseGenerator(private val mStatusCode: Long) {
                 }
             }
         )
+        mDocumentsAdded = true
     }
 
     /**
@@ -155,6 +157,7 @@ class DeviceResponseGenerator(private val mStatusCode: Long) {
      */
     fun addDocument(encodedDocument: ByteArray) = apply {
         mDocumentsBuilder.add(Cbor.decode(encodedDocument))
+        mDocumentsAdded = true
     }
 
     /**
@@ -170,7 +173,9 @@ class DeviceResponseGenerator(private val mStatusCode: Long) {
     fun generate(): ByteArray = Cbor.encode(
         buildCborMap {
             put("version", "1.0")
-            put("documents", mDocumentsBuilder.end().build())
+            if (mDocumentsAdded) {
+                put("documents", mDocumentsBuilder.end().build())
+            }
             // TODO: The documentErrors map entry should only be present if there is a non-zero
             //  number of elements in the array. Right now we don't have a way for the application
             //  to convey document errors but when we add that API we'll need to do something so

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestGeneratorTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestGeneratorTest.kt
@@ -140,7 +140,7 @@ class DeviceRequestGeneratorTest {
     companion object {
         private const val MDL_DOCTYPE = "org.iso.18013.5.1.mDL"
         private const val MDL_NAMESPACE = "org.iso.18013.5.1"
-        private const val AAMVA_NAMESPACE = "org.aamva.18013.5.1"
+        private const val AAMVA_NAMESPACE = "org.iso.18013.5.1.aamva"
         private const val MVR_DOCTYPE = "org.iso.18013.7.1.mVR"
         private const val MVR_NAMESPACE = "org.iso.18013.7.1"
     }


### PR DESCRIPTION
The last import into g3 was commit ce6cec763e015a34439af9fd5d641600a9fa5014, from 2023-04-08. This PR takes all the g3 changes that have been done since that import and ports them to the latest upstream version.

There were many conflicts, mostly from renamed files or files that had been converted from Java to Kotlin. The g3 versions had changed the package namespace, which resulted in a number of unnecessary merge changes. This PR ignores the g3 package name changes.

The coseSign1CheckNoDuplicateHeaderParams function that had been added to multipaz-android-legacy/.../Util.kt needed to be moved to where it was used in DeviceRequestParser.kt, because that's in the core library, multipaz. It was also converted to be more Kotlin-esque and use standard functions that exist in DataItem. It should be reviewed for accuracy.

Omitted changes:
- The provisionMsosForExistingCredential function in Utility.java has a TODO to move it to the mdocstore module. It would take a little work to get this function compiling in Multipaz, so instead I have omitted it in hopes that the TODO can be fixed and that function can be moved to its final destination.
- The changes in KeystoreIdentityCredential.java depend on a function implemented elsewhere in g3, so they were not upstreamed.

Several changes look like they'd already been upstreamed. Two in particular should be reviewed, however:
1) The g3 version added a isNegotiatedHandover parameter to toNdefRecord. The
   behavior of this flag looked very similar to the new skipUuids pararemeter,
   so this change was not upstreamed.
2) In NfcEngagementHelper.kt, in the handleHandoverRequest function, the g3
   version had added some logic to select the connection method, rather than
   selecting the first disambiguated option. On review, it looked like the
   new disambiguation function already contains similar logic and would
   result in the same connection method, but this could use another set of eyes.

Test: ./gradlew check
Test: ./gradlew connectedCheck
Test: Manually spot-checked screens in testapp: About, Document store, CSA
Test: Testapp mdl proximity reading over NFC
Test: Testapp mdl proximity reading using a QR code
Test: Testapp multi-device testing Happy Flow Short (a typical number were successful)

- [X] Tests pass