### PR TITLE
Tweaks for openid4vci server and client code

### DIFF
--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/credential/CredentialFactory.kt
@@ -57,7 +57,7 @@ internal sealed class Openid4VciFormat {
     companion object {
         fun fromJson(json: JsonObject): Openid4VciFormat {
             return when (val format = json["format"]?.jsonPrimitive?.content) {
-                "vc+sd-jwt" -> Openid4VciFormatSdJwt(json["vct"]!!.jsonPrimitive.content)
+                "dc+sd-jwt" -> Openid4VciFormatSdJwt(json["vct"]!!.jsonPrimitive.content)
                 "mso_mdoc" -> Openid4VciFormatMdoc(json["doctype"]!!.jsonPrimitive.content)
                 else -> throw InvalidRequestException("Unsupported format '$format'")
             }
@@ -72,5 +72,5 @@ internal data class Openid4VciFormatMdoc(val docType: String) : Openid4VciFormat
 internal val openId4VciFormatMdl = Openid4VciFormatMdoc(DrivingLicense.MDL_DOCTYPE)
 
 internal data class Openid4VciFormatSdJwt(val vct: String) : Openid4VciFormat() {
-    override val id: String get() = "vc+sd-jwt"
+    override val id: String get() = "dc+sd-jwt"
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtVerifiableCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtVerifiableCredential.kt
@@ -1,6 +1,5 @@
 package org.multipaz.sdjwt
 
-import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcPublicKey
 import org.multipaz.crypto.EcSignature
@@ -25,7 +24,7 @@ import kotlinx.serialization.json.JsonElement
  * <header>.<body>.<signature>~<Disclosure 1>~<Disclosure 2>~...~<Disclosure N>~
  *
  * The header is the base64-encoding of a JSON structure that contains the
- * typ: vc+sd-jwt entry, and an alg entry that specifies how the signature was generated.
+ * typ: dc+sd-jwt entry, and an alg entry that specifies how the signature was generated.
  *
  * It is separated from the body by a period. The body is the base64-encoding of a JSON
  * structure that includes the undisclosed (hashed) identity attributes, along with

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/vc/JwtHeader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/vc/JwtHeader.kt
@@ -10,16 +10,13 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.crypto.X509Cert
 import org.multipaz.crypto.X509CertChain
-import org.multipaz.sdjwt.util.getJsonArray
 import org.multipaz.sdjwt.util.getJsonArrayOrNull
-import org.multipaz.util.fromBase64Url
 import kotlin.io.encoding.Base64
-import kotlin.io.encoding.Base64.PaddingOption
 import kotlin.io.encoding.ExperimentalEncodingApi
 
 /**
  * Header for an (issuer-signed) JWT that is to be used in a SD-JWT VC.
- * It specifies the type 'vc+sd-jwt' and the algorithm used by the
+ * It specifies the type 'dc+sd-jwt' and the algorithm used by the
  * issuer to sign the JWT payload (consisting of the base64-url-encoded
  * header, as defined here, a period, and the base64-url-encoded body, as
  * defined in [JwtBody]).
@@ -48,7 +45,7 @@ class JwtHeader(val algorithm: Algorithm, val kid: String?, val x5c: X509CertCha
 
     companion object {
 
-        const val SD_JWT_VC_TYPE = "vc+sd-jwt"
+        const val SD_JWT_VC_TYPE = "dc+sd-jwt"
 
         fun fromString(input: String): JwtHeader {
             val jsonObj = parse(input)

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/OpenidUtil.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/provisioning/openid4vci/OpenidUtil.kt
@@ -20,7 +20,6 @@ import io.ktor.http.protocolWithAuthority
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 import kotlinx.datetime.Clock
-import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.put
 import org.multipaz.device.AssertionPoPKey
@@ -92,6 +91,7 @@ internal object OpenidUtil {
     suspend fun obtainToken(
         tokenUrl: String,
         clientId: String,
+        landingUrl: String?,
         refreshToken: String? = null,
         accessToken: String? = null,
         authorizationCode: String? = null,
@@ -133,8 +133,9 @@ internal object OpenidUtil {
                     add("code_verifier", codeVerifier)
                 }
                 add("client_id", clientId)
-                // TODO: It's arbitrary in our case, right?
-                add("redirect_uri", "https://secure.redirect.com")
+                if (landingUrl != null) {
+                    add("redirect_uri", landingUrl)
+                }
             }
             val tokenResponse = httpClient.post(tokenUrl) {
                 headers {


### PR DESCRIPTION
Tweaks for openid4vci server and client code to fix discrepancies with the current spec.

Test: issuance for all credential types with our own server and with bundesdruckerei sample server.
