### PR TITLE
Port JsonWebEncryption to Kotlin Multiplatform.

### DIFF
--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/models/verifier/Openid4VpVerifierModel.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/models/verifier/Openid4VpVerifierModel.kt
@@ -172,7 +172,7 @@ class Openid4VpVerifierModel(
         responseUri: String,
         response: String
     ): Map<String, Presentation> {
-        val decrypted = JsonWebEncryption.decrypt(JsonPrimitive(response), ephemeralPrivateKey)
+        val decrypted = JsonWebEncryption.decrypt(response, ephemeralPrivateKey)
         val header = Json.parseToJsonElement(
             response.substring(0, response.indexOf('.')).fromBase64Url().decodeToString()
         ).jsonObject

--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -100,8 +100,6 @@ kotlin {
                 implementation(libs.bouncy.castle.bcprov)
                 implementation(libs.bouncy.castle.bcpkix)
                 implementation(libs.tink)
-                // TODO: remove when JsonWebEncryption is implemented fully in Kotlin
-                implementation(libs.nimbus.oauth2.oidc.sdk)
             }
         }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
@@ -51,11 +51,11 @@ expect object Crypto {
     /**
      * Message encryption.
      *
-     * @param algorithm must be one of [Algorithm.A128GCM], [Algorithm.A192GCM],
-     * [Algorithm.A256GCM].
+     * @param algorithm must be one of [Algorithm.A128GCM], [Algorithm.A192GCM], or [Algorithm.A256GCM].
      * @param key the encryption key.
      * @param nonce the nonce/IV.
      * @param messagePlaintext the message to encrypt.
+     * @param aad additional authenticated data or `null`.
      * @return the cipher text with the tag appended to it.
      * @throws IllegalArgumentException if the given algorithm is not supported.
      */
@@ -64,16 +64,17 @@ expect object Crypto {
         key: ByteArray,
         nonce: ByteArray,
         messagePlaintext: ByteArray,
+        aad: ByteArray? = null
     ): ByteArray
 
     /**
      * Message decryption.
      *
-     * @param algorithm must be one of [Algorithm.A128GCM], [Algorithm.A192GCM],
-     * [Algorithm.A256GCM].
+     * @param algorithm must be one of [Algorithm.A128GCM], [Algorithm.A192GCM], or [Algorithm.A256GCM].
      * @param key the encryption key.
      * @param nonce the nonce/IV.
      * @param messageCiphertext the message to decrypt with the tag at the end.
+     * @param aad additional authenticated data or `null`.
      * @return the plaintext.
      * @throws IllegalArgumentException if the given algorithm is not supported.
      * @throws IllegalStateException if decryption fails
@@ -83,6 +84,7 @@ expect object Crypto {
         key: ByteArray,
         nonce: ByteArray,
         messageCiphertext: ByteArray,
+        aad: ByteArray? = null
     ): ByteArray
 
     /**
@@ -151,6 +153,7 @@ expect object Crypto {
      *
      * @param key the key to use for key agreement.
      * @param otherKey the key from the other party.
+     * @return the shared secret.
      */
     fun keyAgreement(
         key: EcPrivateKey,
@@ -211,19 +214,4 @@ expect object Crypto {
 
     // TODO: replace with non-platform specific code
     internal fun validateCertChain(certChain: X509CertChain): Boolean
-
-    // TODO: replace with non-platform specific code
-    internal fun encryptJwtEcdhEs(
-        key: EcPublicKey,
-        encAlgorithm: Algorithm,
-        claims: JsonObject,
-        apu: String,
-        apv: String
-    ): JsonElement
-
-    // TODO: replace with non-platform specific code
-    internal fun decryptJwtEcdhEs(
-        encryptedJwt: JsonElement,
-        recipientKey: EcPrivateKey
-    ): JsonObject
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebEncryption.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/JsonWebEncryption.kt
@@ -1,8 +1,26 @@
 package org.multipaz.crypto
 
+import io.ktor.utils.io.core.toByteArray
 import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.append
+import kotlinx.io.bytestring.buildByteString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.json.put
+import org.multipaz.util.appendInt32
+import org.multipaz.util.deflate
+import org.multipaz.util.fromBase64Url
+import org.multipaz.util.inflate
+import org.multipaz.util.toBase64Url
+import org.multipaz.util.toHex
+import kotlin.math.ceil
+import kotlin.random.Random
 
 /**
  *  JSON Web Encryption (JWE) support routines
@@ -16,24 +34,73 @@ object JsonWebEncryption {
      * @param claimsSet the claims set to encrypt.
      * @param recipientPublicKey the public key to encrypt to.
      * @param encAlg the encryption algorithm, [Algorithm.A128GCM], [Algorithm.A192GCM], or [Algorithm.A256GCM].
-     * @param apu agreement PartyUInfo (apu) parameter, must be base64url encoded.
-     * @param apv agreement PartyVInfo (apv) parameter, must be base64url encoded.
-     * @return a [JsonElement] with the encrypted JWT.
+     * @param apu agreement PartyUInfo (apu) parameter or `null`.
+     * @param apv agreement PartyVInfo (apv) parameter or `null`.
+     * @param random the [Random] used to generate a nonce.
+     * @param compressionLevel The compression level to use for DEFLATE compression or `null` to not compress.
+     * @return the compact serialization of the JWE.
      */
     fun encrypt(
         claimsSet: JsonObject,
         recipientPublicKey: EcPublicKey,
         encAlg: Algorithm,
-        apu: String,
-        apv: String
-    ): JsonElement {
-        return Crypto.encryptJwtEcdhEs(
-            key = recipientPublicKey,
-            encAlgorithm = encAlg,
-            claims = claimsSet,
-            apu = apu,
-            apv = apv
+        apu: ByteString?,
+        apv: ByteString?,
+        random: Random = Random.Default,
+        compressionLevel: Int? = null
+    ): String {
+        val keyDataLenBits = when (encAlg) {
+            Algorithm.A128GCM -> 128
+            Algorithm.A192GCM -> 192
+            Algorithm.A256GCM -> 256
+            else -> throw IllegalArgumentException("encAlg $encAlg not supported")
+        }
+
+        val senderEphemeralKey = Crypto.createEcPrivateKey(recipientPublicKey.curve)
+
+        val protectedHeader = buildJsonObject {
+            put("alg", "ECDH-ES")
+            put("enc", encAlg.joseAlgorithmIdentifier)
+            apu?.let { put("apu", it.toByteArray().toBase64Url()) }
+            apv?.let { put("apv", it.toByteArray().toBase64Url()) }
+            put("epk", senderEphemeralKey.publicKey.toJwk())
+            if (compressionLevel != null) {
+                put("zip", "DEF")
+            }
+        }
+        val protectedHeaderB64 = Json.encodeToString(protectedHeader).encodeToByteArray().toBase64Url()
+
+        val sharedSecret = Crypto.keyAgreement(senderEphemeralKey, recipientPublicKey)
+
+        val algId = encAlg.joseAlgorithmIdentifier!!.toByteArray()
+        val contentEncryptionKey = concatKDF(
+            sharedSecretZ = ByteString(sharedSecret),
+            keyDataLenBits = keyDataLenBits,
+            algorithmId = buildByteString { appendInt32(algId.size); append(algId) },
+            partyUInfo =  buildByteString { apu?.let { appendInt32(it.size); append(it) } },
+            partyVInfo =  buildByteString { apv?.let { appendInt32(it.size); append(it) } },
+            suppPubInfo = buildByteString { appendInt32(keyDataLenBits) }
         )
+
+        val nonce = random.nextBytes(16)
+        val messageToEncrypt = if (compressionLevel != null) {
+            deflate(
+                data = Json.encodeToString(claimsSet).encodeToByteArray(),
+                compressionLevel = compressionLevel,
+            )
+        } else {
+            Json.encodeToString(claimsSet).encodeToByteArray()
+        }
+        val cipherTextWithTag = Crypto.encrypt(
+            algorithm = encAlg,
+            key = contentEncryptionKey,
+            nonce = nonce,
+            messagePlaintext = messageToEncrypt,
+            aad = protectedHeaderB64.toByteArray(),
+        )
+        val cipherText = cipherTextWithTag.copyOfRange(0, cipherTextWithTag.size - 16)
+        val authTag = cipherTextWithTag.copyOfRange(cipherTextWithTag.size - 16, cipherTextWithTag.size)
+        return protectedHeaderB64 + "." + "." + nonce.toBase64Url() + "." + cipherText.toBase64Url() + "." + authTag.toBase64Url()
     }
 
     /**
@@ -41,15 +108,103 @@ object JsonWebEncryption {
      *
      * Reference: [RFC 7518 Section 4.6 Key Agreement with Elliptic Curve Diffie-Hellman Ephemeral Static (ECDH-ES)](https://datatracker.ietf.org/doc/html/rfc7518#section-4.6)
      *
-     * @param encryptedJwt the encrypted JWT.
+     * @param encryptedJwt the compact serialization of the JWE.
      * @param recipientKey the recipients private key corresponding to the public key this was encrypted to.
      * @return the decrypted claims set.
      */
     fun decrypt(
-        encryptedJwt: JsonElement,
+        encryptedJwt: String,
         recipientKey: EcPrivateKey
     ): JsonObject {
-        return Crypto.decryptJwtEcdhEs(encryptedJwt, recipientKey)
+        val splits = encryptedJwt.split(".")
+        require(splits.size == 5)
+        val (protectedHeaderB64, encryptedKeyB64, ivB64, cipherTextB64, authenticationTagB64) = splits
+        val protectedHeader = Json.decodeFromString(JsonObject.serializer(), protectedHeaderB64.fromBase64Url().decodeToString())
+
+        require(protectedHeader["alg"]!!.jsonPrimitive.content == "ECDH-ES")
+
+        val encAlg = Algorithm.fromJoseAlgorithmIdentifier(protectedHeader["enc"]!!.jsonPrimitive.content)
+        val keyDataLenBits = when (encAlg) {
+            Algorithm.A128GCM -> 128
+            Algorithm.A192GCM -> 192
+            Algorithm.A256GCM -> 256
+            else -> throw IllegalArgumentException("encAlg $encAlg not supported")
+        }
+
+        val senderEphemeralKey = EcPublicKey.fromJwk(protectedHeader["epk"]!!.jsonObject)
+
+        val apu = ByteString(protectedHeader["apu"]?.jsonPrimitive?.content?.fromBase64Url() ?: byteArrayOf())
+        val apv = ByteString(protectedHeader["apv"]?.jsonPrimitive?.content?.fromBase64Url() ?: byteArrayOf())
+
+        val sharedSecret = Crypto.keyAgreement(recipientKey, senderEphemeralKey)
+
+        val algId = encAlg.joseAlgorithmIdentifier!!.toByteArray()
+        val contentEncryptionKey = concatKDF(
+            sharedSecretZ = ByteString(sharedSecret),
+            keyDataLenBits = keyDataLenBits,
+            algorithmId = buildByteString { appendInt32(algId.size); append(algId) },
+            partyUInfo =  buildByteString { appendInt32(apu.size); append(apu) },
+            partyVInfo =  buildByteString { appendInt32(apv.size); append(apv) },
+            suppPubInfo = buildByteString { appendInt32(keyDataLenBits) }
+        )
+        val clearText = Crypto.decrypt(
+            algorithm = encAlg,
+            key = contentEncryptionKey,
+            nonce = ivB64.fromBase64Url(),
+            aad = protectedHeaderB64.toByteArray(),
+            messageCiphertext = cipherTextB64.fromBase64Url() + authenticationTagB64.fromBase64Url()
+        )
+
+        val compressionAlgorithm = protectedHeader["zip"]?.jsonPrimitive?.content
+        if (compressionAlgorithm == null) {
+            return Json.decodeFromString(JsonObject.serializer(), clearText.decodeToString())
+        }
+        when (compressionAlgorithm) {
+            "DEF" -> {
+                val decompressedClearText = inflate(clearText)
+                return Json.decodeFromString(JsonObject.serializer(), decompressedClearText.decodeToString())
+            }
+            else -> throw IllegalArgumentException("Unsupported compression algorithm $compressionAlgorithm")
+        }
+    }
+
+    /**
+     * Implements Concat KDF as specified in RFC 7518, Section 4.6.2.
+     *
+     * KDF(Z, keydatalen, AlgorithmID, PartyUInfo, PartyVInfo, SuppPubInfo, SuppPrivInfo)
+     * For ECDH-ES+AxxxKW, SuppPrivInfo is empty.
+     * For ECDH-ES, this KDF is used to derive the KEK for AES Key Wrap.
+     */
+    internal fun concatKDF(
+        sharedSecretZ: ByteString,
+        keyDataLenBits: Int, // Desired output key length in bits (e.g., 128, 192, 256 for AES Key Wrap)
+        algorithmId: ByteString,
+        partyUInfo: ByteString,
+        partyVInfo: ByteString,
+        suppPubInfo: ByteString // e.g., keyDataLenBits as a 32-bit big-endian integer
+    ): ByteArray {
+        val keyDataLenBytes = keyDataLenBits / 8
+        val reps = ceil(keyDataLenBytes.toDouble() / 32.0).toInt() // Assuming SHA-256 (32 bytes output)
+        var round = 1
+
+        var derivedKeySize = 0
+        val derivedKey = buildByteString {
+            while (derivedKeySize < keyDataLenBytes && round <= reps) {
+                val toDigest = buildByteString {
+                    appendInt32(round)
+                    append(sharedSecretZ)
+                    append(algorithmId)
+                    append(partyUInfo)
+                    append(partyVInfo)
+                    append(suppPubInfo)
+                }
+                // SuppPrivInfo is omitted for ECDH-ES+AxxxKW as per RFC 7518
+                append(Crypto.digest(Algorithm.SHA256, toDigest.toByteArray()))
+                derivedKeySize += 32
+                round++
+            }
+        }
+        return derivedKey.toByteArray(startIndex = 0, endIndex = keyDataLenBytes)
     }
 
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwt.kt
@@ -164,7 +164,7 @@ class SdJwt(
     ): JsonObject {
         // TODO: make sure we perform all checks in Section 7.1
         try {
-            JsonWebSignature.verify(JsonPrimitive("$header.$body.$signature"), issuerKey)
+            JsonWebSignature.verify("$header.$body.$signature", issuerKey)
         } catch (e: Throwable) {
             throw SignatureVerificationException("Error validating issuer signature", e)
         }
@@ -316,7 +316,7 @@ class SdJwt(
             claimsSet = kbBody,
             type = "kb+jwt",
             x5c = null
-        ).jsonPrimitive.content
+        )
         return SdJwtKb(compactSerialization + kbJwt)
     }
 
@@ -356,7 +356,7 @@ class SdJwt(
             claimsSet = kbBody,
             type = "kb+jwt",
             x5c = null
-        ).jsonPrimitive.content
+        )
         return SdJwtKb(compactSerialization + kbJwt)
     }
 
@@ -439,7 +439,7 @@ class SdJwt(
                     claimsSet = issuerSignedJwtBody,
                     type = "dc+sd-jwt",
                     x5c = issuerCertChain
-                ).jsonPrimitive.content
+                )
             )
             sb.append('~')
             for (disclosure in disclosures) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/SdJwtKb.kt
