### PR TITLE
Android signing key digests for app links.

### DIFF
--- a/multipaz-backend-server/src/main/resources/resources/android_trusted_app_signatures.txt
+++ b/multipaz-backend-server/src/main/resources/resources/android_trusted_app_signatures.txt
@@ -1,0 +1,6 @@
+# Digests of Android app signing keys that we trust for development environment. This is used for app
+# links and for DeviceCheck validation on the backend server.
+9D:63:92:0E:03:F6:15:28:26:39:00:FF:E5:1D:03:3E:E2:2C:4B:77:5C:AA:CF:E2:93:78:AA:3E:1C:F7:BE:F4  # multipaz.org
+54:4A:71:AD:63:1F:D8:61:4B:CB:6F:C7:1D:3B:8D:EF:19:56:E5:FC:BA:98:A8:55:02:64:40:0E:8E:1A:2E:1D  # sorotokin
+AC:7F:F2:B8:77:D0:9A:9C:5F:29:1A:E4:28:1F:E9:17:8F:1B:74:A6:8E:B8:0C:61:69:D0:18:EA:CE:CA:4A:88  # sorotokin
+

--- a/multipaz-backend-server/src/main/resources/resources/android_trusted_package_names.txt
+++ b/multipaz-backend-server/src/main/resources/resources/android_trusted_package_names.txt
@@ -1,0 +1,1 @@
+org.multipaz.testapp

--- a/scripts/generate-assetlinks-json.sh
+++ b/scripts/generate-assetlinks-json.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Generate .well-known/assetlinks.json file (on standard output).
+# This script must be run on the top level of the repo.
+
+resourceFolder=multipaz-backend-server/src/main/resources/resources/
+
+function readList() {
+  sed 's/#.*$//' < "$resourceFolder$1"
+}
+
+function item() {
+cat << eof
+{
+  "relation": ["delegate_permission/common.handle_all_urls"],
+  "target": {
+    "namespace": "android_app",
+    "package_name": "$1",
+    "sha256_cert_fingerprints": [
+	   "$2"
+    ]
+  }
+}
+eof
+}
+
+separator=""
+echo -n "["
+for package in $(readList android_trusted_package_names.txt)
+do
+  for hash in $(readList android_trusted_app_signatures.txt)
+  do
+     echo $separator
+     separator=","
+     item "$package" "$hash"
+  done
+done
+echo "]"


### PR DESCRIPTION
We should be able to use the same lists for Android attestation validation in our wallet back-end.

Testing: tested with my own server.