### PR TITLE
Selfie Check and Capture Use case

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/Util.android.kt
@@ -46,22 +46,22 @@ actual fun cropRotateScaleImage(
     cx: Double,
     cy: Double,
     angleDegrees: Double,
-    outputWidth: Int,
-    outputHeight: Int,
-    targetWidth: Int
+    outputWidthPx: Int,
+    outputHeightPx: Int,
+    targetWidthPx: Int
 ): ImageBitmap {
     val androidBitmap = frameData.cameraImage.imageProxy.toBitmap()
-    val finalScale = targetWidth.toFloat() / outputWidth.toFloat()
-    val finalOutputHeight = (outputHeight * finalScale).toInt()
+    val finalScale = targetWidthPx.toFloat() / outputWidthPx.toFloat()
+    val finalOutputHeight = (outputHeightPx * finalScale).toInt()
     val matrix = Matrix() // Use Android's Matrix
 
     matrix.postTranslate(-cx.toFloat(), -cy.toFloat())
     matrix.postRotate(angleDegrees.toFloat())
-    matrix.postTranslate((outputWidth / 2).toFloat(), (outputHeight / 2).toFloat())
+    matrix.postTranslate((outputWidthPx / 2).toFloat(), (outputHeightPx / 2).toFloat())
     matrix.postScale(finalScale, finalScale)
 
     // Create the output bitmap with the final scaled dimensions.
-    val resultBitmap = createBitmap(targetWidth, finalOutputHeight, androidBitmap.config ?: Bitmap.Config.ARGB_8888)
+    val resultBitmap = createBitmap(targetWidthPx, finalOutputHeight, androidBitmap.config ?: Bitmap.Config.ARGB_8888)
     Canvas(resultBitmap).drawBitmap(androidBitmap, matrix, paint)
 
     return resultBitmap.asImageBitmap()

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/Util.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/Util.kt
@@ -29,7 +29,7 @@ expect fun getApplicationInfo(appId: String): ApplicationInfo
 expect fun decodeImage(encodedData: ByteArray): ImageBitmap
 
 /**
- * Encodes a bitmap to PNG
+ * Encodes a bitmap to PNG.
  *
  * @param image the image to encode.
  * @return a [ByteString] with the encoded data.
@@ -82,7 +82,7 @@ expect fun cropRotateScaleImage(
     cx: Double,
     cy: Double,
     angleDegrees: Double,
-    outputWidth: Int,
-    outputHeight: Int,
-    targetWidth: Int // You might want to make targetWidth/Height nullable or handle aspect ratio
+    outputWidthPx: Int,
+    outputHeightPx: Int,
+    targetWidthPx: Int
 ): ImageBitmap

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/camera/CameraFrame.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/camera/CameraFrame.kt
@@ -36,4 +36,8 @@ data class CameraFrame(
      * If preview is disabled, this is the identity matrix.
      */
     val previewTransformation: Matrix
-)
+
+) {
+    /** Determine if the rotation angle indicates the camera was used from a landscape phone orientation mode. */
+    val isLandscape: Boolean = (rotation == 90 || rotation == 270)
+}

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/Util.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/Util.ios.kt
@@ -4,7 +4,10 @@ import androidx.compose.ui.graphics.ImageBitmap
 import androidx.compose.ui.graphics.asSkiaBitmap
 import androidx.compose.ui.graphics.toComposeImageBitmap
 import kotlinx.cinterop.ExperimentalForeignApi
+import kotlinx.cinterop.addressOf
+import kotlinx.cinterop.refTo
 import kotlinx.cinterop.useContents
+import kotlinx.cinterop.usePinned
 import kotlinx.io.bytestring.ByteString
 import org.jetbrains.skia.EncodedImageFormat
 import org.jetbrains.skia.Image
@@ -14,11 +17,21 @@ import platform.CoreGraphics.CGAffineTransformConcat
 import platform.CoreGraphics.CGAffineTransformMakeRotation
 import platform.CoreGraphics.CGAffineTransformMakeScale
 import platform.CoreGraphics.CGAffineTransformMakeTranslation
+import platform.CoreGraphics.CGBitmapContextCreate
+import platform.CoreGraphics.CGBitmapContextCreateImage
+import platform.CoreGraphics.CGColorSpaceCreateDeviceRGB
 import platform.CoreGraphics.CGContextConcatCTM
+import platform.CoreGraphics.CGContextRotateCTM
+import platform.CoreGraphics.CGContextScaleCTM
+import platform.CoreGraphics.CGContextTranslateCTM
+import platform.CoreGraphics.CGImageAlphaInfo
 import platform.CoreGraphics.CGRectMake
 import platform.CoreGraphics.CGSizeMake
+import platform.Foundation.NSData
 import platform.UIKit.UIGraphicsImageRenderer
 import platform.UIKit.UIGraphicsImageRendererFormat