@@ -76,7 +76,7 @@ class SdJwtKb(
         checkCreationTime: (creationTime: Instant) -> Boolean
     ): JsonObject {
         try {
-            JsonWebSignature.verify(JsonPrimitive("$kbHeader.$kbBody.$kbSignature"), sdJwt.kbKey!!)
+            JsonWebSignature.verify("$kbHeader.$kbBody.$kbSignature", sdJwt.kbKey!!)
         } catch (e: Throwable) {
             throw SignatureVerificationException("Error validating KB signature", e)
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Compression.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Compression.kt
@@ -1,0 +1,20 @@
+package org.multipaz.util
+
+/**
+ * Compresses data using DEFLATE algorithm according to [RFC 1951](https://www.ietf.org/rfc/rfc1951.txt).
+ *
+ * @param data the data to compress.
+ * @param compressionLevel must be between 0 and 9, both inclusive.
+ * @return the compressed data.
+ * @throws IllegalArgumentException if [compressionLevel] isn't valid.
+ */
+expect fun deflate(data: ByteArray, compressionLevel: Int = 5): ByteArray
+
+/**
+ * Decompresses data compressed DEFLATE algorithm according to [RFC 1951](https://www.ietf.org/rfc/rfc1951.txt).
+ *
+ * @param compressedData the compressed data to decompress.
+ * @return the decompressed data.
+ * @throws IllegalArgumentException if the given data is invalid
+ */
+expect fun inflate(compressedData: ByteArray): ByteArray

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/CryptoTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/CryptoTests.kt
@@ -77,30 +77,70 @@ class CryptoTests {
         assertEquals(
             "2ccda4a5415cb91e135c2a0f78c9b2fd" + "b36d1df9b9d5e596f83e8b7f52971cb3",
             Crypto.encrypt(
-                Algorithm.A128GCM,
-                "7fddb57453c241d03efbed3ac44e371c".fromHex(),
-                "ee283a3fc75575e33efd4887".fromHex(),
-                "d5de42b461646c255c87bd2962d3b9a2".fromHex(),
+                algorithm = Algorithm.A128GCM,
+                key = "7fddb57453c241d03efbed3ac44e371c".fromHex(),
+                nonce = "ee283a3fc75575e33efd4887".fromHex(),
+                messagePlaintext = "d5de42b461646c255c87bd2962d3b9a2".fromHex(),
             ).toHex()
         )
 
         assertEquals(
             "69482957e6be5c54882d00314e0259cf" + "191e9f29bef63a26860c1e020a21137e",
             Crypto.encrypt(
-                Algorithm.A192GCM,
-                "fbc0b4c56a714c83217b2d1bcadd2ed2e9efb0dcac6cc19f".fromHex(),
-                "5f4b43e811da9c470d6a9b01".fromHex(),
-                "d2ae38c4375954835d75b8e4c2f9bbb4".fromHex(),
+                algorithm = Algorithm.A192GCM,
+                key = "fbc0b4c56a714c83217b2d1bcadd2ed2e9efb0dcac6cc19f".fromHex(),
+                nonce = "5f4b43e811da9c470d6a9b01".fromHex(),
+                messagePlaintext = "d2ae38c4375954835d75b8e4c2f9bbb4".fromHex(),
             ).toHex()
         )
 
         assertEquals(
             "fa4362189661d163fcd6a56d8bf0405a" + "d636ac1bbedd5cc3ee727dc2ab4a9489",
             Crypto.encrypt(
-                Algorithm.A256GCM,
-                "31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22".fromHex(),
-                "0d18e06c7c725ac9e362e1ce".fromHex(),
-                "2db5168e932556f8089a0622981d017d".fromHex(),
+                algorithm = Algorithm.A256GCM,
+                key = "31bdadd96698c204aa9ce1448ea94ae1fb4a9a0b3c9d773b51bb1822666b8f22".fromHex(),
+                nonce = "0d18e06c7c725ac9e362e1ce".fromHex(),
+                messagePlaintext = "2db5168e932556f8089a0622981d017d".fromHex(),
+            ).toHex()
+        )
+    }
+
+    @Test
+    fun encryptWithAad() {
+        // These test vectors are from a zip file that can be downloaded from
+        //
+        //   https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/CAVP-TESTING-BLOCK-CIPHER-MODES#GCMVS
+        //
+        assertEquals(
+            "93fe7d9e9bfd10348a5606e5cafa7354" + "0032a1dc85f1c9786925a2e71d8272dd",
+            Crypto.encrypt(
+                algorithm = Algorithm.A128GCM,
+                key = "c939cc13397c1d37de6ae0e1cb7c423c".fromHex(),
+                nonce = "b3d8cc017cbb89b39e0f67e2".fromHex(),
+                messagePlaintext = "c3b3c41f113a31b73d9a5cd432103069".fromHex(),
+                aad = "24825602bd12a984e0092d3e448eda5f".fromHex()
+            ).toHex()
+        )
+
+        assertEquals(
+            "a54b5da33fc1196a8ef31a5321bfcaeb" + "1c198086450ae1834dd6c2636796bce2",
+            Crypto.encrypt(
+                algorithm = Algorithm.A192GCM,
+                key = "6f44f52c2f62dae4e8684bd2bc7d16ee7c557330305a790d".fromHex(),
+                nonce = "9ae35825d7c7edc9a39a0732".fromHex(),
+                messagePlaintext = "37222d30895eb95884bbbbaee4d9cae1".fromHex(),
+                aad = "1b4236b846fc2a0f782881ba48a067e9".fromHex()
+            ).toHex()
+        )
+
+        assertEquals(
+            "8995ae2e6df3dbf96fac7b7137bae67f" + "eca5aa77d51d4a0a14d9c51e1da474ab",
+            Crypto.encrypt(
+                algorithm = Algorithm.A256GCM,
+                key = "92e11dcdaa866f5ce790fd24501f92509aacf4cb8b1339d50c9c1240935dd08b".fromHex(),
+                nonce = "ac93a1a6145299bde902f21a".fromHex(),
+                messagePlaintext = "2d71bcfa914e4ac045b2aa60955fad24".fromHex(),
+                aad = "1e0889016f67601c8ebea4943bc23ad6".fromHex()
             ).toHex()
         )
     }
@@ -114,30 +154,70 @@ class CryptoTests {
         assertEquals(
             "28286a321293253c3e0aa2704a278032",
             Crypto.decrypt(
-                Algorithm.A128GCM,
-                "e98b72a9881a84ca6b76e0f43e68647a".fromHex(),
-                "8b23299fde174053f3d652ba".fromHex(),
-                ("5a3c1cf1985dbb8bed818036fdd5ab42" + "23c7ab0f952b7091cd324835043b5eb5").fromHex(),
+                algorithm = Algorithm.A128GCM,
+                key = "e98b72a9881a84ca6b76e0f43e68647a".fromHex(),
+                nonce = "8b23299fde174053f3d652ba".fromHex(),
+                messageCiphertext = ("5a3c1cf1985dbb8bed818036fdd5ab42" + "23c7ab0f952b7091cd324835043b5eb5").fromHex(),
             ).toHex()
         )
 
         assertEquals(
             "99ae6f479b3004354ff18cd86c0b6efb",
             Crypto.decrypt(
-                Algorithm.A192GCM,
-                "7a7c5b6a8a9ab5acae34a9f6e41f19a971f9c330023c0f0c".fromHex(),
-                "aa4c38bf587f94f99fee77d5".fromHex(),
-                ("132ae95bd359c44aaefa6348632cafbd" + "19d7c7d5809ad6648110f22f272e7d72").fromHex(),
+                algorithm = Algorithm.A192GCM,
+                key = "7a7c5b6a8a9ab5acae34a9f6e41f19a971f9c330023c0f0c".fromHex(),
+                nonce = "aa4c38bf587f94f99fee77d5".fromHex(),
+                messageCiphertext = ("132ae95bd359c44aaefa6348632cafbd" + "19d7c7d5809ad6648110f22f272e7d72").fromHex(),
             ).toHex()
         )
 
         assertEquals(
             "7789b41cb3ee548814ca0b388c10b343",
             Crypto.decrypt(
-                Algorithm.A256GCM,
-                "4c8ebfe1444ec1b2d503c6986659af2c94fafe945f72c1e8486a5acfedb8a0f8".fromHex(),
-                "473360e0ad24889959858995".fromHex(),
-                ("d2c78110ac7e8f107c0df0570bd7c90c" + "c26a379b6d98ef2852ead8ce83a833a7").fromHex(),
+                algorithm = Algorithm.A256GCM,
+                key = "4c8ebfe1444ec1b2d503c6986659af2c94fafe945f72c1e8486a5acfedb8a0f8".fromHex(),
+                nonce = "473360e0ad24889959858995".fromHex(),
+                messageCiphertext = ("d2c78110ac7e8f107c0df0570bd7c90c" + "c26a379b6d98ef2852ead8ce83a833a7").fromHex(),
+            ).toHex()
+        )
+    }
+
+    @Test
+    fun decryptWithAad() {
+        // These test vectors are from a zip file that can be downloaded from
+        //
+        //   https://csrc.nist.gov/Projects/Cryptographic-Algorithm-Validation-Program/CAVP-TESTING-BLOCK-CIPHER-MODES#GCMVS
+        //
+        assertEquals(
+            "ecafe96c67a1646744f1c891f5e69427",
+            Crypto.decrypt(
+                algorithm = Algorithm.A128GCM,
+                key = "816e39070410cf2184904da03ea5075a".fromHex(),
+                nonce = "32c367a3362613b27fc3e67e".fromHex(),
+                messageCiphertext = ("552ebe012e7bcf90fcef712f8344e8f1" + "ecaae9fc68276a45ab0ca3cb9dd9539f").fromHex(),
+                aad = "f2a30728ed874ee02983c294435d3c16".fromHex()
+            ).toHex()
+        )
+
+        assertEquals(
+            "7e3a29d47de8668a74c249ed96f8f0d2a2d5e05359c116cbdcad74b8c5ddf72c503ee12824b4039b9bf8f2b6aea9b7105f351e",
+            Crypto.decrypt(
+                algorithm = Algorithm.A192GCM,
+                key = "497ac0078bdfa10c7db2d49f978b1ac0610bb40aa60b5b29".fromHex(),
+                nonce = "e1608bae5ad218ae76633f9a".fromHex(),
+                messageCiphertext = ("225cddca92cf6438e69a4afcd8079a03cab65ae81f2631d14035a9656c6c68c699725fc374b909fab2709aab06037447e04cdb" + "a328f90905a4eb69d2c7be7942e7e24a").fromHex(),
+                aad = "fe71426fcb2cab1579a8adaee34fc790".fromHex()
+            ).toHex()
+        )
+
+        assertEquals(
+            "85fc3dfad9b5a8d3258e4fc44571bd3b",
+            Crypto.decrypt(
+                algorithm = Algorithm.A256GCM,
+                key = "54e352ea1d84bfe64a1011096111fbe7668ad2203d902a01458c3bbd85bfce14".fromHex(),
+                nonce = "df7c3bca00396d0c018495d9".fromHex(),
+                messageCiphertext = ("426e0efc693b7be1f3018db7ddbb7e4d" + "ee8257795be6a1164d7e1d2d6cac77a7").fromHex(),
+                aad = "7e968d71b50c1f11fd001f3fef49d045".fromHex()
             ).toHex()
         )
     }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebEncryptionTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebEncryptionTests.kt
@@ -1,0 +1,142 @@
+package org.multipaz.crypto
+
+import kotlinx.io.bytestring.ByteString
+import kotlinx.io.bytestring.append
+import kotlinx.io.bytestring.buildByteString
+import kotlinx.io.bytestring.encodeToByteString
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+import kotlinx.serialization.json.buildJsonObject
+import kotlinx.serialization.json.jsonObject
+import org.multipaz.util.appendInt32
+import org.multipaz.util.fromBase64Url
+import org.multipaz.util.toBase64Url
+import org.multipaz.util.toHex
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class JsonWebEncryptionTests {
+
+    @Test fun roundTrip_P256_A128GCM() = roundtrip(EcCurve.P256, Algorithm.A128GCM, false)
+    @Test fun roundTrip_P384_A128GCM() = roundtrip(EcCurve.P384, Algorithm.A128GCM, false)
+    @Test fun roundTrip_P521_A128GCM() = roundtrip(EcCurve.P521, Algorithm.A128GCM, false)
+    @Test fun roundTrip_B256_A128GCM() = roundtrip(EcCurve.BRAINPOOLP256R1, Algorithm.A128GCM, false)
+    @Test fun roundTrip_B320_A128GCM() = roundtrip(EcCurve.BRAINPOOLP320R1, Algorithm.A128GCM, false)
+    @Test fun roundTrip_B384_A128GCM() = roundtrip(EcCurve.BRAINPOOLP384R1, Algorithm.A128GCM, false)
+    @Test fun roundTrip_B512_A128GCM() = roundtrip(EcCurve.BRAINPOOLP512R1, Algorithm.A128GCM, false)
+    @Test fun roundTrip_X25519_A128GCM() = roundtrip(EcCurve.X25519, Algorithm.A128GCM, false)
+    @Test fun roundTrip_X448_A128GCM() = roundtrip(EcCurve.X448, Algorithm.A128GCM, false)
+
+    @Test fun roundTrip_P256_A192GCM() = roundtrip(EcCurve.P256, Algorithm.A192GCM, false)
+    @Test fun roundTrip_P384_A192GCM() = roundtrip(EcCurve.P384, Algorithm.A192GCM, false)
+    @Test fun roundTrip_P521_A192GCM() = roundtrip(EcCurve.P521, Algorithm.A192GCM, false)
+    @Test fun roundTrip_B256_A192GCM() = roundtrip(EcCurve.BRAINPOOLP256R1, Algorithm.A192GCM, false)
+    @Test fun roundTrip_B320_A192GCM() = roundtrip(EcCurve.BRAINPOOLP320R1, Algorithm.A192GCM, false)
+    @Test fun roundTrip_B384_A192GCM() = roundtrip(EcCurve.BRAINPOOLP384R1, Algorithm.A192GCM, false)
+    @Test fun roundTrip_B512_A192GCM() = roundtrip(EcCurve.BRAINPOOLP512R1, Algorithm.A192GCM, false)
+    @Test fun roundTrip_X25519_A192GCM() = roundtrip(EcCurve.X25519, Algorithm.A192GCM, false)
+    @Test fun roundTrip_X448_A192GCM() = roundtrip(EcCurve.X448, Algorithm.A192GCM, false)
+
+    @Test fun roundTrip_P256_A256GCM() = roundtrip(EcCurve.P256, Algorithm.A256GCM, false)
+    @Test fun roundTrip_P384_A256GCM() = roundtrip(EcCurve.P384, Algorithm.A256GCM, false)
+    @Test fun roundTrip_P521_A256GCM() = roundtrip(EcCurve.P521, Algorithm.A256GCM, false)
+    @Test fun roundTrip_B256_A256GCM() = roundtrip(EcCurve.BRAINPOOLP256R1, Algorithm.A256GCM, false)
+    @Test fun roundTrip_B320_A256GCM() = roundtrip(EcCurve.BRAINPOOLP320R1, Algorithm.A256GCM, false)
+    @Test fun roundTrip_B384_A256GCM() = roundtrip(EcCurve.BRAINPOOLP384R1, Algorithm.A256GCM, false)
+    @Test fun roundTrip_B512_A256GCM() = roundtrip(EcCurve.BRAINPOOLP512R1, Algorithm.A256GCM, false)
+    @Test fun roundTrip_X25519_A256GCM() = roundtrip(EcCurve.X25519, Algorithm.A256GCM, false)
+    @Test fun roundTrip_X448_A256GCM() = roundtrip(EcCurve.X448, Algorithm.A256GCM, false)
+
+    @Test fun roundTripCompression() = roundtrip(EcCurve.P256, Algorithm.A128GCM, true)
+
+    fun roundtrip(curve: EcCurve, encAlg: Algorithm, useCompression: Boolean) {
+        // TODO: use assumeTrue() when available in kotlin-test
+        if (!Crypto.supportedCurves.contains(curve)) {
+            println("Curve $curve not supported on platform")
+            return
+        }
+        val recipientKey = Crypto.createEcPrivateKey(curve)
+        val claims = buildJsonObject {
+            put("vp_token", buildJsonObject {
+                put("credential", buildJsonObject {
+                    put("foo", JsonPrimitive("blah"))
+                })
+            })
+        }
+        val decryptedClaims = JsonWebEncryption.decrypt(
+            encryptedJwt = JsonWebEncryption.encrypt(
+                claimsSet = claims,
+                recipientPublicKey = recipientKey.publicKey,
+                encAlg = encAlg,
+                apu = ByteString(1, 2, 3),
+                apv = ByteString(4, 5, 6),
+                compressionLevel = if (useCompression) 5 else null
+            ),
+            recipientKey = recipientKey
+        )
+        assertEquals(decryptedClaims, claims)
+    }
+
+    @Test
+    fun testConcatKdf() {
+        // This checks our ConcatKdf() implementation works by using test vectors from
+        //
+        //  https://datatracker.ietf.org/doc/html/rfc7518#appendix-C
+        //
+        val bobEphemeralKey = EcPrivateKeyDoubleCoordinate(
+            curve = EcCurve.P256,
+            d = "VEmDZpDXXK8p8N0Cndsxs924q6nS1RXFASRl6BfUqdw".fromBase64Url(),
+            x = "weNJy2HscCSM6AEDTDg04biOvhFhyyWvOHQfeF_PxMQ".fromBase64Url(),
+            y = "e8lnCO-AlStT-NJVX-crhB7QRYhiix03illJOVAOyck".fromBase64Url()
+        )
+        val protectedHeader = Json.decodeFromString(JsonObject.serializer(),
+            """
+                {
+                  "alg":"ECDH-ES",
+                  "enc":"A128GCM",
+                  "apu":"QWxpY2U",
+                  "apv":"Qm9i",
+                  "epk": {
+                    "kty":"EC",
+                    "crv":"P-256",
+                    "x":"gI0GAILBdu7T53akrFmMyGcsF3n5dO7MmwNBHKW5SV0",
+                    "y":"SLW_xSffzlPWrHEVI30DHM_4egVwt3NQqeUD7nMFpps"
+                  }
+                }
+            """.trimIndent().trim()
+        )
+
+        val senderEphemeralKey = EcPublicKey.fromJwk(protectedHeader["epk"]!!.jsonObject)
+        val sharedSecret = Crypto.keyAgreement(bobEphemeralKey, senderEphemeralKey)
+        assertEquals(
+            // This is the hex
+            //
+            //   [158, 86, 217, 29, 129, 113, 53, 211, 114, 131, 66, 131, 191, 132,
+            //   38, 156, 251, 49, 110, 163, 218, 128, 106, 72, 246, 218, 167, 121,
+            //   140, 254, 144, 196]
+            //
+            // from the example.
+            //
+            "9e56d91d817135d372834283bf84269cfb316ea3da806a48f6daa7798cfe90c4",
+            sharedSecret.toHex()
+        )
+
+        val algId = Algorithm.A128GCM.joseAlgorithmIdentifier!!.encodeToByteString()
+        val apu = "Alice".encodeToByteString()
+        val apv = "Bob".encodeToByteString()
+        val contentEncryptionKey = JsonWebEncryption.concatKDF(
+            sharedSecretZ = ByteString(sharedSecret),
+            keyDataLenBits = 128,
+            algorithmId = buildByteString { appendInt32(algId.size); append(algId) },
+            partyUInfo =  buildByteString { appendInt32(apu.size); append(apu) },
+            partyVInfo =  buildByteString { appendInt32(apv.size); append(apv) },
+            suppPubInfo = buildByteString { appendInt32(128) }
+        )
+        assertEquals(
+            "VqqN6vgjbSBcIijNcacQGg",
+            contentEncryptionKey.toBase64Url()
+        )
+
+    }
+}

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebSignatureTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebSignatureTests.kt
@@ -8,9 +8,25 @@ import kotlin.test.Test
 import kotlin.time.Duration.Companion.days
 
 class JsonWebSignatureTests {
-    @Test
-    fun roundtrip() {
-        val signingKey = Crypto.createEcPrivateKey(EcCurve.P256)
+
+    @Test fun roundTrip_P256() = roundtrip(EcCurve.P256)
+    @Test fun roundTrip_P384() = roundtrip(EcCurve.P384)
+    @Test fun roundTrip_P521() = roundtrip(EcCurve.P521)
+    @Test fun roundTrip_B256() = roundtrip(EcCurve.BRAINPOOLP256R1)
+    @Test fun roundTrip_B320() = roundtrip(EcCurve.BRAINPOOLP320R1)
+    @Test fun roundTrip_B384() = roundtrip(EcCurve.BRAINPOOLP384R1)
+    @Test fun roundTrip_B512() = roundtrip(EcCurve.BRAINPOOLP512R1)
+    @Test fun roundTrip_ED25519() = roundtrip(EcCurve.ED25519)
+    @Test fun roundTrip_ED448() = roundtrip(EcCurve.ED448)
+
+    fun roundtrip(curve: EcCurve) {
+        // TODO: use assumeTrue() when available in kotlin-test
+        if (!Crypto.supportedCurves.contains(curve)) {
+            println("Curve $curve not supported on platform")
+            return
+        }
+
+        val signingKey = Crypto.createEcPrivateKey(curve)
         val now = Clock.System.now()
         val signingKeyCert = X509Cert.Builder(
             publicKey = signingKey.publicKey,

--- a/multipaz/src/commonTest/kotlin/org/multipaz/util/CompressionTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/util/CompressionTests.kt
@@ -1,0 +1,64 @@
+package org.multipaz.util
+
+import kotlin.test.Test
+import kotlin.test.assertContentEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertTrue
+
+class CompressionTests {
+    
+    @Test fun roundTripLevel0() { roundTrip(0) }
+    @Test fun roundTripLevel1() { roundTrip(1) }
+    @Test fun roundTripLevel2() { roundTrip(2) }
+    @Test fun roundTripLevel3() { roundTrip(3) }
+    @Test fun roundTripLevel4() { roundTrip(4) }
+    @Test fun roundTripLevel5() { roundTrip(5) }
+    @Test fun roundTripLevel6() { roundTrip(6) }
+    @Test fun roundTripLevel7() { roundTrip(7) }
+    @Test fun roundTripLevel8() { roundTrip(8) }
+    @Test fun roundTripLevel9() { roundTrip(9) }
+
+    fun roundTrip(level: Int) {
+        val sb = StringBuilder()
+        repeat(1000) {
+            sb.append("Hello Multipaz!\n")
+        }
+        val data = sb.toString().encodeToByteArray()
+
+        val compressedData = deflate(data, level)
+        if (level > 0) {
+            assertTrue(compressedData.size < data.size)
+        }
+        val decompressedData = inflate(compressedData)
+        assertContentEquals(decompressedData, data)
+    }
+
+    @Test
+    fun testVector() {
+        val sb = StringBuilder()
+        repeat(1000) {
+            sb.append("Hello Multipaz!\n")
+        }
+        val expectedData = sb.toString().encodeToByteArray()
+
+        val knownCompressedDataBase64Url =
+            "7cehDcAgEABA3ynoNm8YAoFo8gkIMEzPIL1zFz1zlLpzfbOd9wl3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3f_5S8"
+        val decompressedData = inflate(knownCompressedDataBase64Url.fromBase64Url())
+        assertContentEquals(expectedData, decompressedData)
+    }
+
+    @Test
+    fun inflateWithUnsupportedLevel() {
+        assertFailsWith(IllegalArgumentException::class) { deflate(byteArrayOf(1, 2), -10) }
+        assertFailsWith(IllegalArgumentException::class) { deflate(byteArrayOf(1, 2), -1) }
+        assertFailsWith(IllegalArgumentException::class) { deflate(byteArrayOf(1, 2), 10) }
+        assertFailsWith(IllegalArgumentException::class) { deflate(byteArrayOf(1, 2), 11) }
+    }
+
+    @Test
+    fun inflateWithInvalidData() {
+        assertFailsWith(IllegalArgumentException::class) {
+            inflate(byteArrayOf(1, 2))
+        }
+    }
+}

--- a/multipaz/src/iosMain/kotlin/org/multipaz/util/Compression.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/util/Compression.ios.kt
@@ -1,0 +1,34 @@
+package org.multipaz.util
+
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.Foundation.NSMutableData
+import platform.Foundation.NSDataCompressionAlgorithmZlib
+import platform.Foundation.compressUsingAlgorithm
+import platform.Foundation.decompressedDataUsingAlgorithm
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun deflate(data: ByteArray, compressionLevel: Int): ByteArray {
+    require(compressionLevel >=0 && compressionLevel <= 9) {
+        "Compression level $compressionLevel is invalid, must be between 0 and 9"
+    }
+    // Note: This API doesn't allow setting the compressionLevel, it's always hardcoded to 5
+    val data = data.toNSData().mutableCopy() as NSMutableData
+    data.compressUsingAlgorithm(
+        algorithm = NSDataCompressionAlgorithmZlib,
+        error = null
+    )
+    return data.toByteArray()
+}
+
+@OptIn(ExperimentalForeignApi::class)
+actual fun inflate(compressedData: ByteArray): ByteArray {
+    val d = compressedData.toNSData()
+    val ret = d.decompressedDataUsingAlgorithm(
+        algorithm = NSDataCompressionAlgorithmZlib,
+        error = null
+    )
+    if (ret == null) {
+        throw IllegalArgumentException("Error decompressing data")
+    }
+    return ret.toByteArray()
+}

--- a/multipaz/src/javaSharedMain/kotlin/org/multipaz/util/Compression.jvm.kt
+++ b/multipaz/src/javaSharedMain/kotlin/org/multipaz/util/Compression.jvm.kt
@@ -1,0 +1,43 @@
+package org.multipaz.util
+
+import java.io.ByteArrayInputStream
+import java.io.ByteArrayOutputStream
+import java.util.zip.Deflater
+import java.util.zip.Inflater
+import java.util.zip.InflaterInputStream
+
+actual fun deflate(data: ByteArray, compressionLevel: Int): ByteArray {
+    require(compressionLevel >=0 && compressionLevel <= 9) {
+        "Compression level $compressionLevel is invalid, must be between 0 and 9"
+    }
+    val compresser = Deflater(compressionLevel, /* nowrap = */true)
+    compresser.setInput(data)
+    compresser.finish()
+    val baos = ByteArrayOutputStream()
+    val buf = ByteArray(4096)
+    while (!compresser.finished()) {
+        val compressedSize = compresser.deflate(buf)
+        baos.write(buf, 0, compressedSize)
+    }
+    return baos.toByteArray()
+}
+
+actual fun inflate(compressedData: ByteArray): ByteArray {
+    val bais = ByteArrayInputStream(compressedData)
+    val decompresser = Inflater(/* nowrap = */ true)
+    val iis = InflaterInputStream(bais, decompresser)
+    val baos = ByteArrayOutputStream()
+    val buf = ByteArray(4096)
+    try {
+        do {
+            val length = iis.read(buf)
+            if (length > 0) {
+                baos.write(buf, 0, length)
+            }
+        } while (length > 0)
+        iis.close();
+    } catch (e: Throwable) {
+        throw IllegalArgumentException("Error decompressing data", e)
+    }
+    return baos.toByteArray()
+}

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTestsNimbus.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTestsNimbus.kt
@@ -67,7 +67,7 @@ class JsonWebSignatureTestsNimbus {
             x5c = X509CertChain(listOf(signingKeyCert))
         )
 
-        val sjwt = SignedJWT.parse(signedJwt.jsonPrimitive.content)
+        val sjwt = SignedJWT.parse(signedJwt)
         val jwtProcessor = DefaultJWTProcessor<SecurityContext>()
         val x5c = sjwt.header?.x509CertChain ?: throw IllegalArgumentException("Error retrieving x5c")
         val pubCertChain = x5c.mapNotNull { runCatching { X509Cert(it.decode()) }.getOrNull() }
@@ -135,14 +135,14 @@ class JsonWebSignatureTestsNimbus {
         val signedJwt = Json.parseToJsonElement(signedJWT.serialize())
 
         // Verify JwsInfo fields
-        val info = JsonWebSignature.getInfo(signedJwt)
+        val info = JsonWebSignature.getInfo(signedJwt.jsonPrimitive.content)
         assertEquals(claimsSet, info.claimsSet)
         assertEquals("oauth-authz-req+jwt", info.type)
         assertEquals(X509CertChain(listOf(signingKeyCert)), info.x5c)
 
         // Verify signature checks out
         JsonWebSignature.verify(
-            signedJwt,
+            signedJwt.jsonPrimitive.content,
             info.x5c!!.certificates.first().ecPublicKey
         )
 
@@ -150,7 +150,7 @@ class JsonWebSignatureTestsNimbus {
         val otherKey = Crypto.createEcPrivateKey(EcCurve.P256)
         assertFails {
             JsonWebSignature.verify(
-                signedJwt,
+                signedJwt.jsonPrimitive.content,
                 otherKey.publicKey
             )
         }

--- a/server/src/main/java/org/multipaz/wallet/server/VerifierServlet.kt
+++ b/server/src/main/java/org/multipaz/wallet/server/VerifierServlet.kt
@@ -850,7 +850,10 @@ class VerifierServlet : BaseHttpServlet() {
         val encryptedResponse = response["response"]
         val vpToken = if (encryptedResponse != null) {
             session.responseWasEncrypted = true
-            val decryptedResponse = JsonWebEncryption.decrypt(encryptedResponse, session.encryptionKey).jsonObject
+            val decryptedResponse = JsonWebEncryption.decrypt(
+                encryptedResponse.jsonPrimitive.content,
+                session.encryptionKey
+            ).jsonObject
             decryptedResponse["vp_token"]!!.jsonObject
         } else {
             response["vp_token"]!!.jsonObject
@@ -1597,7 +1600,7 @@ private fun calcDcRequestStringOpenID4VP(
         x5c = readerAuthKeyCertification
     )
     val signedRequest = buildJsonObject {
-        put("request", JsonPrimitive(signedRequestElement.jsonPrimitive.content))
+        put("request", JsonPrimitive(signedRequestElement))
     }
     return signedRequest.toString()
 }


### PR DESCRIPTION
This means we no longer have to depend on the Nimbus library for the core Multipaz library on JVM. Do keep this library around and use it in the JVM-specific tests to check that our implementation interoperates.

Other changes:
- Use `String` instead of `JsonElement` in both JsonWebEncryption and JsonWebSignature APIs - it's cleaner this way since we're always using compact serialization and have no plans to support anything else.
- Add support for AAD in `Crypto.encrypt()` and `Crypto.decrypt()` APIs along with new unit tests using NIST test vectors.
- Add new `inflate()` and `deflate()` with JVM and iOS implementations and unit tests.

Test: ./gradlew check && ./gradlew connectedCheck
Test: New unit tests and all unit tests pass.
