### PR TITLE
Appverifier: set android:fitsSystemWindows to no longer cover screen …

### DIFF
--- a/appverifier/src/main/res/layout/activity_main.xml
+++ b/appverifier/src/main/res/layout/activity_main.xml
@@ -5,6 +5,7 @@
     android:id="@+id/dlMainDrawer"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:fitsSystemWindows="true"
     tools:context=".MainActivity">
 
     <fragment


### PR DESCRIPTION
Fixes #1005 so that nav bar no longer covers screen content

Test: manual check every screen in Appverifier

### Side bar

**Before**

<img src="https://github.com/user-attachments/assets/ede9db10-2299-4184-bca2-2708bdd89b58" width="300" alt="side nav covered" />

**After**

<img src="https://github.com/user-attachments/assets/b218cce4-2dd5-4eab-9828-ec40278d0a96" width="300" alt="side nav with padding" />

### Certificate list

**Before **

<img src="https://github.com/user-attachments/assets/7883f9cf-c555-4162-906d-ad2117e9f69e" width="300" alt="certificate list covered" />

**After**

<img src="https://github.com/user-attachments/assets/b37ba844-bfdf-4f1f-89f7-6cb8d8ea1bdf" width="300" alt="certificate list with padding" />
