### PR TITLE
Fix data race in BLE GATT implementation

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
@@ -600,25 +600,26 @@ internal class BleCentralManagerAndroid : BleCentralManager {
         characteristic: BluetoothGattCharacteristic,
         value: ByteArray,
     ) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
-            val rc = gatt!!.writeCharacteristic(
-                characteristic,
-                value,
-                BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
-            )
-            if (rc != BluetoothStatusCodes.SUCCESS) {
-                throw Error("Error writing to characteristic ${characteristic.uuid}, rc=$rc")
-            }
-        } else {
-            @Suppress("DEPRECATION")
-            characteristic.setValue(value)
-            @Suppress("DEPRECATION")
-            if (!gatt!!.writeCharacteristic(characteristic)) {
-                throw Error("Error writing to characteristic ${characteristic.uuid}")
-            }
-        }
-        suspendCancellableCoroutine<Boolean> { continuation ->
+        suspendCancellableCoroutine { continuation ->
             setWaitCondition(WaitState.CHARACTERISTIC_WRITE_COMPLETED, continuation)
+
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.UPSIDE_DOWN_CAKE) {
+                val rc = gatt!!.writeCharacteristic(
+                    characteristic,
+                    value,
+                    BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE
+                )
+                if (rc != BluetoothStatusCodes.SUCCESS) {
+                    throw Error("Error writing to characteristic ${characteristic.uuid}, rc=$rc")
+                }
+            } else {
+                @Suppress("DEPRECATION")
+                characteristic.setValue(value)
+                @Suppress("DEPRECATION")
+                if (!gatt!!.writeCharacteristic(characteristic)) {
+                    throw Error("Error writing to characteristic ${characteristic.uuid}")
+                }
+            }
         }
     }
 

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebEncryptionTests.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebEncryptionTests.kt
@@ -56,7 +56,7 @@ class JsonWebEncryptionTests {
             Curve.P_256,
             recipientKey.publicKey.javaPublicKey as ECPublicKey,
             recipientKey.javaPrivateKey as ECPrivateKey,
-            null, null, null, null, null, null, null, null, null
+            null, null, null, null, null, null, null, null, null, null, null, null
         )
         val decrypter = ECDHDecrypter(encKey)
         encryptedJWT.decrypt(decrypter)

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTests.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTests.kt
@@ -1,7 +1,5 @@
 package org.multipaz.crypto
 
-import org.multipaz.asn1.ASN1Integer
-import org.multipaz.util.toBase64Url
 import com.nimbusds.jose.JOSEObjectType
 import com.nimbusds.jose.JWSAlgorithm
 import com.nimbusds.jose.JWSHeader
@@ -14,17 +12,15 @@ import com.nimbusds.jose.proc.JWSKeySelector
 import com.nimbusds.jose.proc.SecurityContext
 import com.nimbusds.jwt.JWTClaimsSet
 import com.nimbusds.jwt.SignedJWT
-import com.nimbusds.jwt.proc.BadJWTException
 import com.nimbusds.jwt.proc.DefaultJWTProcessor
-import com.nimbusds.jwt.proc.JWTClaimsSetVerifier
-import junit.framework.TestCase.assertTrue
 import kotlinx.datetime.Clock
-import kotlinx.datetime.Instant
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import org.multipaz.asn1.ASN1Integer
+import org.multipaz.util.toBase64Url
 import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
 import kotlin.test.Test
@@ -120,7 +116,7 @@ class JsonWebSignatureTests {
             Curve.P_256,
             signingKey.publicKey.javaPublicKey as ECPublicKey,
             signingKey.javaPrivateKey as ECPrivateKey,
-            null, null, null, null, null, null, null, null, null
+            null, null, null, null, null, null, null, null, null, null, null, null
         )
         val builder = JWSHeader.Builder(JWSAlgorithm.ES256)
         builder.x509CertChain(


### PR DESCRIPTION
Set the wait condition before actually writing the value in the characteristic, as the callback that reads the value might be called before the value is actually set.

Test: ./gradlew multipaz:check multipaz:connectedCheck
Test: Manually tested local build with our wallet implementation

Fixes #1019 