### PR TITLE
Restore custom LogPrinter functionality

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/util/Logger.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/util/Logger.android.kt
@@ -1,9 +1,9 @@
 package org.multipaz.util
 
 import android.util.Log
-import org.multipaz.util.Logger.Level
+import org.multipaz.util.Logger.LogPrinter.Level
 
-internal actual fun platformLogPrinter(level: Level, tag: String, msg: String, throwable: Throwable?) {
+internal actual fun getPlatformLogPrinter() = Logger.LogPrinter { level, tag, msg, throwable ->
     // Android clamps the log message at just over 4000 characters so chunk and only include
     // the throwable with the first Log.x() call
     val messages = msg.chunked(4000)

--- a/multipaz/src/iosMain/kotlin/org/multipaz/util/Logger.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/util/Logger.ios.kt
@@ -1,5 +1,5 @@
 package org.multipaz.util
 
-internal actual fun platformLogPrinter(level: Logger.Level, tag: String, msg: String, throwable: Throwable?) {
+internal actual fun getPlatformLogPrinter() = Logger.LogPrinter { level, tag, msg, throwable ->
     println(Logger.prepareLine(level, tag, msg, throwable))
 }

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/util/Logger.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/util/Logger.jvm.kt
@@ -1,5 +1,5 @@
 package org.multipaz.util
 
-internal actual fun platformLogPrinter(level: Logger.Level, tag: String, msg: String, throwable: Throwable?) {
+actual fun getPlatformLogPrinter() = Logger.LogPrinter { level, tag, msg, throwable ->
     println(Logger.prepareLine(level, tag, msg, throwable))
 }


### PR DESCRIPTION
Restore the old `LogPrinter` interface to `Logger` and allow overriding the default printer with a new `logPrinter` property. The default printer is provided by slightly changed `getPlatformLogPrinter()` expect function, which now returns an platform-specific implementation of the interface.

Test: ./gradlew multipaz:check multipaz:connectedCheck
Test: Manually tested that testapp outputs logs & our implementation is able to override logger

Fixes #978