+import platform.UIKit.UIImage
+import platform.posix.memcpy
 import kotlin.math.PI
 
 actual fun getApplicationInfo(appId: String): ApplicationInfo {
@@ -35,9 +48,81 @@ actual fun encodeImageToPng(image: ImageBitmap): ByteString {
     return ByteString(data.bytes)
 }
 
+
 @OptIn(ExperimentalForeignApi::class)
 actual fun cropRotateScaleImage(
-    frameData: CameraFrame, //UIImage
+    frameData: CameraFrame,
+    cx: Double, // ASSUMED: from top-left of image data, Y increases downwards
+    cy: Double, // ASSUMED: from top-left of image data, Y increases downwards
+    angleDegrees: Double,
+    outputWidthPx: Int,
+    outputHeightPx: Int,
+    targetWidthPx: Int
+): ImageBitmap {
+    val originalUIImage = frameData.cameraImage.uiImage
+    val originalImageWidth = originalUIImage.size.useContents { width }
+    val originalImageHeight = originalUIImage.size.useContents { height }
+
+    val scaleFactor = targetWidthPx.toDouble() / outputWidthPx.toDouble()
+    val finalCanvasWidth = targetWidthPx.toDouble()
+    val finalCanvasHeight = outputHeightPx.toDouble() * scaleFactor
+
+    val rendererFormat = UIGraphicsImageRendererFormat.defaultFormat().apply {
+        opaque = true; scale = 0.0; preferredRange = 2
+    }
+    val renderer = UIGraphicsImageRenderer(
+        size = CGSizeMake(finalCanvasWidth, finalCanvasHeight),
+        format = rendererFormat
+    )
+
+    val resultUIImage = renderer.imageWithActions { rendererContext ->
+        val cgContext = rendererContext?.CGContext
+
+        // --- Step 1: Adjust context orientation based on output mode ---
+        // Goal: Make the context effectively (0,0) at top-left, Y increases downwards
+        // for subsequent drawing of UIImage.
+
+        if (!frameData.isLandscape) { // PORTRAIT
+            // Standard flip for portrait: UIImage (0,0) is top-left, CGContext default is often bottom-left.
+            CGContextTranslateCTM(cgContext, 0.0, finalCanvasHeight)
+            CGContextScaleCTM(cgContext, 1.0, -1.0)
+        } else { // LANDSCAPE
+            // If the portrait flip makes landscape upside down, it implies that for landscape,
+            // the context as provided by UIGraphicsImageRenderer might already be
+            // effectively top-left, Y-down, or it's rotated in a way that the standard
+            // portrait flip is incorrect.
+            // HYPOTHESIS: No initial flip is needed for landscape if it's already top-left Y-down.
+            // (If this assumption is wrong, landscape images will be upside down OR correctly oriented
+            // if the renderer provides a Y-down context for landscape by default).
+        }
+
+        // --- Step 2: Transformations to center (cx,cy) and crop/scale ---
+        // (cx,cy) are from top-left of original image.
+
+        // a. Move drawing origin to the center of the output canvas
+        CGContextTranslateCTM(cgContext, finalCanvasWidth / 2.0, finalCanvasHeight / 2.0)
+
+        // b. Scale based on desired output crop becoming target width
+        CGContextScaleCTM(cgContext, scaleFactor, scaleFactor)
+
+        // c. Rotate. angleDegrees is defined for the image being upright.
+        CGContextRotateCTM(cgContext, -angleDegrees * PI / 180.0)
+
+        // d. Translate so that (cx,cy) of the original image is at the current (transformed) origin.
+        CGContextTranslateCTM(cgContext, -cx, -cy)
+
+        // --- Step 3: Draw ---
+        originalUIImage.drawInRect(
+            CGRectMake(0.0, 0.0, originalImageWidth, originalImageHeight)
+        )
+    }
+    return CameraImage(resultUIImage).toImageBitmap()
+}
+
+
+@OptIn(ExperimentalForeignApi::class)
+fun cropRotateScaleImage0(
+    frameData: CameraFrame,
     cx: Double,
     cy: Double,
     angleDegrees: Double,
@@ -45,19 +130,19 @@ actual fun cropRotateScaleImage(
     outputHeight: Int,
     targetWidth: Int
 ): ImageBitmap {
-    val originalUIImage = frameData.cameraImage.uiImage // You'll need a way to convert ImageBitmap to UIImage
-
-    // 2. Calculate final dimensions and scale factor
+    val originalUIImage = frameData.cameraImage.uiImage
     val finalScale = targetWidth.toDouble() / outputWidth.toDouble()
     val finalOutputWidth = targetWidth.toDouble()
     val finalOutputHeight = outputHeight.toDouble() * finalScale
-
-    // 3. Set up the drawing context with the *final* output dimensions
     val rendererFormat = UIGraphicsImageRendererFormat.defaultFormat().apply {
         opaque = true
-        scale = originalUIImage.scale
+        scale = originalUIImage.scale //todo remove?
         preferredRange = 2
     }
+
+    // Compensate for iOS camera flip direction.
+    val cy2 = frameData.height - cy
+
     val renderer = UIGraphicsImageRenderer(
         size = CGSizeMake(finalOutputWidth, finalOutputHeight),
         format = rendererFormat
@@ -68,11 +153,9 @@ actual fun cropRotateScaleImage(
         var transform = CGAffineTransformMakeTranslation(finalOutputWidth / 2.0, finalOutputHeight / 2.0)
         transform = CGAffineTransformConcat(CGAffineTransformMakeScale(finalScale, finalScale), transform)
         transform = CGAffineTransformConcat(CGAffineTransformMakeRotation(angleDegrees * PI / 180.0), transform)
-        transform = CGAffineTransformConcat(CGAffineTransformMakeTranslation(-cx, -cy), transform)
+        transform = CGAffineTransformConcat(CGAffineTransformMakeTranslation(-cx, -cy2), transform)
         CGContextConcatCTM(cgContext, transform)
 
-        // Draw the original (normalized) UIImage.
-        // It's drawn at (0,0) in its own coordinate system. The CTM handles the rest.
         originalUIImage.drawInRect(
             CGRectMake(
                 0.0,
@@ -84,4 +167,28 @@ actual fun cropRotateScaleImage(
     }
 
     return CameraImage(resultUIImage).toImageBitmap()
+}
+
+/** Convert ImageBitmap to iOS UIImage. */
+@OptIn(ExperimentalForeignApi::class)
+fun ImageBitmap.toUIImage(): UIImage? {
+    val width = this.width
+    val height = this.height
+    val buffer = IntArray(width * height)
+
+    this.readPixels(buffer)
+
+    val colorSpace = CGColorSpaceCreateDeviceRGB()
+    val context = CGBitmapContextCreate(
+        data = buffer.refTo(0),
+        width = width.toULong(),
+        height = height.toULong(),
+        bitsPerComponent = 8u,
+        bytesPerRow = (4 * width).toULong(),
+        space = colorSpace,
+        bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value
+    )
+
+    val cgImage = CGBitmapContextCreateImage(context)
+    return cgImage?.let { UIImage.imageWithCGImage(it) }
 }

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/camera/CameraImage.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/camera/CameraImage.ios.kt
@@ -5,10 +5,13 @@ import androidx.compose.ui.graphics.toComposeImageBitmap
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.get
 import kotlinx.cinterop.readBytes
+import kotlinx.io.bytestring.ByteString
 import org.jetbrains.skia.ColorAlphaType
 import org.jetbrains.skia.ColorType
 import org.jetbrains.skia.Image
 import org.jetbrains.skia.ImageInfo
+import org.multipaz.util.getByteString
+import org.multipaz.util.toByteArray
 import platform.CoreFoundation.CFDataGetBytePtr
 import platform.CoreFoundation.CFDataGetLength
 import platform.CoreFoundation.CFRelease
@@ -19,7 +22,9 @@ import platform.CoreGraphics.CGImageGetBytesPerRow
 import platform.CoreGraphics.CGImageGetDataProvider
 import platform.CoreGraphics.CGImageGetHeight
 import platform.CoreGraphics.CGImageGetWidth
+import platform.Foundation.NSData
 import platform.UIKit.UIImage
+import platform.UIKit.UIImagePNGRepresentation
 
 /**
  * iOS specific implementation of [org.multipaz.compose.camera.CameraImage].

--- a/multipaz-mlkit/src/androidMain/kotlin/org/multipaz/facedetection/FaceDetector.android.kt
+++ b/multipaz-mlkit/src/androidMain/kotlin/org/multipaz/facedetection/FaceDetector.android.kt
@@ -39,9 +39,10 @@ actual fun detectFaces(image: ImageBitmap): List<DetectedFace>? {
 
 private val faceDetectorOptions = FaceDetectorOptions.Builder()
     .setClassificationMode(FaceDetectorOptions.CLASSIFICATION_MODE_ALL)
-    .setPerformanceMode(FaceDetectorOptions.PERFORMANCE_MODE_FAST)
+    .setPerformanceMode(FaceDetectorOptions.PERFORMANCE_MODE_ACCURATE)
     .setLandmarkMode(FaceDetectorOptions.LANDMARK_MODE_ALL)
     .setContourMode(FaceDetectorOptions.CONTOUR_MODE_ALL)
+    .setMinFaceSize(0.20f)
     .build()
 
 private fun detectFaces(inputImage: InputImage, rotation: Int): List<DetectedFace>? =

--- a/multipaz-mlkit/src/commonMain/composeResources/values/strings.xml
+++ b/multipaz-mlkit/src/commonMain/composeResources/values/strings.xml
@@ -1,0 +1,35 @@
+<resources>
+
+    <!-- Selfie check stepFeedback (displayed on the dedicated card). -->
+    <string name="selfie_instruction_preface">To verify your identity you will be asked to perform a series of head movements in the following screens.\n
+All analysis is local, doesn't leave the device, and isn't shared with anyone. One of the video frames from the verification will be shared with %1$s at the end, after your approval.\n
+Please do this in a well-lit room and without any distractions in the background.</string>
+    <string name="selfie_instruction_initial_state">Get ready for selfie check.</string>
+    <string name="selfie_instruction_center_face">Please center your face in the oval.</string>
+    <string name="selfie_instruction_rotate_head_left">Slowly turn your head to the LEFT.</string>
+    <string name="selfie_instruction_rotate_head_right">Slowly turn your head to the RIGHT.</string>
+    <string name="selfie_instruction_rotate_head_up">Slowly tilt your head UP.</string>
+    <string name="selfie_instruction_rotate_head_down">Slowly tilt your head DOWN.</string>
+    <string name="selfie_instruction_circular_gaze_start">Look around you (all the way left and right).</string>
+    <string name="selfie_instruction_circular_gaze_remaining">Keep looking around... %1$s areas.</string>
+    <string name="selfie_instruction_close_eyes">Please close your eyes.</string>
+    <string name="selfie_instruction_smile">Please smile.</string>
+    <string name="selfie_instruction_completed">Selfie check completed! Thank you.</string>
+    <string name="selfie_instruction_move_horizontally">Move face horizontally to center.</string>
+    <string name="selfie_instruction_move_vertically">Move face vertically to center.</string>
+    <string name="selfie_instruction_keep_head_level">Keep your head level while looking around.</string>
+    <string name="selfie_instruction_look_around">Look around (left and right).</string>
+    <string name="selfie_instruction_keep_looking">Keep looking around slowly to fill missing areas.</string>
+    <string name="selfie_instruction_close_firmly">Please close both eyes firmly but relaxed.</string>
+    <string name="selfie_instruction_clear_smile">Please give a clear smile.</string>
+    <string name="selfie_instruction_look_straight">Please look directly into the camera with the face centered.</string>
+    <string name="selfie_instruction_failed_timeout">Verification Failed. Step timed out: %1$s. Please try again.</string>
+    <string name="selfie_instruction_selfie_sent">Image sent. You can close this dialog window.</string>
+
+    <string name="selfie_button_try_again">TRY AGAIN</string>
+    <string name="selfie_button_start_check">START VERIFICATION</string>
+    <string name="selfie_prompt_consent">I consent to sharing this image with %1$s.</string>
+    <string name="selfie_prompt_done">Done!</string>
+    <string name="selfie_button_send">Send</string>
+
+</resources>

--- a/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/HeadRotationDirection.kt
+++ b/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/HeadRotationDirection.kt
@@ -1,0 +1,9 @@
+package org.multipaz.selfiecheck
+
+/**
+ * Distinct head positions identifying expected sets of MLKit data triplets for the face normal vector (euler angles
+ * of the face orientation in 3D space).
+ */
+enum class HeadRotationDirection {
+    LEFT, RIGHT, UP, DOWN
+}

--- a/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/SelfieCheck.kt
+++ b/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/SelfieCheck.kt
@@ -1,0 +1,763 @@
+package org.multipaz.selfiecheck
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.Canvas
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.automirrored.filled.ArrowForward
+import androidx.compose.material.icons.filled.ArrowDownward
+import androidx.compose.material.icons.filled.ArrowUpward
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.clipToBounds
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ImageBitmap
+import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.Fill
+import androidx.compose.ui.graphics.drawscope.Stroke
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.jetbrains.compose.resources.stringResource
+import org.multipaz.compose.camera.Camera
+import org.multipaz.compose.camera.CameraCaptureResolution
+import org.multipaz.facedetection.detectFaces
+import org.multipaz.multipaz_mlkit.generated.resources.Res
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_button_send
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_button_start_check
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_button_try_again
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_center_face
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_circular_gaze_remaining
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_circular_gaze_start
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_clear_smile
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_close_eyes
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_close_firmly
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_completed
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_failed_timeout
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_keep_head_level
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_keep_looking
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_look_around
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_look_straight
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_move_horizontally
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_move_vertically
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_preface
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_rotate_head_down
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_rotate_head_left
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_rotate_head_right
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_rotate_head_up
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_instruction_smile
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_prompt_consent
+import org.multipaz.multipaz_mlkit.generated.resources.selfie_prompt_done
+import org.multipaz.selfiecheck.SelfieCheckStep.COMPLETED
+import org.multipaz.selfiecheck.SelfieCheckStep.DONE
+import org.multipaz.selfiecheck.SelfieCheckStep.FAILED
+import org.multipaz.selfiecheck.SelfieCheckStep.IMAGE_TAKEN
+import org.multipaz.selfiecheck.SelfieCheckStep.INITIAL
+import org.multipaz.selfiecheck.SelfieCheckViewModel.EventId
+import org.multipaz.selfiecheck.SelfieCheckViewModel.StepFeedback
+import kotlin.math.PI
+import kotlin.math.cos
+import kotlin.math.sin
+
+/**
+ * Selfie check screen content presenter.
+ * Includes live camera preview as well as dynamic user-guiding info-graphics and textual content.
+ *
+ * @param modifier Modifier for the screen composition in the parent composable.
+ * @param viewModel Selfie check view model orchestrating the user journey.
+ * @param identityIssuer The name or identification of the inquiring identity issuer who is receiving the result
+ *     of the person image verification (e.g. "Utopia Department of Motor Vehicles").
+ */
+@Composable
+fun SelfieCheck(
+    modifier: Modifier = Modifier,
+    viewModel: SelfieCheckViewModel,
+    onVerificationComplete: () -> Unit,
+    identityIssuer: String
+) {
+    val isLandscape by viewModel.isLandscape.collectAsState()
+    val currentStep by viewModel.currentStep.collectAsState()
+    val instructions by viewModel.instructions.collectAsState()
+    val hapticFeedback = LocalHapticFeedback.current
+    val countdownSeconds by viewModel.countdownSeconds.collectAsState()
+    val countdownProgress by viewModel.countdownProgress.collectAsState()
+    val sectors = remember { mutableStateOf(List(8) { false }) }
+    var isShowingCameraPreview by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+
+
+    LaunchedEffect(currentStep) {
+        if (currentStep == DONE) {
+            onVerificationComplete()
+        }
+        isShowingCameraPreview = !(currentStep == INITIAL || currentStep == DONE)
+    }
+
+
+    // Step success feedback monitor.
+    LaunchedEffect(viewModel.stepSuccessEvent) {
+        viewModel.stepSuccessEvent.collect {
+            hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+        }
+    }
+
+    val cameraPreviewContent = @Composable {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(if (isShowingCameraPreview) 0.8f else 0f) // Hide but not remove to track orientation.
+                .aspectRatio(1f)
+                .clip(CircleShape)
+                .clipToBounds(),
+            contentAlignment = Alignment.Center
+        ) {
+            Camera(
+                modifier = Modifier.fillMaxSize(),
+                captureResolution = CameraCaptureResolution.MEDIUM,
+                showCameraPreview = isShowingCameraPreview,
+                onFrameCaptured = { frameData ->
+                    viewModel.setLandscape(frameData.isLandscape)
+                    if (currentStep != INITIAL &&
+                        currentStep != DONE &&
+                        currentStep != FAILED
+                    ) {
+                        val faces = detectFaces(frameData)
+                        if (!faces.isNullOrEmpty()) {
+                            viewModel.onFaceDataUpdated(
+                                faces[0],
+                                frameData
+                            )
+                        }
+                    }
+                }
+            )
+
+            // Face preview overlay for centering the face.
+            if (currentStep != INITIAL &&
+                currentStep != COMPLETED &&
+                currentStep != FAILED &&
+                currentStep != IMAGE_TAKEN &&
+                currentStep != DONE
+            ) {
+                // Overlays with graphic step hints.
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth(0.7f)
+                        .aspectRatio(0.75f)
+                        .border(
+                            BorderStroke(4.dp, MaterialTheme.colorScheme.primary),
+                            CircleShape
+                        )
+                )
+                when (instructions.eventId) {
+                    EventId.MOVE_HORIZONTALLY -> VisualHintMoveHorizontally(this, Modifier)
+                    EventId.MOVE_VERTICALLY -> VisualHintMoveVertically(this, Modifier)
+                    EventId.ROTATE_HEAD_DOWN -> VisualHintMoveUpDown(this, Modifier, isUp = false)
+                    EventId.ROTATE_HEAD_UP -> VisualHintMoveUpDown(this, Modifier, isUp = true)
+                    EventId.ROTATE_HEAD_LEFT -> VisualHintMoveLeftRight(this, Modifier, isLeft = true)
+                    EventId.ROTATE_HEAD_RIGHT -> VisualHintMoveLeftRight(this, Modifier, isLeft = false)
+                    EventId.SECTOR_HIT -> {
+                        // New list to facilitate recomposition of Canvas.
+                        val newList = sectors.value.toMutableList().apply {
+                            this[instructions.textParam.toInt()] = true
+                        }
+                        sectors.value = newList.toList()
+                        VisualHintGaze(Modifier, sectorStates = sectors.value)
+
+                        if (!sectors.value.contains(false)) {
+                            coroutineScope.launch {
+                                delay(500L)
+                                // Reset if all sectors are filled by prior check session.
+                                sectors.value = MutableList(GAZE_CIRCLE_SECTORS) { false }
+                            }
+                        }
+                    }
+
+                    EventId.KEEP_HEAD_LEVEL -> { // Reset to start over.
+                        sectors.value = MutableList(GAZE_CIRCLE_SECTORS) { false }
+                        VisualHintGaze(Modifier, sectorStates = sectors.value)
+                    }
+
+                    EventId.LOOK_STRAIGHT -> {
+                        VisualHintMoveHorizontally(this, Modifier)
+                        VisualHintMoveVertically(this, Modifier)
+                    }
+
+                    else -> {}
+                }
+            }
+        }
+    }
+
+    val instructionAndControlsContent = @Composable {
+        if (isLandscape && currentStep == INITIAL) {
+            // Show the button on the right in Landscape mode (more space for instructions),
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                // Step prompt.
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(4.dp).weight(2f),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                ) {
+                    SelfieCheckInstructions(instructions)
+                }
+
+                Button(
+                    onClick = { viewModel.startSelfieCheck() },
+                    modifier = Modifier.wrapContentWidth().weight(1f)
+                ) {
+                    Text(
+                        if (currentStep == FAILED) {
+                            stringResource(Res.string.selfie_button_try_again)
+                        } else {
+                            stringResource(Res.string.selfie_button_start_check)
+                        }
+                    )
+                }
+            }
+        }
+        else {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = if (isLandscape) Arrangement.Center else Arrangement.Top,
+                modifier = if (isLandscape)
+                    Modifier.fillMaxHeight().padding(start = 16.dp) else Modifier.fillMaxWidth()
+            ) {
+                // Step prompt.
+                Card(
+                    modifier = Modifier.fillMaxWidth().padding(top = 16.dp),
+                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                ) {
+                    SelfieCheckInstructions(instructions)
+                }
+
+                Spacer(modifier = Modifier.height(24.dp))
+
+                when (currentStep) {
+                    INITIAL, FAILED -> {
+                        Button(
+                            onClick = { viewModel.startSelfieCheck() },
+                            modifier = Modifier.align(Alignment.End).wrapContentWidth()
+                        ) {
+                            Text(
+                                if (currentStep == FAILED) {
+                                    stringResource(Res.string.selfie_button_try_again)
+                                } else {
+                                    stringResource(Res.string.selfie_button_start_check)
+                                }
+                            )
+                        }
+                    }
+
+                    IMAGE_TAKEN -> // Ask for image sharing consent.
+                        Column(
+                            horizontalAlignment = Alignment.CenterHorizontally,
+                            verticalArrangement = Arrangement.Center
+                        ) {
+                            val isChecked = remember { mutableStateOf(false) }
+                            Row(verticalAlignment = Alignment.CenterVertically) {
+                                Checkbox(
+                                    checked = isChecked.value,
+                                    onCheckedChange = {
+                                        isChecked.value = it
+
+                                        hapticFeedback.performHapticFeedback(HapticFeedbackType.LongPress)
+                                    }
+                                )
+                                Spacer(Modifier.width(8.dp))
+                                val fullText = stringResource(Res.string.selfie_prompt_consent, identityIssuer)
+                                Text(
+                                    text = buildAnnotatedString {
+                                        val startIndex = fullText.indexOf(identityIssuer)
+                                        val endIndex = startIndex + identityIssuer.length
+                                        append(fullText.substring(0, startIndex))
+                                        withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                                            append(fullText.substring(startIndex, endIndex))
+                                        }
+                                        append(fullText.substring(endIndex))
+                                    }
+                                )
+                            }
+
+                            Button(
+                                onClick = { viewModel.selfieSendConsentReceived() },
+                                modifier = Modifier.wrapContentSize(),
+                                enabled = isChecked.value
+                            ) {
+                                Text(stringResource(Res.string.selfie_button_send))
+                            }
+                        }
+
+                    DONE -> {
+                        Text(
+                            stringResource(Res.string.selfie_prompt_done),
+                            color = MaterialTheme.colorScheme.primary,
+                            style = MaterialTheme.typography.headlineSmall,
+                            textAlign = TextAlign.Center
+                        )
+                    }
+
+                    else -> {
+                        Box(
+                            contentAlignment = Alignment.Center,
+                            modifier = Modifier.size(64.dp)
+                        ) {
+                            CircularProgressIndicator(
+                                progress = { countdownProgress },
+                                modifier = Modifier.fillMaxSize(),
+                                strokeWidth = 6.dp,
+                                color = MaterialTheme.colorScheme.primary,
+                                trackColor = MaterialTheme.colorScheme.surfaceVariant
+                            )
+                            Text(
+                                text = "$countdownSeconds",
+                                style = MaterialTheme.typography.titleLarge.copy(
+                                    fontWeight = FontWeight.Bold,
+                                    fontSize = 20.sp
+                                ),
+                                color = MaterialTheme.colorScheme.onSurface
+                            )
+                        }
+                    }
+                }
+                if (!isLandscape) { // Needed only here to push content up.
+                    Spacer(modifier = Modifier.height(64.dp))
+                }
+            }
+        }
+    }
+
+    val selfieImageContent = @Composable {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth(0.8f)
+                .aspectRatio(1f)
+                .clipToBounds(),
+            contentAlignment = Alignment.Center
+        ) {
+            Image(
+                bitmap = viewModel.internalCapturedFaceImagePreview ?: ImageBitmap(1, 1),
+                contentDescription = null,
+                modifier = Modifier.fillMaxSize()
+            )
+        }
+    }
+
+    if (isLandscape) {
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                //.padding(16.dp)
+                .verticalScroll(rememberScrollState()),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top,
+
+            ) {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+                horizontalArrangement = Arrangement.SpaceEvenly
+            ) {
+                Box(
+                    modifier = Modifier.weight(1f),
+                    contentAlignment = Alignment.Center
+                ) {
+                    if (currentStep == IMAGE_TAKEN) {
+                        selfieImageContent()
+                    } else {
+                        cameraPreviewContent()
+                    }
+                }
+                if (isShowingCameraPreview) {
+                    Spacer(modifier = Modifier.width(16.dp)) // Space between camera and controls.
+                }
+
+                Box(
+                    modifier = if (isShowingCameraPreview) Modifier.weight(1f) else Modifier,
+                    contentAlignment = Alignment.Center // Center the content vertically within this Box.
+                ) {
+                    instructionAndControlsContent()
+                }
+            }
+        }
+    } else { // Portrait layout.
+        Column(
+            modifier = modifier
+                .fillMaxWidth()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp),
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Top
+        ) {
+            if (currentStep == IMAGE_TAKEN) {
+                selfieImageContent()
+            } else {
+                cameraPreviewContent()
+            }
+
+            instructionAndControlsContent()
+        }
+    }
+}
+
+private object Painter {
+    const val NUM_RADIANS_PER_DEGREE = PI / 180.0
+    const val STROKE_WIDTH = 4f
+    const val ARCH_WIDTH = 20f
+    val filledColor = Color.Red
+    val strokeColor = Color.White
+}
+
+@Composable
+fun VisualHintGaze(modifier: Modifier, sectorStates: List<Boolean>) {
+    Canvas(modifier = modifier.fillMaxSize()) {
+        val canvasWidth = size.width
+        val canvasHeight = size.height
+        val center = Offset(canvasWidth / 2, canvasHeight / 2)
+
+        val outerRadius = (kotlin.math.min(canvasWidth, canvasHeight) / 2f) - Painter.STROKE_WIDTH / 2
+        val innerRadius = outerRadius - Painter.ARCH_WIDTH
+
+        if (sectorStates.isEmpty()) return@Canvas
+
+        val totalAngle = 180f // Drawing on the bottom half (0 for top and change sign in the sweepAnglePerSector).
+        val numSectors = 8
+        val sweepAnglePerSector = totalAngle / numSectors
+        var currentStartAngle = 0f
+
+        sectorStates.forEachIndexed { _, isFilled ->
+            if (isFilled) {
+                // Draw filled sector.
+                val sectorPath = Path().apply {
+                    arcTo(
+                        rect = androidx.compose.ui.geometry.Rect(
+                            center.x - innerRadius,
+                            center.y - innerRadius,
+                            center.x + innerRadius,
+                            center.y + innerRadius
+                        ),
+                        startAngleDegrees = currentStartAngle,
+                        sweepAngleDegrees = sweepAnglePerSector,
+                        forceMoveTo = true // Important: starts a new sub-path.
+                    )
+
+                    arcTo(
+                        rect = androidx.compose.ui.geometry.Rect(
+                            center.x - outerRadius,
+                            center.y - outerRadius,
+                            center.x + outerRadius,
+                            center.y + outerRadius
+                        ),
+                        startAngleDegrees = currentStartAngle + sweepAnglePerSector,
+                        sweepAngleDegrees = -sweepAnglePerSector, // Counterclockwise.
+                        forceMoveTo = false
+                    )
+
+                    close()
+                }
+                drawPath(
+                    path = sectorPath,
+                    color = Painter.filledColor,
+                    style = Fill
+                )
+            }
+
+            // Outer arc of the sector.
+            drawArc(
+                color = Painter.strokeColor,
+                startAngle = currentStartAngle,
+                sweepAngle = sweepAnglePerSector,
+                useCenter = false,
+                topLeft = Offset(center.x - outerRadius, center.y - outerRadius),
+                size = Size(outerRadius * 2, outerRadius * 2),
+                style = Stroke(width = Painter.STROKE_WIDTH)
+            )
+            // Inner arc of the sector.
+            drawArc(
+                color = Painter.strokeColor,
+                startAngle = currentStartAngle,
+                sweepAngle = sweepAnglePerSector,
+                useCenter = false,
+                topLeft = Offset(center.x - innerRadius, center.y - innerRadius),
+                size = Size(innerRadius * 2, innerRadius * 2),
+                style = Stroke(width = Painter.STROKE_WIDTH)
+            )
+
+            drawDivider(currentStartAngle, center, outerRadius, innerRadius)
+
+            currentStartAngle += sweepAnglePerSector
+        }
+
+        // End divider.
+        drawDivider(currentStartAngle, center, outerRadius, innerRadius)
+    }
+}
+
+/** Arch sector divider. */
+private fun DrawScope.drawDivider(
+    currentStartAngle: Float,
+    center: Offset,
+    outerRadius: Float,
+    innerRadius: Float
+) {
+    val finalAngleRad = currentStartAngle * Painter.NUM_RADIANS_PER_DEGREE
+    val finalOuter = Offset(
+        center.x + outerRadius * cos(finalAngleRad).toFloat(),
+        center.y + outerRadius * sin(finalAngleRad).toFloat()
+    )
+    val finalInner = Offset(
+        center.x + innerRadius * cos(finalAngleRad).toFloat(),
+        center.y + innerRadius * sin(finalAngleRad).toFloat()
+    )
+    drawLine(Painter.strokeColor, finalInner, finalOuter, Painter.STROKE_WIDTH)
+}
+
+@Composable
+fun VisualHintMoveLeftRight(boxScope: BoxScope, modifier: Modifier.Companion, isLeft: Boolean) {
+    val leftIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowBack
+    val rightIcon: ImageVector = Icons.AutoMirrored.Filled.ArrowForward
+    with(boxScope) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .align(Alignment.Center),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            if (isLeft) {
+                Icon(
+                    imageVector = leftIcon,
+                    contentDescription = "Look Left",
+                    tint = Color.Red,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else {
+                Spacer(modifier = Modifier.size(leftIcon.defaultWidth))
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            if (!isLeft) {
+                Icon(
+                    imageVector = rightIcon,
+                    contentDescription = "Look Right",
+                    tint = Color.Red,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else {
+                Spacer(modifier = Modifier.size(rightIcon.defaultWidth))
+            }
+        }
+    }
+}
+
+@Composable
+fun VisualHintMoveUpDown(boxScope: BoxScope, modifier: Modifier.Companion, isUp: Boolean) {
+    val upIcon: ImageVector = Icons.Filled.ArrowUpward
+    val downIcon: ImageVector = Icons.Filled.ArrowDownward
+    with(boxScope) {
+        Column(
+            modifier = modifier
+                .fillMaxHeight()
+                .align(Alignment.Center),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            if (isUp) {
+                Icon(
+                    imageVector = upIcon,
+                    contentDescription = "Look up",
+                    tint = Color.Red,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else {
+                Spacer(modifier = Modifier.size(upIcon.defaultHeight))
+            }
+
+            Spacer(modifier = Modifier.width(8.dp))
+
+            if (!isUp) {
+                Icon(
+                    imageVector = downIcon,
+                    contentDescription = "Look down",
+                    tint = Color.Red,
+                    modifier = Modifier.padding(16.dp)
+                )
+            } else {
+                Spacer(modifier = Modifier.size(downIcon.defaultHeight))
+            }
+        }
+    }
+}
+
+@Composable
+fun VisualHintMoveVertically(boxScope: BoxScope, modifier: Modifier.Companion) {
+    with(boxScope) {
+        Column(
+            modifier = modifier
+                .fillMaxHeight()
+                .align(Alignment.Center),
+            verticalArrangement = Arrangement.SpaceBetween,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Icon(
+                imageVector = Icons.Filled.ArrowDownward,
+                contentDescription = "Vertical motion indicator",
+                tint = Color.Red,
+                modifier = Modifier.padding(16.dp)
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Icon(
+                imageVector = Icons.Filled.ArrowUpward,
+                contentDescription = "Vertical motion indicator",
+                tint = Color.Red,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+fun VisualHintMoveHorizontally(
+    boxScope: BoxScope,
+    modifier: Modifier = Modifier,
+) {
+    with(boxScope) {
+        Row(
+            modifier = modifier
+                .fillMaxWidth()
+                .align(Alignment.Center),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically
+        ) {
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowForward,
+                contentDescription = "Horizontal motion indicator",
+                tint = Color.Red,
+                modifier = Modifier.padding(16.dp)
+            )
+
+            Spacer(modifier = Modifier.weight(1f))
+
+            Icon(
+                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                contentDescription = "Horizontal motion indicator",
+                tint = Color.Red,
+                modifier = Modifier.padding(16.dp)
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelfieCheckInstructions(stepFeedback: StepFeedback) {
+    when (stepFeedback.eventId) {
+        EventId.INITIAL -> stringResource(Res.string.selfie_instruction_preface, stepFeedback.textParam)
+        EventId.CENTER_FACE -> stringResource(Res.string.selfie_instruction_center_face)
+        EventId.ROTATE_HEAD_LEFT -> stringResource(Res.string.selfie_instruction_rotate_head_left)
+        EventId.ROTATE_HEAD_RIGHT -> stringResource(Res.string.selfie_instruction_rotate_head_right)
+        EventId.ROTATE_HEAD_UP -> stringResource(Res.string.selfie_instruction_rotate_head_up)
+        EventId.ROTATE_HEAD_DOWN -> stringResource(Res.string.selfie_instruction_rotate_head_down)
+        EventId.CIRCULAR_GAZE_START -> stringResource(Res.string.selfie_instruction_circular_gaze_start)
+        EventId.CIRCULAR_GAZE_LEFT ->
+            stringResource(Res.string.selfie_instruction_circular_gaze_remaining, stepFeedback.textParam)
+        EventId.CLOSE_EYES -> stringResource(Res.string.selfie_instruction_close_eyes)
+        EventId.SMILE -> stringResource(Res.string.selfie_instruction_smile)
+        EventId.COMPLETED -> stringResource(Res.string.selfie_instruction_completed)
+        EventId.MOVE_HORIZONTALLY -> stringResource(Res.string.selfie_instruction_move_horizontally)
+        EventId.MOVE_VERTICALLY -> stringResource(Res.string.selfie_instruction_move_vertically)
+        EventId.KEEP_HEAD_LEVEL -> stringResource(Res.string.selfie_instruction_keep_head_level)
+        EventId.KEEP_LOOKING -> stringResource(Res.string.selfie_instruction_keep_looking, stepFeedback.textParam)
+        EventId.LOOK_AROUND -> stringResource(Res.string.selfie_instruction_look_around)
+        EventId.CLOSE_FIRMLY -> stringResource(Res.string.selfie_instruction_close_firmly)
+        EventId.CLEAR_SMILE -> stringResource(Res.string.selfie_instruction_clear_smile)
+        EventId.FAILED_TIMEOUT -> stringResource(Res.string.selfie_instruction_failed_timeout, stepFeedback.textParam)
+        EventId.LOOK_STRAIGHT -> stringResource(Res.string.selfie_instruction_look_straight)
+        EventId.SECTOR_HIT -> stringResource(Res.string.selfie_instruction_keep_looking)
+        EventId.IMAGE_TAKEN -> stringResource(Res.string.selfie_instruction_completed)
+        EventId.DONE -> null // No card, or stringResource(Res.string.selfie_instruction_selfie_sent) to show some.
+    }?.let {
+        if (stepFeedback.eventId == EventId.INITIAL) {
+            val fullText = stringResource(Res.string.selfie_instruction_preface, stepFeedback.textParam)
+            Text(
+                text = buildAnnotatedString {
+                    val startIndex = fullText.indexOf(stepFeedback.textParam)
+                    val endIndex = startIndex + stepFeedback.textParam.length
+                    append(fullText.substring(0, startIndex))
+                    withStyle(style = SpanStyle(fontWeight = FontWeight.Bold)) {
+                        append(fullText.substring(startIndex, endIndex))
+                    }
+                    append(fullText.substring(endIndex))
+                },
+                textAlign = TextAlign.Start,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+            )
+        } else {
+            Text(
+                text = it,
+                modifier = Modifier
+                    .padding(16.dp)
+                    .fillMaxWidth(),
+                textAlign = TextAlign.Center,
+                style = MaterialTheme.typography.titleMedium,
+                minLines = 2
+            )
+        }
+    }
+}

--- a/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/SelfieCheckStep.kt
+++ b/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/SelfieCheckStep.kt
@@ -1,0 +1,49 @@
+package org.multipaz.selfiecheck
+
+
+/**
+ * Distinct Selfie Check process steps used to verify the photo identity along with the feedback,
+ * as needed to schedule randomized and fixed selfie verification steps, and to signal updates of the UI content.
+ * Some of the instructions are deliberately randomized some fixed for the beginning and the end of the verification
+ * flow.
+ */
+enum class SelfieCheckStep {
+    /** Initial phase after the model initialization and reset. */
+    INITIAL,
+
+    /** User expected to center their face in the provided frame. */
+    CENTER_FACE,
+
+    /** Directional head rotation commands confirmation expected. Randomized. */
+    ROTATE_HEAD_LEFT,
+    ROTATE_HEAD_RIGHT,
+    ROTATE_HEAD_UP,
+    ROTATE_HEAD_DOWN,
+
+    /**
+     * User expected to look left and right, gradually passing several expected face directions without leaving the
+     * vertical limits for the fce orientation.
+     */
+    CIRCULAR_GAZE,
+
+    /** User expected to close both eyes for a period of time. */
+    CLOSE_EYES,
+
+    /** User expected to clearly smile into camera. */
+    SMILE,
+
+    /** General failure of one of the steps (given instructions not confirmed within allocated time). */
+    FAILED,
+
+    /** Final step of the selfie check process. Also helping */
+    LOOK_STRAIGHT, // Final image taking step.,
+
+    /** All verification steps completed successfully. */
+    COMPLETED,
+
+    /** Signals that the final image is taken and ready for requesting the user consent to share it with the issuer. */
+    IMAGE_TAKEN,
+
+    /** Signals the completion of the entire process. */
+    DONE
+}

--- a/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/SelfieCheckViewModel.kt
+++ b/multipaz-mlkit/src/commonMain/kotlin/org/multipaz/selfiecheck/SelfieCheckViewModel.kt
@@ -1,0 +1,600 @@
+package org.multipaz.selfiecheck
+
+import androidx.compose.ui.geometry.Rect
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ImageBitmap
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharedFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.isActive
+import kotlinx.coroutines.launch
+import kotlinx.io.bytestring.ByteString
+import org.multipaz.compose.camera.CameraFrame
+import org.multipaz.compose.cropRotateScaleImage
+import org.multipaz.compose.encodeImageToPng
+import org.multipaz.facedetection.DetectedFace
+import org.multipaz.facedetection.FaceLandmarkType
+import org.multipaz.util.Logger
+import kotlin.math.PI
+import kotlin.math.atan2
+import kotlin.math.sqrt
+import kotlin.random.Random
+
+const val TAG = "SelfieCheck"
+
+private const val FACE_CENTER_TOLERANCE = 0.1f
+private const val HEAD_ROTATION_ANGLE_THRESHOLD = 20.0f
+private const val HEAD_STRAIGHT_ANGLE_THRESHOLD = 5.0f
+private const val EYE_OPEN_THRESHOLD = 0.3f
+private const val EYE_CLOSED_THRESHOLD = 0.2f // 0.1 is better for false positives, but harder detected in low light.
+private const val EYES_CLOSED_DURATION = 30 // Low pass filter (counter in frames 1-1.5 sec with some false negatives).
+private const val SMILING_THRESHOLD = 0.7f
+private const val STEP_TIMEOUT_SECONDS = 10
+private const val ONE_SECOND_MS = 1000L
+private const val GAZE_PITCH_TOLERANCE = 25f // Max degrees up/down allowed while still considered "looking around".
+private const val GAZE_YAW_MAX = 35f // Max degrees left or right from center.
+private const val GAZE_MIN_CONSECUTIVE_HITS_IN_SECTOR = 2 // Debouncing.
+internal const val GAZE_CIRCLE_SECTORS = 8 // How many distinct directions for looking around.
+internal const val ENOUGH_TIME_PASSED = 1 // Seconds to wait before accepting step result (apparent step bypass UX fix).
+
+/**
+ * View model for the selfie check process initialization, orchestration, and data exchange with UI.
+ *
+ * @param identityIssuer The name or identification of the photo identity issuer receiving the result of the
+ *     person image verification.
+ * @param externalScope optional coroutine scope to be used by the view model async routines.
+ */
+class SelfieCheckViewModel(
+    private val identityIssuer: String,
+    externalScope: CoroutineScope? = null,
+) {
+    /** Public access to the latest captured frame. */
+    var capturedFaceImage: ByteString? = null
+    internal var internalCapturedFaceImagePreview: ImageBitmap? = null
+
+    private val viewModelScope = externalScope ?: CoroutineScope(Dispatchers.Default + SupervisorJob())
+    private var stepTimeoutJob: Job? = null
+
+    private val allVerifiableSteps = listOf(
+        // Define all steps that can be shuffled
+        SelfieCheckStep.ROTATE_HEAD_LEFT,
+        SelfieCheckStep.ROTATE_HEAD_RIGHT,
+        SelfieCheckStep.ROTATE_HEAD_UP,
+        SelfieCheckStep.ROTATE_HEAD_DOWN,
+        SelfieCheckStep.CIRCULAR_GAZE,
+        SelfieCheckStep.CLOSE_EYES,
+        SelfieCheckStep.SMILE,
+    )
+
+    private var shuffledStepsQueue = mutableListOf<SelfieCheckStep>()
+    private var currentRandomStepIndex = -1
+    private var currentRotationTargetDirection: HeadRotationDirection? = null
+    private var eyesClosedCounter = 0
+    private val gazeSectorsHit = mutableSetOf<Int>()
+    private var lastGazeSector = -1
+    private var consecutiveGazeSectorHits = 0
+    private var allSectorsCovered = false
+    private var isEnoughTimePassed = false
+
+    private val stepSuccessEventFlow = MutableSharedFlow<Unit>(
+        extraBufferCapacity = 1,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST
+    )
+    val stepSuccessEvent: SharedFlow<Unit> = stepSuccessEventFlow.asSharedFlow()
+
+    private val currentStepFlow = MutableStateFlow(SelfieCheckStep.INITIAL)
+    val currentStep: StateFlow<SelfieCheckStep> = currentStepFlow.asStateFlow()
+
+    private val stepFeedback = MutableStateFlow(StepFeedback(EventId.INITIAL, identityIssuer))
+    internal val instructions: StateFlow<StepFeedback> = stepFeedback.asStateFlow()
+
+    private val countdownSecondsFlow = MutableStateFlow(STEP_TIMEOUT_SECONDS)
+    val countdownSeconds: StateFlow<Int> = countdownSecondsFlow.asStateFlow()
+
+    private val countdownProgressFlow = MutableStateFlow(1.0f)
+    val countdownProgress: StateFlow<Float> = countdownProgressFlow.asStateFlow()
+
+    private val isLandscapeFlow = MutableStateFlow(false)
+    val isLandscape: StateFlow<Boolean> = isLandscapeFlow.asStateFlow()
+
+    init {
+        prepareShuffledSteps()
+    }
+
+    private fun prepareShuffledSteps() {
+        shuffledStepsQueue.clear()
+        shuffledStepsQueue.addAll(allVerifiableSteps.shuffled(Random))
+        currentRandomStepIndex = -1 // Reset index
+    }
+
+    /**
+     * Resets the ViewModel to its initial state and prepares for a new selfie check process.
+     * This is the public function to be called to restart the selfie check.
+     */
+    fun resetForNewCheck() {
+        cancelStepTimeout()
+        resetSpecificStepStates()
+        prepareShuffledSteps()
+        currentStepFlow.value = SelfieCheckStep.INITIAL
+        generateFeedbackEvent()
+    }
+
+    internal fun startSelfieCheck() {
+        if (currentStepFlow.value != SelfieCheckStep.INITIAL) {
+            resetForNewCheck()
+        }
+        // Always start with centering as some other steps depends on it.
+        currentStepFlow.value = SelfieCheckStep.CENTER_FACE
+        generateFeedbackEvent()
+        startStepTimeout()
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun resetSpecificStepStates() {
+        currentRotationTargetDirection = null
+
+        eyesClosedCounter = 0
+
+        resetGazeProcessor()
+
+        countdownSecondsFlow.value = STEP_TIMEOUT_SECONDS
+        countdownProgressFlow.value = 1.0f
+        isLandscapeFlow.value = false
+        stepSuccessEventFlow.resetReplayCache()
+        internalCapturedFaceImagePreview = null
+        capturedFaceImage = null
+    }
+
+    /** Signal the orientation value change from the UI (Composable scope). */
+    internal fun setLandscape(isLandscape: Boolean) {
+        isLandscapeFlow.value = isLandscape
+    }
+
+    /**
+     * Update model on new frame with detected face data and frame size to feed current check processor.
+     */
+    internal fun onFaceDataUpdated(faceData: DetectedFace, frameData: CameraFrame) {
+        if (currentStepFlow.value == SelfieCheckStep.FAILED || currentStepFlow.value == SelfieCheckStep.INITIAL) {
+            return
+        }
+
+        val previewSize = Size(frameData.width.toFloat(), frameData.height.toFloat())
+
+        when (currentStepFlow.value) {
+            SelfieCheckStep.CENTER_FACE -> processFaceCentering(faceData.boundingBox, previewSize)
+            SelfieCheckStep.ROTATE_HEAD_LEFT,
+            SelfieCheckStep.ROTATE_HEAD_RIGHT,
+            SelfieCheckStep.ROTATE_HEAD_UP,
+            SelfieCheckStep.ROTATE_HEAD_DOWN -> {
+                val targetDirection = when (currentStepFlow.value) {
+                    SelfieCheckStep.ROTATE_HEAD_LEFT -> HeadRotationDirection.LEFT
+                    SelfieCheckStep.ROTATE_HEAD_RIGHT -> HeadRotationDirection.RIGHT
+                    SelfieCheckStep.ROTATE_HEAD_UP -> HeadRotationDirection.UP
+                    SelfieCheckStep.ROTATE_HEAD_DOWN -> HeadRotationDirection.DOWN
+                    else -> null // Should not happen.
+                }
+                processHeadRotation(
+                    targetDirection = targetDirection,
+                    headEulerAngleX = faceData.headEulerAngleX,
+                    headEulerAngleY = faceData.headEulerAngleY
+                )
+            }
+
+            SelfieCheckStep.CIRCULAR_GAZE -> {
+                processGazeCircularMotion(
+                    headEulerAngleY = faceData.headEulerAngleY,
+                    headEulerAngleX = faceData.headEulerAngleX
+                )
+            }
+
+            SelfieCheckStep.CLOSE_EYES -> processEyeClosure(
+                faceData.leftEyeOpenProbability,
+                faceData.rightEyeOpenProbability
+            )
+
+            SelfieCheckStep.SMILE -> processSmile(faceData.smilingProbability)
+
+            SelfieCheckStep.LOOK_STRAIGHT -> processLookStraight(faceData, previewSize)
+
+            SelfieCheckStep.COMPLETED -> saveFaceImagePreview(faceData, frameData)
+
+            else -> { /* INITIAL, FAILED - no processing. */
+            }
+        }
+    }
+
+    private fun startStepTimeout() {
+        cancelStepTimeout()
+        val currentStepVal = currentStepFlow.value
+        val timeoutDuration = if (currentStepVal == SelfieCheckStep.CIRCULAR_GAZE) {
+            STEP_TIMEOUT_SECONDS * 2 // As it might take longer to complete compared to others.
+        } else {
+            STEP_TIMEOUT_SECONDS
+        }
+        countdownSecondsFlow.value = timeoutDuration
+        countdownProgressFlow.value = 1.0f
+
+        if (currentStepVal == SelfieCheckStep.INITIAL || currentStepVal == SelfieCheckStep.COMPLETED
+            || currentStepVal == SelfieCheckStep.FAILED || currentStepVal == SelfieCheckStep.DONE
+            || currentStepVal == SelfieCheckStep.IMAGE_TAKEN
+        ) {
+            return
+        }
+
+        stepTimeoutJob = viewModelScope.launch {
+            for (i in timeoutDuration downTo 0) {
+                if (!isActive) break
+                if (i > ENOUGH_TIME_PASSED) isEnoughTimePassed = true
+                countdownSecondsFlow.value = i
+                countdownProgressFlow.value = i.toFloat() / timeoutDuration.toFloat()
+                if (i == 0) {
+                    if (currentStepFlow.value != SelfieCheckStep.COMPLETED
+                        && currentStepFlow.value != SelfieCheckStep.FAILED
+                    ) {
+                        failCheck(StepFeedback(EventId.FAILED_TIMEOUT, currentStepFlow.value.toString()))
+                    }
+                    break
+                }
+                delay(ONE_SECOND_MS)
+            }
+        }
+    }
+
+    private fun cancelStepTimeout() {
+        stepTimeoutJob?.cancel()
+        stepTimeoutJob = null
+        isEnoughTimePassed = false
+    }
+
+    private fun failCheck(reason: StepFeedback) {
+        cancelStepTimeout()
+        resetGazeProcessor()
+        currentStepFlow.value = SelfieCheckStep.FAILED
+        stepFeedback.value = reason
+        countdownSecondsFlow.value = 0
+        countdownProgressFlow.value = 0.0f
+    }
+
+    private fun processLookStraight(face: DetectedFace?, previewSize: Size?) {
+        if ((face == null || previewSize == null) || previewSize.width < 1 || previewSize.height < 1) {
+            Logger.e(TAG, "Bad data from face detector.")
+            return
+        }
+
+        val faceBounds = face.boundingBox
+        val faceCenterXpx = faceBounds.left + faceBounds.width / 2f
+        val faceCenterYpx = faceBounds.top + faceBounds.height / 2f
+
+        // Normalized face center check.
+        val normalizedFaceCenterX = faceCenterXpx / previewSize.width
+        val normalizedFaceCenterY = faceCenterYpx / previewSize.height
+        val isHorizontallyCentered = kotlin.math.abs(normalizedFaceCenterX - 0.5f) < FACE_CENTER_TOLERANCE
+        val isVerticallyCentered = kotlin.math.abs(normalizedFaceCenterY - 0.5f) < FACE_CENTER_TOLERANCE
+        val isFaceStraight = kotlin.math.abs(face.headEulerAngleX) < HEAD_STRAIGHT_ANGLE_THRESHOLD &&
+                kotlin.math.abs(face.headEulerAngleY) < HEAD_STRAIGHT_ANGLE_THRESHOLD &&
+                kotlin.math.abs(face.headEulerAngleZ) < HEAD_STRAIGHT_ANGLE_THRESHOLD
+        val isEyesOpen = face.leftEyeOpenProbability > EYE_OPEN_THRESHOLD &&
+                face.rightEyeOpenProbability > EYE_OPEN_THRESHOLD
+
+        if (!isHorizontallyCentered || !isVerticallyCentered || !isFaceStraight || !isEyesOpen || !isEnoughTimePassed) {
+            stepFeedback.value = StepFeedback(EventId.LOOK_STRAIGHT)
+        } else {
+            proceedToNextStep()
+        }
+    }
+
+    private fun processFaceCentering(faceBounds: Rect?, previewSize: Size?) {
+        if ((faceBounds == null || previewSize == null) || previewSize.width < 1 || previewSize.height < 1) {
+            Logger.e(TAG, "Bad data from face detector.")
+            return
+        }
+
+        val faceCenterXpx = faceBounds.left + faceBounds.width / 2f
+        val faceCenterYpx = faceBounds.top + faceBounds.height / 2f
+
+        // Normalized face center check.
+        val normalizedFaceCenterX = faceCenterXpx / previewSize.width
+        val normalizedFaceCenterY = faceCenterYpx / previewSize.height
+        val isHorizontallyCentered = kotlin.math.abs(normalizedFaceCenterX - 0.5f) < FACE_CENTER_TOLERANCE
+        val isVerticallyCentered = kotlin.math.abs(normalizedFaceCenterY - 0.5f) < FACE_CENTER_TOLERANCE
+
+        if (isHorizontallyCentered && isVerticallyCentered && isEnoughTimePassed) {
+            proceedToNextStep()
+        } else {
+            // Apparently swapped directions due to the constant 90 deg camera frame angle with the screen.
+            val isFaceCenteredY = kotlin.math.abs(normalizedFaceCenterY - 0.5f) < FACE_CENTER_TOLERANCE
+            stepFeedback.value = StepFeedback(
+                if (isLandscape.value) {
+                    if (isFaceCenteredY) EventId.MOVE_HORIZONTALLY else EventId.MOVE_VERTICALLY
+                } else {
+                    if (isFaceCenteredY) EventId.MOVE_VERTICALLY else EventId.MOVE_HORIZONTALLY
+                }
+            )
+        }
+    }
+
+    private fun processHeadRotation(
+        targetDirection: HeadRotationDirection?,
+        headEulerAngleX: Float?,
+        headEulerAngleY: Float?
+    ) {
+        if (targetDirection == null || headEulerAngleX == null || headEulerAngleY == null) return
+
+        val achieved = when (targetDirection) {
+            HeadRotationDirection.LEFT -> headEulerAngleY > HEAD_ROTATION_ANGLE_THRESHOLD
+            HeadRotationDirection.RIGHT -> headEulerAngleY < -HEAD_ROTATION_ANGLE_THRESHOLD
+            HeadRotationDirection.UP -> headEulerAngleX > HEAD_ROTATION_ANGLE_THRESHOLD
+            HeadRotationDirection.DOWN -> headEulerAngleX < -HEAD_ROTATION_ANGLE_THRESHOLD
+        }
+
+        if (achieved) {
+            proceedToNextStep()
+        }
+    }
+
+    private fun processGazeCircularMotion(
+        headEulerAngleY: Float, // Yaw.
+        headEulerAngleX: Float  // Pitch.
+    ) {
+        if (kotlin.math.abs(headEulerAngleX) > GAZE_PITCH_TOLERANCE) {
+            stepFeedback.value = StepFeedback(EventId.KEEP_HEAD_LEVEL)
+            resetGazeProcessor()
+            return
+        }
+
+        val effectiveYaw = headEulerAngleY.coerceIn(-GAZE_YAW_MAX, GAZE_YAW_MAX)
+        val mappedYaw = effectiveYaw + GAZE_YAW_MAX
+
+        // Calculate current sector.
+        val sectorAngleSize = 2 * GAZE_YAW_MAX / GAZE_CIRCLE_SECTORS
+        val currentSector = (mappedYaw / sectorAngleSize).toInt().coerceIn(0, GAZE_CIRCLE_SECTORS - 1)
+        if (currentSector != lastGazeSector) {
+            consecutiveGazeSectorHits++
+            if (consecutiveGazeSectorHits >= GAZE_MIN_CONSECUTIVE_HITS_IN_SECTOR) {
+                // Confirmed entry into currentCalculatedSector (not a noise).
+                if (gazeSectorsHit.add(currentSector)) {
+                    stepFeedback.value = StepFeedback(EventId.SECTOR_HIT, currentSector.toString())
+                }
+                lastGazeSector = currentSector
+                consecutiveGazeSectorHits = 0
+            }
+        } else {
+            consecutiveGazeSectorHits = 0
+        }
+
+        if (gazeSectorsHit.size >= GAZE_CIRCLE_SECTORS) {
+            if (allSectorsCovered) {
+                proceedToNextStep()
+            } else {
+                allSectorsCovered = true
+                stepFeedback.value = StepFeedback(EventId.SECTOR_HIT, currentSector.toString())
+            }
+        }
+    }
+
+    private fun resetGazeProcessor() {
+        gazeSectorsHit.clear()
+        lastGazeSector = -1
+        consecutiveGazeSectorHits = 0
+        allSectorsCovered = false
+    }
+
+    private fun processEyeClosure(leftEyeOpenProbability: Float?, rightEyeOpenProbability: Float?) {
+        if (leftEyeOpenProbability != null && rightEyeOpenProbability != null &&
+            leftEyeOpenProbability < EYE_CLOSED_THRESHOLD &&
+            rightEyeOpenProbability < EYE_CLOSED_THRESHOLD &&
+            eyesClosedCounter > EYES_CLOSED_DURATION
+        ) {
+            proceedToNextStep()
+        } else {
+            stepFeedback.value = StepFeedback(EventId.CLOSE_FIRMLY)
+            eyesClosedCounter++
+        }
+    }
+
+    private fun processSmile(smilingProbability: Float?) {
+        if (smilingProbability != null && smilingProbability > SMILING_THRESHOLD) {
+            proceedToNextStep()
+        } else {
+            stepFeedback.value = StepFeedback(EventId.CLEAR_SMILE)
+        }
+    }
+
+    private fun proceedToNextStep() {
+        cancelStepTimeout()
+        val previousStep = currentStepFlow.value
+
+        if (previousStep == SelfieCheckStep.CIRCULAR_GAZE && gazeSectorsHit.size < GAZE_CIRCLE_SECTORS) {
+            resetGazeProcessor()
+        }
+
+        val advancedSuccessfully: Boolean
+
+        if (previousStep == SelfieCheckStep.CENTER_FACE) {
+            currentRandomStepIndex = 0
+            if (shuffledStepsQueue.isNotEmpty()) {
+                currentStepFlow.value = shuffledStepsQueue[currentRandomStepIndex]
+                advancedSuccessfully = true
+            } else {
+                currentStepFlow.value = SelfieCheckStep.LOOK_STRAIGHT
+                advancedSuccessfully = true
+            }
+        } else if (previousStep == SelfieCheckStep.LOOK_STRAIGHT) {
+            currentStepFlow.value = SelfieCheckStep.COMPLETED
+            advancedSuccessfully = true
+        } else if (previousStep == SelfieCheckStep.COMPLETED) {
+            currentStepFlow.value = SelfieCheckStep.IMAGE_TAKEN
+            advancedSuccessfully = true
+        } else {
+            currentRandomStepIndex++
+            if (currentRandomStepIndex < shuffledStepsQueue.size) {
+                currentStepFlow.value = shuffledStepsQueue[currentRandomStepIndex]
+                advancedSuccessfully = true
+            } else {
+                currentStepFlow.value = SelfieCheckStep.LOOK_STRAIGHT
+                advancedSuccessfully = true
+            }
+        }
+
+        // Signal step success for UI feedback.
+        if (advancedSuccessfully && currentStepFlow.value != SelfieCheckStep.INITIAL) {
+            stepSuccessEventFlow.tryEmit(Unit)
+        }
+
+        generateFeedbackEvent()
+
+        if (currentStepFlow.value == SelfieCheckStep.COMPLETED) {
+            countdownSecondsFlow.value = STEP_TIMEOUT_SECONDS
+            countdownProgressFlow.value = 1.0f
+        } else if (currentStepFlow.value != SelfieCheckStep.FAILED) {
+            // Circular motion needs a more specialized reset.
+            if (currentStepFlow.value == SelfieCheckStep.CIRCULAR_GAZE) {
+                resetGazeProcessor()
+            }
+            startStepTimeout()
+        }
+    }
+
+    private fun generateFeedbackEvent() {
+        stepFeedback.value = when (currentStepFlow.value) {
+            SelfieCheckStep.INITIAL -> StepFeedback(EventId.INITIAL)
+            SelfieCheckStep.CENTER_FACE -> StepFeedback(EventId.CENTER_FACE)
+            SelfieCheckStep.ROTATE_HEAD_LEFT -> StepFeedback(EventId.ROTATE_HEAD_LEFT)
+            SelfieCheckStep.ROTATE_HEAD_RIGHT -> StepFeedback(EventId.ROTATE_HEAD_RIGHT)
+            SelfieCheckStep.ROTATE_HEAD_UP -> StepFeedback(EventId.ROTATE_HEAD_UP)
+            SelfieCheckStep.ROTATE_HEAD_DOWN -> StepFeedback(EventId.ROTATE_HEAD_DOWN)
+            SelfieCheckStep.CIRCULAR_GAZE -> {
+                val remaining = GAZE_CIRCLE_SECTORS - gazeSectorsHit.size
+                if (gazeSectorsHit.isEmpty()) {
+                    StepFeedback(EventId.CIRCULAR_GAZE_START)
+                } else {
+                    StepFeedback(EventId.CIRCULAR_GAZE_LEFT, remaining.toString())
+                }
+            }
+
+            SelfieCheckStep.CLOSE_EYES -> StepFeedback(EventId.CLOSE_EYES)
+            SelfieCheckStep.SMILE -> StepFeedback(EventId.SMILE)
+            SelfieCheckStep.LOOK_STRAIGHT -> StepFeedback(EventId.LOOK_STRAIGHT)
+            SelfieCheckStep.COMPLETED -> StepFeedback(EventId.COMPLETED)
+            SelfieCheckStep.IMAGE_TAKEN -> StepFeedback(EventId.IMAGE_TAKEN)
+            SelfieCheckStep.DONE -> StepFeedback(EventId.DONE)
+            SelfieCheckStep.FAILED -> stepFeedback.value // Propagate any error message as is.
+        }
+    }
+
+    /** Store the image as a PNG file format ByteString within the model. */
+    internal fun selfieSendConsentReceived() {
+        internalCapturedFaceImagePreview?.let { capturedFaceImage = encodeImageToPng(it) }
+        currentStepFlow.value = SelfieCheckStep.DONE
+        generateFeedbackEvent()
+        internalCapturedFaceImagePreview = null
+    }
+
+    private fun saveFaceImagePreview(faceData: DetectedFace, frameData: CameraFrame) {
+        val faceImage = extractFaceBitmap(frameData, listOf(faceData))
+        internalCapturedFaceImagePreview = faceImage
+        proceedToNextStep()
+    }
+
+    /** Cut out the face square, rotate it to level eyes line, scale to the smaller size for face matching tasks. */
+    private fun extractFaceBitmap(
+        frameData: CameraFrame,
+        faces: List<DetectedFace>?,
+    ): ImageBitmap {
+        if (faces.isNullOrEmpty()) {
+            Logger.w(TAG, "No face data for bitmap extraction.")
+            return frameData.cameraImage.toImageBitmap()
+        }
+
+        val mouthPosition = faces[0].landmarks.find { it.type == FaceLandmarkType.MOUTH_BOTTOM }
+        val leftEye = faces[0].landmarks.find { it.type == FaceLandmarkType.LEFT_EYE }
+        val rightEye = faces[0].landmarks.find { it.type == FaceLandmarkType.RIGHT_EYE }
+
+        if (leftEye == null || rightEye == null || mouthPosition == null) {
+            Logger.w(TAG, "No face features for bitmap extraction.")
+            return frameData.cameraImage.toImageBitmap()
+        }
+
+        // Heuristic multiplier to fit the face normalized to the eyes pupilar distance.
+        val faceCropFactor = 4f
+
+        // Heuristic multiplier to offset vertically so the face is better centered within the rectangular crop.
+        val faceVerticalOffsetFactor = 0.25f
+
+        var faceCenterX = (leftEye.position.x + rightEye.position.x) / 2
+        var faceCenterY = (leftEye.position.y + rightEye.position.y) / 2
+        val eyeOffsetX = leftEye.position.x - rightEye.position.x
+        val eyeOffsetY = leftEye.position.y - rightEye.position.y
+        val eyeDistance = sqrt(eyeOffsetX * eyeOffsetX + eyeOffsetY * eyeOffsetY)
+        val faceWidth = eyeDistance * faceCropFactor
+        val faceVerticalOffset = eyeDistance * faceVerticalOffsetFactor
+        if (frameData.isLandscape) {
+            /** Required for iOS capable of upside-down face detection. */
+            faceCenterY += faceVerticalOffset * (if (leftEye.position.y < mouthPosition.position.y) 1 else -1)
+
+        } else {
+            /** Required for iOS capable of upside-down face detection. */
+            faceCenterX -= faceVerticalOffset * (if (leftEye.position.x < mouthPosition.position.x) -1 else 1)
+        }
+        val eyesAngleRad = atan2(eyeOffsetY, eyeOffsetX)
+        val eyesAngleDeg = eyesAngleRad * 180.0 / PI
+        val totalRotationDegrees = 180 - eyesAngleDeg
+
+        // Call platform dependent bitmap transformation.
+        return cropRotateScaleImage(
+            frameData = frameData, // Platform-specific image data.
+            cx = faceCenterX.toDouble(), // Point between eyes.
+            cy = faceCenterY.toDouble(), // Point between eyes.
+            angleDegrees = totalRotationDegrees, // Includes the camera rotation and eyes rotation.
+            outputWidthPx = faceWidth.toInt(),  // Expected face width for cropping *before* final scaling.
+            outputHeightPx = faceWidth.toInt(), // Expected face height for cropping *before* final scaling.
+            targetWidthPx = 256 // Final square image size (for database saving and face matching tasks).
+        )
+    }
+
+    /** Selfie-check unique flow event IDs. */
+    internal enum class EventId {
+        INITIAL,
+        CENTER_FACE,
+        ROTATE_HEAD_LEFT,
+        ROTATE_HEAD_RIGHT,
+        ROTATE_HEAD_UP,
+        ROTATE_HEAD_DOWN,
+        CIRCULAR_GAZE_START,
+        CIRCULAR_GAZE_LEFT,
+        CLOSE_EYES,
+        SMILE,
+        MOVE_HORIZONTALLY,
+        MOVE_VERTICALLY,
+        KEEP_HEAD_LEVEL,
+        KEEP_LOOKING,
+        LOOK_AROUND,
+        CLOSE_FIRMLY,
+        CLEAR_SMILE,
+        FAILED_TIMEOUT,
+        SECTOR_HIT,
+        LOOK_STRAIGHT,
+        COMPLETED,
+        IMAGE_TAKEN,
+        DONE,
+    }
+
+    /**
+     * Selfie-check flow feedback object used for the UI to display instructions (text, graphic, etc).
+     *
+     * @param eventId Flow instructions Id. Currently used to display text in the UI.
+     * @param textParam String value to display within the formatted string if any.
+     */
+    internal data class StepFeedback(val eventId: EventId, val textParam: String = "")
+
+}

--- a/multipaz-mlkit/src/iosMain/kotlin/org/multipaz/facedetection/FaceDetector.ios.kt
+++ b/multipaz-mlkit/src/iosMain/kotlin/org/multipaz/facedetection/FaceDetector.ios.kt
@@ -11,6 +11,7 @@ import cocoapods.GoogleMLKit.MLKFaceDetectorClassificationModeAll
 import cocoapods.GoogleMLKit.MLKFaceDetectorContourModeAll
 import cocoapods.GoogleMLKit.MLKFaceDetectorLandmarkModeAll
 import cocoapods.GoogleMLKit.MLKFaceDetectorOptions
+import cocoapods.GoogleMLKit.MLKFaceDetectorPerformanceModeAccurate
 import cocoapods.GoogleMLKit.MLKFaceDetectorPerformanceModeFast
 import cocoapods.GoogleMLKit.MLKFaceLandmark
 import cocoapods.MLKitVision.MLKVisionImage
@@ -20,6 +21,7 @@ import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.refTo
 import kotlinx.cinterop.useContents
 import org.multipaz.compose.camera.CameraFrame
+import org.multipaz.compose.toUIImage
 import org.multipaz.util.Logger
 import platform.CoreGraphics.CGBitmapContextCreate
 import platform.CoreGraphics.CGBitmapContextCreateImage
@@ -51,9 +53,10 @@ actual fun detectFaces(image: ImageBitmap): List<DetectedFace>? {
 @OptIn(ExperimentalForeignApi::class)
 private val faceDetectorOptions = MLKFaceDetectorOptions().apply {
     classificationMode = MLKFaceDetectorClassificationModeAll
-    performanceMode = MLKFaceDetectorPerformanceModeFast
+    performanceMode = MLKFaceDetectorPerformanceModeAccurate
     landmarkMode = MLKFaceDetectorLandmarkModeAll
     contourMode = MLKFaceDetectorContourModeAll
+    minFaceSize = 0.20
 }
 
 @OptIn(ExperimentalForeignApi::class)
@@ -150,29 +153,6 @@ private fun MLKFace.toMultiplatformFace(): DetectedFace {
             contours = (contours as List<MLKFaceContour>).toMFaceContourList()
         )
     }
-}
-
-@OptIn(ExperimentalForeignApi::class)
-private fun ImageBitmap.toUIImage(): UIImage? {
-    val width = this.width
-    val height = this.height
-    val buffer = IntArray(width * height)
-
-    this.readPixels(buffer)
-
-    val colorSpace = CGColorSpaceCreateDeviceRGB()
-    val context = CGBitmapContextCreate(
-        data = buffer.refTo(0),
-        width = width.toULong(),
-        height = height.toULong(),
-        bitsPerComponent = 8u,
-        bytesPerRow = (4 * width).toULong(),
-        space = colorSpace,
-        bitmapInfo = CGImageAlphaInfo.kCGImageAlphaPremultipliedLast.value
-    )
-
-    val cgImage = CGBitmapContextCreateImage(context)
-    return cgImage?.let { UIImage.imageWithCGImage(it) }
 }
 
 private fun calculateMLKitImageOrientation(frameData: CameraFrame): UIImageOrientation {

--- a/samples/testapp/src/commonMain/composeResources/values/strings.xml
+++ b/samples/testapp/src/commonMain/composeResources/values/strings.xml
@@ -30,5 +30,8 @@
     <string name="camera_title">Camera</string>
     <string name="face_detection_title">Face Detection</string>
     <string name="barcode_scanning_title">Barcode Scanning</string>
+    <string name="selfie_check_title">Selfie Check</string>
+    <string name="selfie_check_subtitle">Selfie Verification for Utopia Department of Motor Vehicles</string>
+    <string name="selfie_check_dialog_title">Selfie Verification</string>
 
 </resources>

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -40,6 +40,7 @@ import org.multipaz.testapp.ui.AppTheme
 import org.multipaz.testapp.ui.BarcodeScanningScreen
 import org.multipaz.testapp.ui.CameraScreen
 import org.multipaz.testapp.ui.FaceDetectionScreen
+import org.multipaz.testapp.ui.SelfieCheckScreen
 import org.multipaz.models.digitalcredentials.DigitalCredentials
 import org.multipaz.models.presentment.PresentmentModel
 import org.multipaz.asn1.ASN1Integer
@@ -670,7 +671,8 @@ class App private constructor (val promptModel: PromptModel) {
                             onClickScreenLock = { navController.navigate(ScreenLockDestination.route) },
                             onClickCamera = { navController.navigate(CameraDestination.route) },
                             onClickFaceDetection = { navController.navigate(FaceDetectionDestination.route) },
-                            onClickBarcodeScanning = { navController.navigate(BarcodeScanningDestination.route) }
+                            onClickBarcodeScanning = { navController.navigate(BarcodeScanningDestination.route) },
+                            onClickSelfieCheck = { navController.navigate(SelfieCheckScreenDestination.route) }
                         )
                     }
                     composable(route = SettingsDestination.route) {
@@ -902,6 +904,11 @@ class App private constructor (val promptModel: PromptModel) {
                     }
                     composable(route = BarcodeScanningDestination.route) {
                         BarcodeScanningScreen(
+                            showToast = { message -> showToast(message) }
+                        )
+                    }
+                    composable(route = SelfieCheckScreenDestination.route) {
+                        SelfieCheckScreen(
                             showToast = { message -> showToast(message) }
                         )
                     }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Destinations.kt
@@ -31,6 +31,7 @@ import multipazproject.samples.testapp.generated.resources.face_detection_title
 import multipazproject.samples.testapp.generated.resources.passphrase_prompt_screen_title
 import multipazproject.samples.testapp.generated.resources.rich_text_title
 import multipazproject.samples.testapp.generated.resources.screen_lock_title
+import multipazproject.samples.testapp.generated.resources.selfie_check_title
 import multipazproject.samples.testapp.generated.resources.settings_screen_title
 import org.jetbrains.compose.resources.StringResource
 
@@ -220,6 +221,11 @@ data object BarcodeScanningDestination : Destination {
     override val title = Res.string.barcode_scanning_title
 }
 
+data object SelfieCheckScreenDestination : Destination {
+    override val route = "SelfieCheck"
+    override val title = Res.string.selfie_check_title
+}
+
 val appDestinations = listOf(
     StartDestination,
     SettingsDestination,
@@ -250,5 +256,6 @@ val appDestinations = listOf(
     ScreenLockDestination,
     CameraDestination,
     FaceDetectionDestination,
-    BarcodeScanningDestination
+    BarcodeScanningDestination,
+    SelfieCheckScreenDestination
 )

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SelfieCheckScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/SelfieCheckScreen.kt
@@ -1,0 +1,133 @@
+package org.multipaz.testapp.ui
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.DialogProperties
+import kotlinx.coroutines.launch
+import multipazproject.samples.testapp.generated.resources.Res
+import multipazproject.samples.testapp.generated.resources.selfie_check_dialog_title
+import multipazproject.samples.testapp.generated.resources.selfie_check_subtitle
+import org.jetbrains.compose.resources.stringResource
+import org.multipaz.compose.camera.CameraCaptureResolution
+import org.multipaz.compose.camera.CameraCaptureResolution.MEDIUM
+import org.multipaz.compose.permissions.rememberCameraPermissionState
+import org.multipaz.selfiecheck.SelfieCheck
+import org.multipaz.selfiecheck.SelfieCheckViewModel
+import org.multipaz.util.Logger
+
+private const val TAG = "SelfieCheckScreen"
+
+@Composable
+fun SelfieCheckScreen(
+    showToast: (message: String) -> Unit
+) {
+    val identityIssuer = "Utopia Department of Motor Vehicles"
+    val showSelfieDialog = remember { mutableStateOf<CaptureConfig?>(null) }
+    val cameraPermissionState = rememberCameraPermissionState()
+    val coroutineScope = rememberCoroutineScope()
+    val viewModel: SelfieCheckViewModel = remember { SelfieCheckViewModel(identityIssuer) }
+
+    if (showSelfieDialog.value != null) {
+        val isLandscapeFromViewModel by viewModel.isLandscape.collectAsState()
+        Logger.d(TAG, "isLandscapeFromViewModel: $isLandscapeFromViewModel")
+
+        AlertDialog(
+            modifier = Modifier
+                .fillMaxWidth(if (isLandscapeFromViewModel) 0.8f else 1f)
+                .padding(if (isLandscapeFromViewModel) 4.dp else 4.dp),
+            title = { Text(text = stringResource(Res.string.selfie_check_dialog_title)) },
+            text = {
+                Box(
+                    modifier = Modifier.fillMaxWidth()
+                ) {
+                    SelfieCheck(
+                        modifier = Modifier.fillMaxWidth(),
+                        onVerificationComplete = {
+                            showSelfieDialog.value = null
+                            viewModel.resetForNewCheck()
+                            // Use the `viewModel.capturedFaceImage` here for further processing (before VM destroyed).
+                        },
+                        viewModel = viewModel,
+                        identityIssuer = identityIssuer
+                    )
+                }
+            },
+            onDismissRequest = { showSelfieDialog.value = null },
+            confirmButton = {},
+            dismissButton = {
+                TextButton(onClick = {
+                    showSelfieDialog.value = null
+                    viewModel.resetForNewCheck()
+                }) {
+                    Text(text = "Close")
+                }
+            },
+            properties = DialogProperties(
+                usePlatformDefaultWidth = false, // Crucial for any custom width.
+                dismissOnClickOutside = true,
+                dismissOnBackPress = true
+            )
+        )
+    }
+
+    if (!cameraPermissionState.isGranted) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        cameraPermissionState.launchPermissionRequest()
+                    }
+                }
+            ) {
+                Text("Request Camera permission")
+            }
+        }
+    } else {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background
+        ) {
+            LazyColumn(
+                modifier = Modifier.padding(8.dp)
+            ) {
+                item {
+                    val cameraConfig = CaptureConfig(MEDIUM)
+
+                    TextButton(onClick = {
+                        showSelfieDialog.value = cameraConfig
+                    }) { Text(stringResource(Res.string.selfie_check_subtitle)) }
+                }
+            }
+        }
+    }
+}
+
+/** Camera parameters variants to display in the UI. */
+private data class CaptureConfig(
+    val captureResolution: CameraCaptureResolution
+)
+

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/StartScreen.kt
@@ -37,6 +37,7 @@ import multipazproject.samples.testapp.generated.resources.screen_lock_title
 import multipazproject.samples.testapp.generated.resources.secure_enclave_secure_area_screen_title
 import multipazproject.samples.testapp.generated.resources.software_secure_area_screen_title
 import multipazproject.samples.testapp.generated.resources.face_detection_title
+import multipazproject.samples.testapp.generated.resources.selfie_check_title
 import kotlinx.coroutines.launch
 import multipazproject.samples.testapp.generated.resources.barcode_scanning_title
 import multipazproject.samples.testapp.generated.resources.camera_title
@@ -69,7 +70,8 @@ fun StartScreen(
     onClickScreenLock: () -> Unit = {},
     onClickCamera: () -> Unit = {},
     onClickFaceDetection: () -> Unit = {},
-    onClickBarcodeScanning: () -> Unit = {}
+    onClickBarcodeScanning: () -> Unit = {},
+    onClickSelfieCheck: () -> Unit = {}
 ) {
     val blePermissionState = rememberBluetoothPermissionState()
     val coroutineScope = rememberCoroutineScope()
@@ -250,6 +252,12 @@ fun StartScreen(
                 item {
                     TextButton(onClick = onClickBarcodeScanning) {
                         Text(stringResource(Res.string.barcode_scanning_title))
+                    }
+                }
+
+                item {
+                    TextButton(onClick = onClickSelfieCheck) {
+                        Text(stringResource(Res.string.selfie_check_title))
                     }
                 }
             }


### PR DESCRIPTION
Implement Selfie Check and capture flow.

- Use directions to navigate the user through several selfie liveness checks. 
- Confirm checks passing using MLKit.
- Capture selfie bitmap if checks passed.

Tests: manually verify happy and unhappy paths using TestApp on Android and iOS.

Ticket: #1071
- [x] Tests pass