### PR TITLE
Add 'No documents received.' message to show document screen

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/fragment/ShowDocumentFragment.kt
@@ -206,6 +206,10 @@ class ShowDocumentFragment : Fragment() {
         sb.append("Session encryption curve: <b>" + transferManager.getMdocSessionEncryptionCurve() + "</b><br>")
         sb.append("<br>")
 
+        if (documents.isEmpty()) {
+            sb.append("<h3>No documents received.</h3>")
+        }
+
         for (doc in documents) {
             sb.append("<h3>Doctype: <font color=\"$primaryColor\">${doc.docType}</font></h3>")
             val cc = doc.issuerCertificateChain.certificates


### PR DESCRIPTION
Fixes #1007 to indicate no document received on the show document screen

Test: manual test both presenting documents and presenting no documents