### PR TITLE
Remove dependency on BouncyCastle library.

### DIFF
--- a/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/VerifierApp.kt
@@ -18,7 +18,6 @@ import org.multipaz.trustmanagement.TrustPoint
 import com.android.mdl.appreader.settings.UserPreferences
 import com.android.mdl.appreader.util.KeysAndCertificates
 import com.google.android.material.color.DynamicColors
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.io.ByteArrayInputStream
 import java.security.Security
 import java.security.cert.CertificateFactory
@@ -49,10 +48,7 @@ class VerifierApp : Application() {
 
     override fun onCreate() {
         super.onCreate()
-        // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
-        // based implementation included in the OS itself.
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-        Security.addProvider(BouncyCastleProvider())
+        // Do NOT add BouncyCastle here - we want to use the normal AndroidOpenSSL JCA provider
         DynamicColors.applyToActivitiesIfAvailable(this)
         userPreferencesInstance = userPreferences
         Logger.isDebugEnabled = userPreferences.isDebugLoggingEnabled()

--- a/appverifier/src/main/java/com/android/mdl/appreader/readercertgen/ReaderCertificateGenerator.kt
+++ b/appverifier/src/main/java/com/android/mdl/appreader/readercertgen/ReaderCertificateGenerator.kt
@@ -8,7 +8,6 @@ import org.multipaz.crypto.javaPublicKey
 import org.multipaz.crypto.javaX509Certificate
 import com.android.mdl.appreader.readercertgen.CertificateGenerator.generateCertificate
 import org.bouncycastle.asn1.x509.KeyUsage
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import java.math.BigInteger
 import java.security.InvalidAlgorithmParameterException
 import java.security.KeyPair
@@ -29,14 +28,8 @@ import java.util.Optional
 object ReaderCertificateGenerator {
     fun generateECDSAKeyPair(curve: String): KeyPair {
         return try {
-            // NOTE older devices may not have the right BC installed for this to work
-            val kpg: KeyPairGenerator
-            if (listOf("Ed25519", "Ed448").any { it.equals(curve, ignoreCase = true) }) {
-                kpg = KeyPairGenerator.getInstance(curve, BouncyCastleProvider())
-            } else {
-                kpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider())
-                kpg.initialize(ECGenParameterSpec(curve))
-            }
+            val kpg = KeyPairGenerator.getInstance("EC")
+            kpg.initialize(ECGenParameterSpec(curve))
             println(kpg.provider.info)
             kpg.generateKeyPair()
         } catch (e: NoSuchAlgorithmException) {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ kotlinx-coroutines = "1.8.1"
 kotlinx-io = "0.4.0"
 kotlinx-datetime = "0.6.0"
 kotlinx-serialization = "1.7.0"
-bouncy-castle = "1.78.1"
+bouncy-castle = "1.81"
 tink = "1.13.0"
 ksp = "2.1.21-2.0.1"
 androidx-biometrics = "1.2.0-alpha05"
@@ -65,6 +65,7 @@ errorprone = "2.38.0"
 mlkit-barcode-scanning = "17.3.0"
 semver = "3.0.0"
 skie = "0.10.2"
+process-phoenix = "3.0.0"
 
 [libraries]
 androidx-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "uiToolingPreview" }
@@ -149,6 +150,7 @@ androidx-credentials-registry-provider = { module = "androidx.credentials.regist
 errorprone-annotations = { module = "com.google.errorprone:error_prone_annotations", version.ref="errorprone"}
 mlkit-barcode-scanning = { module = "com.google.mlkit:barcode-scanning", version.ref="mlkit-barcode-scanning"}
 semver = { module = "io.github.z4kn4fein:semver", version.ref="semver" }
+process-phoenix = { module = "com.jakewharton:process-phoenix", version.ref="process-phoenix" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }

--- a/multipaz-android-legacy/build.gradle.kts
+++ b/multipaz-android-legacy/build.gradle.kts
@@ -46,7 +46,6 @@ android {
 dependencies {
     implementation(project(":multipaz"))
     implementation(libs.androidx.biometrics)
-    implementation(libs.bouncy.castle.bcprov)
     implementation(libs.bouncy.castle.bcpkix)
     implementation(libs.volley)
     implementation(libs.kotlinx.datetime)

--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/legacy/DynamicAuthTest.java
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/legacy/DynamicAuthTest.java
@@ -33,7 +33,6 @@ import androidx.test.filters.LargeTest;
 
 import org.multipaz.crypto.EcCurve;
 
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,11 +70,7 @@ import co.nstant.in.cbor.CborException;
 public class DynamicAuthTest {
     private static final String TAG = "DynamicAuthTest";
 
-    @Before
-    public void setup() {
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
-        Security.addProvider(new BouncyCastleProvider());
-    }
+    // Do NOT add BouncyCastle at setup time - we want to run tests against the normal AndroidOpenSSL JCA provider
 
     @SuppressWarnings("deprecation")
     @Test

--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/deviceretrieval/DeviceRetrievalHelperTest.kt
@@ -73,7 +73,6 @@ import kotlinx.coroutines.runBlocking
 import kotlinx.datetime.Clock.System.now
 import kotlinx.datetime.Instant
 import kotlinx.datetime.Instant.Companion.fromEpochMilliseconds
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -110,10 +109,7 @@ class DeviceRetrievalHelperTest {
 
     @Before
     fun setUp() = runBlocking {
-        // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
-        // based implementation included in Android.
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-        Security.addProvider(BouncyCastleProvider())
+        // Do NOT add BouncyCastle at setup time - we want to run tests against the normal AndroidOpenSSL JCA provider
 
         initializeApplication(InstrumentationRegistry.getInstrumentation().targetContext)
 

--- a/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.kt
+++ b/multipaz-android-legacy/src/androidTest/java/com/android/identity/android/mdoc/engagement/NfcEnagementHelperTest.kt
@@ -34,7 +34,6 @@ import org.multipaz.mdoc.connectionmethod.MdocConnectionMethodWifiAware
 import org.multipaz.mdoc.engagement.EngagementParser
 import org.multipaz.util.UUID
 import org.multipaz.util.toHex
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Before
 import org.junit.Test
@@ -46,13 +45,7 @@ import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 
 class NfcEnagementHelperTest {
-    @Before
-    fun setup() {
-        // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
-        // based implementation included in Android.
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-        Security.addProvider(BouncyCastleProvider())
-    }
+    // Do NOT add BouncyCastle at setup time - we want to run tests against the normal AndroidOpenSSL JCA provider
 
     @Test
     @SmallTest

--- a/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Util.kt
+++ b/multipaz-android-legacy/src/main/java/com/android/identity/android/legacy/Util.kt
@@ -47,7 +47,6 @@ import org.bouncycastle.asn1.DERSequenceGenerator
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCEdDSAPublicKey
 import org.bouncycastle.jcajce.provider.asymmetric.edec.BCXDHPublicKey
 import org.bouncycastle.jcajce.spec.XDHParameterSpec
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.bouncycastle.util.BigIntegers
 import java.lang.StringBuilder
 import java.io.ByteArrayInputStream
@@ -1038,10 +1037,7 @@ object Util {
         val y = BigInteger(1, encodedY)
         return try {
             val params: AlgorithmParameters =
-                AlgorithmParameters.getInstance(
-                    "EC",
-                    BouncyCastleProvider.PROVIDER_NAME
-                )
+                AlgorithmParameters.getInstance("EC")
             params.init(ECGenParameterSpec(curveName))
             val ecParameters =
                 params.getParameterSpec(
@@ -1078,22 +1074,22 @@ object Util {
             val kf: KeyFactory
             when (crv) {
                 EcCurve.ED448 -> {
-                    kf = KeyFactory.getInstance("EdDSA", BouncyCastleProvider.PROVIDER_NAME)
+                    kf = KeyFactory.getInstance("EdDSA")
                     prefix = ED448_X509_ENCODED_PREFIX
                 }
 
                 EcCurve.ED25519 -> {
-                    kf = KeyFactory.getInstance("EdDSA", BouncyCastleProvider.PROVIDER_NAME)
+                    kf = KeyFactory.getInstance("EdDSA")
                     prefix = ED25519_X509_ENCODED_PREFIX
                 }
 
                 EcCurve.X25519 -> {
-                    kf = KeyFactory.getInstance("XDH", BouncyCastleProvider.PROVIDER_NAME)
+                    kf = KeyFactory.getInstance("XDH")
                     prefix = X25519_X509_ENCODED_PREFIX
                 }
 
                 EcCurve.X448 -> {
-                    kf = KeyFactory.getInstance("XDH", BouncyCastleProvider.PROVIDER_NAME)
+                    kf = KeyFactory.getInstance("XDH")
                     prefix = X448_X509_ENCODED_PREFIX
                 }
 
@@ -1889,32 +1885,17 @@ object Util {
         return try {
             val kpg: KeyPairGenerator
             if (stdName == "X25519") {
-                kpg = KeyPairGenerator.getInstance(
-                    "X25519",
-                    BouncyCastleProvider.PROVIDER_NAME
-                )
+                kpg = KeyPairGenerator.getInstance("X25519")
                 kpg.initialize(XDHParameterSpec(XDHParameterSpec.X25519))
             } else if (stdName == "Ed25519") {
-                kpg = KeyPairGenerator.getInstance(
-                    "Ed25519",
-                    BouncyCastleProvider.PROVIDER_NAME
-                )
+                kpg = KeyPairGenerator.getInstance("Ed25519")
             } else if (stdName == "X448") {
-                kpg = KeyPairGenerator.getInstance(
-                    "X448",
-                    BouncyCastleProvider.PROVIDER_NAME
-                )
+                kpg = KeyPairGenerator.getInstance("X448")
                 kpg.initialize(XDHParameterSpec(XDHParameterSpec.X448))
             } else if (stdName == "Ed448") {
-                kpg = KeyPairGenerator.getInstance(
-                    "Ed448",
-                    BouncyCastleProvider.PROVIDER_NAME
-                )
+                kpg = KeyPairGenerator.getInstance("Ed448")
             } else {
-                kpg = KeyPairGenerator.getInstance(
-                    "EC",
-                    BouncyCastleProvider.PROVIDER_NAME
-                )
+                kpg = KeyPairGenerator.getInstance("EC")
                 kpg.initialize(ECGenParameterSpec(stdName))
             }
             kpg.generateKeyPair()

--- a/multipaz-android-legacy/src/test/java/com/android/identity/android/legacy/UtilTest.java
+++ b/multipaz-android-legacy/src/test/java/com/android/identity/android/legacy/UtilTest.java
@@ -41,7 +41,6 @@ import org.bouncycastle.cert.X509CertificateHolder;
 import org.bouncycastle.cert.jcajce.JcaX509CertificateConverter;
 import org.bouncycastle.cert.jcajce.JcaX509v3CertificateBuilder;
 import org.bouncycastle.jce.ECNamedCurveTable;
-import org.bouncycastle.jce.provider.BouncyCastleProvider;
 import org.bouncycastle.jce.spec.ECParameterSpec;
 import org.bouncycastle.operator.ContentSigner;
 import org.bouncycastle.operator.OperatorCreationException;
@@ -112,10 +111,7 @@ public class UtilTest {
 
     private static final String TAG = "UtilTest";
 
-    @Before
-    public void setUp() {
-        Security.insertProviderAt(new BouncyCastleProvider(), 1);
-    }
+    // Do NOT add BouncyCastle at setup time - we want to run tests against the normal AndroidOpenSSL JCA provider
 
     /**
      * Helper function to create a self-signed credential, including authentication keys and
@@ -603,16 +599,16 @@ public class UtilTest {
     }
 
     private KeyPair generateKeyPair() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
         kpg.initialize(new ECGenParameterSpec("secp256r1"));
         return kpg.generateKeyPair();
     }
 
     @Test
     public void coseSignAndVerify_P256() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC", BouncyCastleProvider.PROVIDER_NAME);
-        ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp256r1");
-        kpg.initialize(ecSpec);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        ECGenParameterSpec ecgSpec = new ECGenParameterSpec("secp256r1");
+        kpg.initialize(ecgSpec);
         KeyPair keyPair = kpg.generateKeyPair();
 
         byte[] data = new byte[]{0x10, 0x11, 0x12, 0x13};
@@ -626,11 +622,9 @@ public class UtilTest {
 
     @Test
     public void coseSignAndVerify_P384() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(
-                "EC",
-                new BouncyCastleProvider());
-        ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp384r1");
-        kpg.initialize(ecSpec);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        ECGenParameterSpec ecgSpec = new ECGenParameterSpec("secp384r1");
+        kpg.initialize(ecgSpec);
         KeyPair keyPair = kpg.generateKeyPair();
 
         byte[] data = new byte[]{0x10, 0x11, 0x12, 0x13};
@@ -646,11 +640,9 @@ public class UtilTest {
     @Ignore
     @Test
     public void coseSignAndVerify_P521() throws Exception {
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(
-                "EC",
-                new BouncyCastleProvider());
-        ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("secp521r1");
-        kpg.initialize(ecSpec);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
+        ECGenParameterSpec ecgSpec = new ECGenParameterSpec("secp521r1");
+        kpg.initialize(ecgSpec);
         KeyPair keyPair = kpg.generateKeyPair();
 
         byte[] data = new byte[]{0x10, 0x11, 0x12, 0x13};
@@ -662,13 +654,11 @@ public class UtilTest {
         assertEquals(0, Util.coseSign1GetX5Chain(sig).size());
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider
+    @Ignore
     @Test
     public void coseSignAndVerify_brainpoolP256r1() throws Exception {
-        BouncyCastleProvider bcProvider = new BouncyCastleProvider();
-
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(
-                "EC",
-                bcProvider);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
         ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("brainpoolP256r1");
         kpg.initialize(ecSpec);
         KeyPair keyPair = kpg.generateKeyPair();
@@ -676,7 +666,7 @@ public class UtilTest {
         byte[] data = new byte[]{0x10, 0x11, 0x12, 0x13};
         byte[] detachedContent = new byte[]{};
 
-        Signature s = Signature.getInstance("SHA256withECDSA", bcProvider);
+        Signature s = Signature.getInstance("SHA256withECDSA");
         s.initSign(keyPair.getPrivate());
 
         DataItem sig = Util.coseSign1Sign(s, data, detachedContent, null);
@@ -685,13 +675,11 @@ public class UtilTest {
         assertEquals(0, Util.coseSign1GetX5Chain(sig).size());
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider
+    @Ignore
     @Test
     public void coseSignAndVerify_brainpoolP384r1() throws Exception {
-        BouncyCastleProvider bcProvider = new BouncyCastleProvider();
-
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(
-                "EC",
-                bcProvider);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
         ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("brainpoolP384r1");
         kpg.initialize(ecSpec);
         KeyPair keyPair = kpg.generateKeyPair();
@@ -699,7 +687,7 @@ public class UtilTest {
         byte[] data = new byte[]{0x10, 0x11, 0x12, 0x13};
         byte[] detachedContent = new byte[]{};
 
-        Signature s = Signature.getInstance("SHA384withECDSA", bcProvider);
+        Signature s = Signature.getInstance("SHA384withECDSA");
         s.initSign(keyPair.getPrivate());
 
         DataItem sig = Util.coseSign1Sign(s, data, detachedContent, null);
@@ -708,13 +696,11 @@ public class UtilTest {
         assertEquals(0, Util.coseSign1GetX5Chain(sig).size());
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider
+    @Ignore
     @Test
     public void coseSignAndVerify_brainpoolP512r1() throws Exception {
-        BouncyCastleProvider bcProvider = new BouncyCastleProvider();
-
-        KeyPairGenerator kpg = KeyPairGenerator.getInstance(
-                "EC",
-                bcProvider);
+        KeyPairGenerator kpg = KeyPairGenerator.getInstance("EC");
         ECParameterSpec ecSpec = ECNamedCurveTable.getParameterSpec("brainpoolP512r1");
         kpg.initialize(ecSpec);
         KeyPair keyPair = kpg.generateKeyPair();
@@ -722,7 +708,7 @@ public class UtilTest {
         byte[] data = new byte[]{0x10, 0x11, 0x12, 0x13};
         byte[] detachedContent = new byte[]{};
 
-        Signature s = Signature.getInstance("SHA512withECDSA", bcProvider);
+        Signature s = Signature.getInstance("SHA512withECDSA");
         s.initSign(keyPair.getPrivate());
 
         DataItem sig = Util.coseSign1Sign(s, data, detachedContent, null);
@@ -764,7 +750,6 @@ public class UtilTest {
                             .addExtension(Extension.basicConstraints, true, new BasicConstraints(true))
                             .build(signer);
             return new JcaX509CertificateConverter()
-                    .setProvider(new BouncyCastleProvider())
                     .getCertificate(certHolder);
         } catch (OperatorCreationException | CertIOException | CertificateException e) {
             throw new IllegalStateException("Error generating self-signed certificate", e);
@@ -1262,41 +1247,57 @@ public class UtilTest {
         testCoseKey(EcCurve.P521);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider
+    @Ignore
     @Test
     public void testCoseKeyBrainpool256() {
         testCoseKey(EcCurve.BRAINPOOLP256R1);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider
+    @Ignore
     @Test
     public void testCoseKeyBrainpool320() {
         testCoseKey(EcCurve.BRAINPOOLP320R1);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider
+    @Ignore
     @Test
     public void testCoseKeyBrainpool384() {
         testCoseKey(EcCurve.BRAINPOOLP384R1);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider
+    @Ignore
     @Test
     public void testCoseKeyBrainpool521() {
         testCoseKey(EcCurve.BRAINPOOLP512R1);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider and this doesn't work there
+    @Ignore
     @Test
     public void testCoseKeyX25519() {
         testCoseKey(EcCurve.X25519);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider and this doesn't work there
+    @Ignore
     @Test
     public void testCoseKeyX448() {
         testCoseKey(EcCurve.X448);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider and this doesn't work there
+    @Ignore
     @Test
     public void testCoseKeyEd25519() {
         testCoseKey(EcCurve.ED25519);
     }
 
+    // Ignored out b/c we run tests against AndroidOpenSSL provider and this doesn't work there
+    @Ignore
     @Test
     public void testCoseKeyEd448() {
         testCoseKey(EcCurve.ED448);

--- a/multipaz-backend-server/build.gradle.kts
+++ b/multipaz-backend-server/build.gradle.kts
@@ -31,7 +31,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.io.bytestring)
-    implementation(libs.bouncy.castle.bcprov)
     implementation(libs.hsqldb)
     implementation(libs.mysql)
     implementation(libs.ktor.client.core)

--- a/multipaz-csa/build.gradle.kts
+++ b/multipaz-csa/build.gradle.kts
@@ -22,6 +22,4 @@ dependencies {
     ksp(project(":multipaz-cbor-rpc"))
 
     testImplementation(libs.kotlin.test)
-    testImplementation(libs.bouncy.castle.bcprov)
-    testImplementation(libs.bouncy.castle.bcpkix)
 }

--- a/multipaz-doctypes/build.gradle.kts
+++ b/multipaz-doctypes/build.gradle.kts
@@ -51,16 +51,12 @@ kotlin {
 
         val jvmMain by getting {
             dependencies {
-                implementation(libs.bouncy.castle.bcprov)
-                implementation(libs.bouncy.castle.bcpkix)
                 implementation(libs.tink)
             }
         }
 
         val jvmTest by getting {
             dependencies {
-                implementation(libs.bouncy.castle.bcprov)
-                implementation(libs.bouncy.castle.bcpkix)
             }
         }
     }

--- a/multipaz-models/build.gradle.kts
+++ b/multipaz-models/build.gradle.kts
@@ -57,8 +57,6 @@ kotlin {
 
         val androidMain by getting {
             dependencies {
-                implementation(libs.bouncy.castle.bcprov)
-                implementation(libs.bouncy.castle.bcpkix)
                 implementation(libs.tink)
                 implementation(libs.accompanist.permissions)
                 implementation(libs.androidx.material)

--- a/multipaz-openid4vci-server/build.gradle.kts
+++ b/multipaz-openid4vci-server/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.io.bytestring)
-    implementation(libs.bouncy.castle.bcprov)
     implementation(libs.zxing.core)
     implementation(libs.hsqldb)
     implementation(libs.mysql)

--- a/multipaz-verifier-server/build.gradle.kts
+++ b/multipaz-verifier-server/build.gradle.kts
@@ -30,7 +30,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.io.bytestring)
-    implementation(libs.bouncy.castle.bcprov)
     implementation(libs.zxing.core)
     implementation(libs.hsqldb)
     implementation(libs.mysql)

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -82,7 +82,6 @@ import kotlinx.serialization.json.putJsonObject
 import net.minidev.json.JSONArray
 import net.minidev.json.JSONObject
 import net.minidev.json.JSONStyle
-import org.bouncycastle.util.BigIntegers
 import org.multipaz.asn1.ASN1
 import org.multipaz.asn1.ASN1Encoding
 import org.multipaz.asn1.ASN1Sequence
@@ -315,9 +314,7 @@ private suspend fun getReaderIdentity(): ServerIdentity =
 
         val validFrom = Instant.fromEpochSeconds(Clock.System.now().epochSeconds)
         val validUntil = validFrom.plus(DateTimePeriod(years = 5), TimeZone.currentSystemDefault())
-        val serial = ASN1Integer(
-            BigIntegers.fromUnsignedByteArray(Random.Default.nextBytes(16)).toByteArray()
-        )
+        val serial = ASN1Integer.fromRandom(128)
 
         val readerRootKey = Crypto.createEcPrivateKey(EcCurve.P384)
         val readerRootCertificate =

--- a/multipaz/build.gradle.kts
+++ b/multipaz/build.gradle.kts
@@ -1,9 +1,7 @@
 import org.gradle.kotlin.dsl.dependencies
 import org.gradle.kotlin.dsl.get
-import org.gradle.kotlin.dsl.implementation
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
-import org.jetbrains.kotlin.gradle.plugin.mpp.apple.XCFramework
 import org.jetbrains.kotlin.konan.target.HostManager
 
 plugins {
@@ -104,8 +102,6 @@ kotlin {
         val javaSharedMain by creating {
             dependsOn(commonMain)
             dependencies {
-                implementation(libs.bouncy.castle.bcprov)
-                implementation(libs.bouncy.castle.bcpkix)
                 implementation(libs.tink)
             }
         }
@@ -113,8 +109,6 @@ kotlin {
         val jvmMain by getting {
             dependsOn(javaSharedMain)
             dependencies {
-                implementation(libs.bouncy.castle.bcprov)
-                implementation(libs.bouncy.castle.bcpkix)
                 implementation(libs.tink)
                 implementation(libs.ktor.client.java)
             }
@@ -161,6 +155,8 @@ kotlin {
                 implementation(libs.kotlinx.coroutines.test)
                 implementation(libs.kotlinx.coroutines.android)
                 implementation(libs.ktor.client.mock)
+                implementation(libs.bouncy.castle.bcprov)
+                implementation(libs.bouncy.castle.bcpkix)
                 implementation(project(":multipaz-csa"))
             }
         }

--- a/multipaz/consumer-rules.pro
+++ b/multipaz/consumer-rules.pro
@@ -1,5 +1,0 @@
-# Prevent BouncyCastle BC provider and EC algorithm from being stripped out
--keep class org.bouncycastle.jcajce.provider.keystore.BC$Mappings { *; }
--keep class org.bouncycastle.jcajce.provider.asymmetric.EC$Mappings { *; }
--keep class org.bouncycastle.jcajce.provider.keystore.bc.* { *; }
--keep class org.bouncycastle.jcajce.provider.asymmetric.ec.* { *; }

--- a/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/AndroidKeystoreSecureAreaTest.kt
+++ b/multipaz/src/androidInstrumentedTest/kotlin/org/multipaz/securearea/AndroidKeystoreSecureAreaTest.kt
@@ -33,7 +33,6 @@ import org.multipaz.storage.android.AndroidStorage
 import org.multipaz.util.AndroidAttestationExtensionParser
 import kotlinx.coroutines.test.runTest
 import kotlinx.datetime.Clock
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.junit.Assert
 import org.junit.Assume
 import org.junit.Before
@@ -46,7 +45,6 @@ import java.security.KeyStore
 import java.security.KeyStoreException
 import java.security.NoSuchAlgorithmException
 import java.security.NoSuchProviderException
-import java.security.Security
 import java.security.cert.Certificate
 import java.security.cert.CertificateException
 import kotlinx.datetime.Instant.Companion.fromEpochMilliseconds
@@ -58,11 +56,6 @@ class AndroidKeystoreSecureAreaTest {
 
     @Before
     fun setup() {
-        // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
-        // based implementation included in Android.
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-        Security.addProvider(BouncyCastleProvider())
-
         initializeApplication(InstrumentationRegistry.getInstrumentation().targetContext)
         val storage = AndroidStorage(databasePath = null, clock = Clock.System)
         secureAreaProvider = SecureAreaProvider {

--- a/multipaz/src/androidUnitTest/kotlin/org/multipaz/testUtil.android.kt
+++ b/multipaz/src/androidUnitTest/kotlin/org/multipaz/testUtil.android.kt
@@ -1,0 +1,9 @@
+package org.multipaz
+
+import org.multipaz.crypto.Crypto
+
+actual fun testUtilSetupCryptoProvider() {
+    println("In testUtilCommonSetup for Android")
+    println("Crypto.provider: ${Crypto.provider}")
+    println("Crypto.supportedCurves: ${Crypto.supportedCurves}")
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/Crypto.kt
@@ -3,8 +3,6 @@
 package org.multipaz.crypto
 
 import org.multipaz.util.UUID
-import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 
 /**
  * Cryptographic support routines.
@@ -18,6 +16,11 @@ expect object Crypto {
      * The Elliptic Curve Cryptography curves supported by the platform.
      */
     val supportedCurves: Set<EcCurve>
+
+    /**
+     * A human-readable description of the underlying library used.
+     */
+    val provider: String
 
     /**
      * Message digest function.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/software/SoftwareSecureArea.kt
@@ -45,9 +45,7 @@ import kotlin.random.Random
  * with 256-bit keys with the key derived from the passphrase using
  * [HKDF](https://en.wikipedia.org/wiki/HKDF).
  *
- * This is currently implemented using the
- * [Bouncy Castle](https://www.bouncycastle.org/) library but this implementation
- * detail may change in the future.
+ * On JVM and Android this is using [Crypto] and the algorithms and curves it implements.
  *
  * Use [SoftwareSecureArea.create] to create an instance of SoftwareSecureArea.
  */

--- a/multipaz/src/commonTest/kotlin/org/multipaz/cose/CoseTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/cose/CoseTests.kt
@@ -3,7 +3,6 @@ package org.multipaz.cose
 import kotlinx.coroutines.test.runTest
 import kotlinx.io.bytestring.ByteString
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.CborMap
 import org.multipaz.cbor.DataItem
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.cbor.toDataItem
@@ -14,7 +13,9 @@ import org.multipaz.crypto.EcPublicKeyDoubleCoordinate
 import org.multipaz.securearea.CreateKeySettings
 import org.multipaz.securearea.software.SoftwareSecureArea
 import org.multipaz.storage.ephemeral.EphemeralStorage
+import org.multipaz.testUtilSetupCryptoProvider
 import org.multipaz.util.fromHex
+import kotlin.test.BeforeTest
 
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -22,6 +23,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class CoseTests {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
 
     @Test
     fun coseKeyDecode() {

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/CryptoTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/CryptoTests.kt
@@ -1,16 +1,20 @@
 package org.multipaz.crypto
 
+import org.multipaz.testUtilSetupCryptoProvider
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toHex
 import org.multipaz.util.fromHex
 import kotlin.experimental.xor
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class CryptoTests {
-    
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
+
     @Test
     fun digests() {
         assertEquals(

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/EcPrivateKeyTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/EcPrivateKeyTests.kt
@@ -1,10 +1,14 @@
 package org.multipaz.crypto
 
+import org.multipaz.testUtilSetupCryptoProvider
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 
 class EcPrivateKeyTests {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
 
     fun createAndCheck(curve: EcCurve) {
         // TODO: use assumeTrue() when available in kotlin-test

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebEncryptionTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebEncryptionTests.kt
@@ -10,16 +10,19 @@ import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
-import kotlinx.serialization.json.put
+import org.multipaz.testUtilSetupCryptoProvider
 import org.multipaz.util.appendInt32
 import org.multipaz.util.fromBase64Url
 import org.multipaz.util.toBase64Url
 import org.multipaz.util.toHex
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class JsonWebEncryptionTests {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
 
     @Test fun roundTrip_P256_A128GCM() = roundtrip(EcCurve.P256, Algorithm.A128GCM, false)
     @Test fun roundTrip_P384_A128GCM() = roundtrip(EcCurve.P384, Algorithm.A128GCM, false)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebSignatureTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/JsonWebSignatureTests.kt
@@ -4,10 +4,14 @@ import kotlinx.datetime.Clock
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
 import org.multipaz.asn1.ASN1Integer
+import org.multipaz.testUtilSetupCryptoProvider
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.time.Duration.Companion.days
 
 class JsonWebSignatureTests {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
 
     @Test fun roundTrip_P256() = roundtrip(EcCurve.P256)
     @Test fun roundTrip_P384() = roundtrip(EcCurve.P384)

--- a/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertTests.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/crypto/X509CertTests.kt
@@ -7,14 +7,17 @@ import org.multipaz.util.fromHex
 import org.multipaz.util.toHex
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import org.multipaz.testUtilSetupCryptoProvider
+import kotlin.test.BeforeTest
 import kotlin.test.Test
-import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.hours
 
 class X509CertTests {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
 
     // This is a key attestation recorded from an Android device and traces up to a Google CA.
     // It contains both EC and RSA keys of various sizes making it an useful test vector for

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestParserTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/request/DeviceRequestParserTest.kt
@@ -20,7 +20,6 @@ import org.multipaz.cbor.Bstr
 import org.multipaz.cbor.Cbor
 import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.toDataItem
-import org.multipaz.crypto.Algorithm
 import org.multipaz.crypto.X509CertChain
 import org.multipaz.crypto.Crypto
 import org.multipaz.crypto.EcCurve
@@ -30,6 +29,7 @@ import org.multipaz.mdoc.TestVectors
 import org.multipaz.util.fromHex
 import kotlinx.datetime.Clock
 import kotlinx.datetime.Instant
+import org.multipaz.testUtilSetupCryptoProvider
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
@@ -38,6 +38,9 @@ import kotlin.test.assertFalse
 import kotlin.test.assertTrue
 
 class DeviceRequestParserTest {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
+
     @Test
     fun testDeviceRequestParserWithVectors() {
         // Strip the #6.24 tag since our APIs expects just the bytes of SessionTranscript.

--- a/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryptionTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryptionTest.kt
@@ -23,14 +23,19 @@ import org.multipaz.crypto.EcPrivateKeyDoubleCoordinate
 import org.multipaz.mdoc.TestVectors
 import org.multipaz.mdoc.engagement.EngagementParser
 import org.multipaz.mdoc.role.MdocRole
+import org.multipaz.testUtilSetupCryptoProvider
 import org.multipaz.util.Constants
 import org.multipaz.util.fromHex
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertContentEquals
 import kotlin.test.assertEquals
 import kotlin.test.assertNull
 
 class SessionEncryptionTest {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
+
     @Test
     fun testReaderAgainstVectors() {
         val eReaderKey: EcPrivateKey = EcPrivateKeyDoubleCoordinate(

--- a/multipaz/src/commonTest/kotlin/org/multipaz/testUtil.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/testUtil.kt
@@ -1,0 +1,5 @@
+package org.multipaz
+
+// Any test using Cryptographic functionality should call this in its setup() function
+//
+expect fun testUtilSetupCryptoProvider()

--- a/multipaz/src/iosMain/kotlin/org/multipaz/crypto/CryptoIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/crypto/CryptoIos.kt
@@ -29,6 +29,8 @@ actual object Crypto {
         EcCurve.P521,
     )
 
+    actual val provider: String = "CryptoKit"
+
     actual fun digest(
         algorithm: Algorithm,
         message: ByteArray

--- a/multipaz/src/iosTest/kotlin/org/multipaz/testUtil.ios.kt
+++ b/multipaz/src/iosTest/kotlin/org/multipaz/testUtil.ios.kt
@@ -1,0 +1,9 @@
+package org.multipaz
+
+import org.multipaz.crypto.Crypto
+
+actual fun testUtilSetupCryptoProvider() {
+    println("In testUtilCommonSetup for iOS")
+    println("Crypto.provider: ${Crypto.provider}")
+    println("Crypto.supportedCurves: ${Crypto.supportedCurves}")
+}

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/cose/CoseTestsJvm.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/cose/CoseTestsJvm.kt
@@ -6,7 +6,7 @@ import org.multipaz.cbor.toDataItem
 import org.multipaz.crypto.EcCurve
 import org.multipaz.crypto.EcPublicKeyDoubleCoordinate
 
-import org.bouncycastle.util.BigIntegers
+import org.multipaz.crypto.BigIntegersAsUnsignedByteArray
 import java.math.BigInteger
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -66,5 +66,5 @@ class CoseTestsJvm {
  * of SEC 1: Elliptic Curve Cryptography (https://www.secg.org/sec1-v2.pdf).
  */
 private fun BigInteger.sec1EncodeFieldElementAsOctetString(octetStringSize: Int): ByteArray {
-    return BigIntegers.asUnsignedByteArray(octetStringSize, this)
+    return BigIntegersAsUnsignedByteArray(octetStringSize, this)
 }

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/EcPrivateKeyTestsJvm.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/EcPrivateKeyTestsJvm.kt
@@ -1,11 +1,20 @@
 package org.multipaz.crypto
 
+import org.multipaz.testUtilSetupCryptoProvider
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
 class EcPrivateKeyTestsJvm {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
 
     fun conversion(curve: EcCurve) {
+        // TODO: use assumeTrue() when available in kotlin-test
+        if (!Crypto.supportedCurves.contains(curve)) {
+            println("Curve $curve not supported on platform")
+            return
+        }
         val key = Crypto.createEcPrivateKey(curve)
         val javaPrivateKey = key.javaPrivateKey
         val keyFromJava = javaPrivateKey.toEcPrivateKey(key.publicKey.javaPublicKey, curve)

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTestsNimbus.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/crypto/JsonWebSignatureTestsNimbus.kt
@@ -20,9 +20,11 @@ import kotlinx.serialization.json.buildJsonObject
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import org.multipaz.asn1.ASN1Integer
+import org.multipaz.testUtilSetupCryptoProvider
 import org.multipaz.util.toBase64
 import java.security.interfaces.ECPrivateKey
 import java.security.interfaces.ECPublicKey
+import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFails
@@ -31,6 +33,8 @@ import kotlin.time.Duration.Companion.days
 // Note: This checks the JsonWebSignature implementation against the https://connect2id.com/products/nimbus-jose-jwt
 // implementation
 class JsonWebSignatureTestsNimbus {
+    @BeforeTest
+    fun setup() = testUtilSetupCryptoProvider()
 
     // TODO: Check for other curves than just P-256.
 

--- a/multipaz/src/jvmTest/kotlin/org/multipaz/testUtil.jvm.kt
+++ b/multipaz/src/jvmTest/kotlin/org/multipaz/testUtil.jvm.kt
@@ -1,0 +1,16 @@
+package org.multipaz
+
+import org.bouncycastle.jce.provider.BouncyCastleProvider
+import org.multipaz.crypto.Crypto
+import java.security.Security
+
+actual fun testUtilSetupCryptoProvider() {
+    println("In testUtilCommonSetup for JVM")
+
+    // On the JVM load BouncyCastleProvider so we can exercise the all the tests involving Brainpool curves.
+    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+    Security.insertProviderAt(BouncyCastleProvider(), 1)
+
+    println("Crypto.provider: ${Crypto.provider}")
+    println("Crypto.supportedCurves: ${Crypto.supportedCurves}")
+}

--- a/multipazctl/src/main/java/org/multipaz/multipazctl/MultipazCtl.kt
+++ b/multipazctl/src/main/java/org/multipaz/multipazctl/MultipazCtl.kt
@@ -16,7 +16,6 @@ import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.buildJsonObject
 import org.bouncycastle.jce.provider.BouncyCastleProvider
-import org.bouncycastle.util.BigIntegers
 import org.multipaz.crypto.X509CertChain
 import java.io.File
 import java.nio.charset.StandardCharsets
@@ -87,7 +86,7 @@ object MultipazCtl {
             "https://github.com/openwallet-foundation-labs/identity-credential"
         )
 
-        val serial = ASN1Integer(BigIntegers.fromUnsignedByteArray(Random.Default.nextBytes(16)).toByteArray())
+        val serial = ASN1Integer.fromRandom(128)
 
         val iacaCertificate = MdocUtil.generateIacaCertificate(
             iacaKey,
@@ -148,7 +147,7 @@ object MultipazCtl {
 
         val dsKey = Crypto.createEcPrivateKey(curve)
 
-        val serial = ASN1Integer(BigIntegers.fromUnsignedByteArray(Random.Default.nextBytes(16)).toByteArray())
+        val serial = ASN1Integer.fromRandom(128)
 
         val dsCertificate = MdocUtil.generateDsCertificate(
             iacaCert,
@@ -192,7 +191,7 @@ object MultipazCtl {
         val curveName = getArg(args, "curve", "P-384")
         val curve = EcCurve.fromJwkName(curveName)
 
-        val serial = ASN1Integer(BigIntegers.fromUnsignedByteArray(Random.Default.nextBytes(16)).toByteArray())
+        val serial = ASN1Integer.fromRandom(128)
 
 
         println("Curve: $curve [$curveName]")
@@ -288,6 +287,7 @@ Generate an reader root and corresponding private key:
 
     @JvmStatic
     fun main(args: Array<String>) {
+        // Load BouncyCastle for Brainpool curve support
         Security.insertProviderAt(BouncyCastleProvider(), 1)
 
         if (args.size == 0) {

--- a/samples/testapp/build.gradle.kts
+++ b/samples/testapp/build.gradle.kts
@@ -76,6 +76,7 @@ kotlin {
                 implementation(libs.play.services.identity.credentials)
                 implementation(libs.androidx.credentials)
                 implementation(libs.androidx.credentials.registry.provider)
+                implementation(libs.process.phoenix)
             }
         }
 

--- a/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NdefService.kt
+++ b/samples/testapp/src/androidMain/kotlin/com/android/identity/testapp/NdefService.kt
@@ -104,6 +104,7 @@ class NdefService: HostApduService() {
                 storage = platformStorage(),
                 readOnly = true
             )
+            platformCryptoInit(settingsModel)
             val t1 = Clock.System.now()
             Logger.i(TAG, "Settings loaded in ${(t1 - t0).inWholeMilliseconds} ms")
 

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/App.kt
@@ -195,6 +195,7 @@ class App private constructor (val promptModel: PromptModel) {
             val initFuncs = listOf<Pair<suspend () -> Unit, String>>(
                 Pair(::platformInit, "platformInit"),
                 Pair(::settingsInit, "settingsInit"),
+                Pair(::platformCryptoInit, "platformCryptoInit"),
                 Pair(::documentTypeRepositoryInit, "documentTypeRepositoryInit"),
                 Pair(::documentStoreInit, "documentStoreInit"),
                 Pair(::documentModelInit, "documentModelInit"),
@@ -216,6 +217,10 @@ class App private constructor (val promptModel: PromptModel) {
             Logger.i(TAG, "Total application initialization time: ${(end - begin).inWholeMilliseconds} ms")
             initialized = true
         }
+    }
+
+    private suspend fun platformCryptoInit() {
+        platformCryptoInit(settingsModel)
     }
 
     private suspend fun settingsInit() {
@@ -657,7 +662,10 @@ class App private constructor (val promptModel: PromptModel) {
                         )
                     }
                     composable(route = SettingsDestination.route) {
-                        SettingsScreen(this@App)
+                        SettingsScreen(
+                            app = this@App,
+                            showToast = { message: String -> showToast(message) }
+                        )
                     }
                     composable(route = AboutDestination.route) {
                         AboutScreen()

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/Platform.kt
@@ -10,6 +10,7 @@ import kotlinx.datetime.Instant
 import kotlinx.io.bytestring.ByteString
 import org.jetbrains.compose.resources.DrawableResource
 import org.multipaz.crypto.Algorithm
+import org.multipaz.prompt.PromptModel
 
 enum class Platform(val displayName: String) {
     ANDROID("Android"),
@@ -24,6 +25,8 @@ expect val platform: Platform
 
 expect suspend fun platformInit()
 
+expect suspend fun platformCryptoInit(settingsModel: TestAppSettingsModel)
+
 expect fun getLocalIpAddress(): String
 
 expect val platformIsEmulator: Boolean
@@ -32,6 +35,7 @@ expect fun platformStorage(): Storage
 
 expect fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*>
 
+expect fun platformRestartApp()
 /**
  * Gets a provider for the preferred [SecureArea] implementation for the platform.
  */

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/TestAppSettingsModel.kt
@@ -1,7 +1,6 @@
 package org.multipaz.testapp
 
 import org.multipaz.cbor.Cbor
-import org.multipaz.cbor.CborArray
 import org.multipaz.cbor.Tstr
 import org.multipaz.cbor.toDataItem
 import org.multipaz.crypto.EcCurve
@@ -151,6 +150,8 @@ class TestAppSettingsModel private constructor(
         bind(readerAllowMultipleRequests, "readerAllowMultipleRequests", false)
 
         bind(cloudSecureAreaUrl, "cloudSecureAreaUrl", CSA_URL_DEFAULT)
+
+        bind(cryptoPreferBouncyCastle, "cryptoForceBouncyCastle", false)
     }
 
     val presentmentBleCentralClientModeEnabled = MutableStateFlow<Boolean>(false)
@@ -173,6 +174,8 @@ class TestAppSettingsModel private constructor(
     val readerAllowMultipleRequests = MutableStateFlow<Boolean>(false)
 
     val cloudSecureAreaUrl = MutableStateFlow<String>(CSA_URL_DEFAULT)
+
+    val cryptoPreferBouncyCastle = MutableStateFlow<Boolean>(false)
 }
 
 // On the Android Emulator, 10.0.2.2 points to the host so this will work

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SettingsScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SettingsScreen.kt
@@ -20,16 +20,23 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.IO
+import kotlinx.coroutines.launch
 import org.multipaz.crypto.EcCurve
 import org.multipaz.testapp.App
 import org.multipaz.testapp.Platform
 import org.multipaz.testapp.TestAppSettingsModel
 import org.multipaz.testapp.platform
 import org.multipaz.compose.cards.WarningCard
+import org.multipaz.testapp.platformCryptoInit
+import org.multipaz.testapp.platformRestartApp
 
 @Composable
 fun SettingsScreen(
     app: App,
+    showToast: (message: String) -> Unit,
 ) {
     // NFC engagement as an mdoc is only supported on Android.
     //
@@ -39,6 +46,22 @@ fun SettingsScreen(
     LazyColumn(
         modifier = Modifier.padding(8.dp)
     ) {
+        item { SettingHeadline("Cryptography Library Settings") }
+        item {
+            SettingToggle(
+                title = "Prefer BouncyCastle to Conscrypt (restarts app)",
+                isChecked = app.settingsModel.cryptoPreferBouncyCastle.collectAsState().value,
+                onCheckedChange = {
+                    app.settingsModel.cryptoPreferBouncyCastle.value = it
+                    try {
+                        platformRestartApp()
+                    } catch (e: Throwable) {
+                        showToast("An error occurred: $e")
+                    }
+                },
+                enabled = (platform == Platform.ANDROID)
+            )
+        }
         item { SettingHeadline("ISO mdoc NFC Engagement Settings") }
         item {
             if (!nfcAvailable) {

--- a/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SoftwareSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/com/android/identity/testapp/ui/SoftwareSecureAreaScreen.kt
@@ -38,6 +38,9 @@ fun SoftwareSecureAreaScreen(
     LazyColumn(
         modifier = Modifier.padding(8.dp)
     ) {
+        item {
+            Text(text = "Implementation: ${Crypto.provider}")
+        }
         for (algorithm in softwareSecureArea.supportedAlgorithms) {
             for ((passphraseRequired, description) in arrayOf(
                 Pair(true, "- Passphrase"),

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
@@ -39,6 +39,7 @@ import multipazproject.samples.testapp.generated.resources.app_icon
 import org.jetbrains.compose.resources.painterResource
 import org.multipaz.compose.decodeImage
 import org.multipaz.crypto.Algorithm
+import org.multipaz.prompt.PromptModel
 import platform.Foundation.NSDocumentDirectory
 import platform.Foundation.NSFileManager
 import platform.Foundation.NSUserDomainMask
@@ -62,6 +63,15 @@ actual val platform = Platform.IOS
 
 actual suspend fun platformInit() {
     // Nothing to do
+}
+
+actual suspend fun platformCryptoInit(settingsModel: TestAppSettingsModel) {
+    // Nothing to do
+}
+
+actual fun platformRestartApp() {
+    // Currently only needed on Android
+    TODO()
 }
 
 @OptIn(ExperimentalForeignApi::class)

--- a/server-env/build.gradle.kts
+++ b/server-env/build.gradle.kts
@@ -23,7 +23,6 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.io.bytestring)
-    implementation(libs.bouncy.castle.bcprov)
     implementation(libs.hsqldb)
     implementation(libs.mysql)
     implementation(libs.ktor.client.core)

--- a/server-env/src/main/java/com/android/identity/server/BaseHttpServlet.kt
+++ b/server-env/src/main/java/com/android/identity/server/BaseHttpServlet.kt
@@ -10,8 +10,6 @@ import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.buildJsonObject
-import org.bouncycastle.jce.provider.BouncyCastleProvider
-import java.security.Security
 import kotlin.reflect.KClass
 
 open class BaseHttpServlet : HttpServlet() {
@@ -41,10 +39,6 @@ open class BaseHttpServlet : HttpServlet() {
         }
 
         fun environmentFor(clazz: KClass<*>): BackendEnvironment? = environmentMap[clazz]
-
-        init {
-            Security.addProvider(BouncyCastleProvider())
-        }
     }
 
     val environment get() = backendEnvironment

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -34,13 +34,14 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.coroutines.core)
     implementation(libs.kotlinx.io.bytestring)
-    implementation(libs.bouncy.castle.bcprov)
     implementation(libs.hsqldb)
     implementation(libs.zxing.core)
     implementation(libs.mysql)
     implementation(libs.ktor.client.core)
     implementation(libs.ktor.client.java)
     implementation(libs.nimbus.oauth2.oidc.sdk)
+    implementation(libs.bouncy.castle.bcprov)
+    implementation(libs.bouncy.castle.bcpkix)
 
     testImplementation(libs.junit)
 }

--- a/server/src/main/java/org/multipaz/wallet/server/CloudSecureAreaServlet.kt
+++ b/server/src/main/java/org/multipaz/wallet/server/CloudSecureAreaServlet.kt
@@ -68,6 +68,14 @@ class CloudSecureAreaServlet : BaseHttpServlet() {
         )
 
         companion object {
+            init {
+                // Load BouncyCastle for Brainpool curve support.
+                Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
+                Security.insertProviderAt(BouncyCastleProvider(), 1)
+                println("Crypto.provider: ${Crypto.provider}")
+                println("Crypto.supportedCurves: ${Crypto.supportedCurves}")
+            }
+
             fun fromCbor(encodedCbor: ByteArray): KeyMaterial {
                 val array = Cbor.decode(encodedCbor).asArray
                 return KeyMaterial(
@@ -185,7 +193,6 @@ class CloudSecureAreaServlet : BaseHttpServlet() {
         }
 
         private fun createCloudSecureArea(serverEnvironment: BackendEnvironment): CloudSecureAreaServer {
-            Security.addProvider(BouncyCastleProvider())
             val settings = ProvisioningBackendSettings(serverEnvironment.getInterface(Configuration::class)!!)
             return CloudSecureAreaServer(
                 serverSecureAreaBoundKey = keyMaterial.serverSecureAreaBoundKey,

--- a/wallet/src/main/java/org/multipaz/wallet/WalletApplication.kt
+++ b/wallet/src/main/java/org/multipaz/wallet/WalletApplication.kt
@@ -67,7 +67,6 @@ import org.multipaz.wallet.dynamicregistration.PowerOffReceiver
 import org.multipaz.wallet.logging.EventLogger
 import org.multipaz.wallet.util.toByteArray
 import kotlinx.datetime.Clock
-import org.bouncycastle.jce.provider.BouncyCastleProvider
 import org.multipaz.document.buildDocumentStore
 import java.io.File
 import java.net.URLDecoder
@@ -144,10 +143,7 @@ class WalletApplication : Application() {
         initializeApplication(applicationContext)
         //DirectAccess.warmupTransport()
 
-        // This is needed to prefer BouncyCastle bundled with the app instead of the Conscrypt
-        // based implementation included in the OS itself.
-        Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
-        Security.addProvider(BouncyCastleProvider())
+        // Do NOT add BouncyCastle here - we want to use the normal AndroidOpenSSL JCA provider
 
         // init documentTypeRepository
         documentTypeRepository = DocumentTypeRepository()

--- a/wallet/src/test/java/org/multipaz/wallet/SelfSignedMdlTest.kt
+++ b/wallet/src/test/java/org/multipaz/wallet/SelfSignedMdlTest.kt
@@ -14,11 +14,6 @@ import org.junit.Test
 import java.security.Security
 
 class SelfSignedMdlTest {
-    @Before
-    fun setup() {
-        Security.insertProviderAt(BouncyCastleProvider(), 1)
-    }
-
     private fun getProofingQuestions() : List<org.multipaz.provisioning.evidence.EvidenceRequest> {
         return listOf<org.multipaz.provisioning.evidence.EvidenceRequest>(
             org.multipaz.provisioning.evidence.EvidenceRequestMessage(


### PR DESCRIPTION
This change removes the dependency on BouncyCastle in the Multipaz libraries, except for `multipaz-android-legacy` (more at the end about this).

The root problem is that `CryptoJvm`'s initializer did the following

```
    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME)
    Security.insertProviderAt(BouncyCastleProvider(), 1)
```

which is fundamentally wrong as a library should never modify process-wide state behind the user's back. Remove this.

The other problem is that we were using various functions/interfaces from BouncyCastle library that we didn't really need to use anymore, especially since we implemented our own code for parsing/generating ASN.1 and X.509 certificates.

After this, another problem remains. Since the application is now in charge of managing which JCA providers to use - as it should - we need to handle the situation where the Java `PublicKey` and `PrivateKey` instances we're dealing with are from arbitrary providers (e.g. `AndroidOpenSSL` which is the name of the Conscrypt provider which is the default on Android) instead of always assuming they're from BouncyCastle.

In samples/testapp, add a new setting "Prefer BouncyCastle to Conscrypt" toggle which defaults to off, meaning that by default our TestApp will use Conscrypt instead of BouncyCastle. This does mean that Brainpool curves won't work (as Conscrypt doesn't currently support that) but everything else works and of course Brainpool curves will work when this new setting is on. Also restart the app when this is toggled and use ProcessPhoenix for this since is in fact non-trivial.

Adjust `Crypto.supportedCurves` to not include Brainpool curves unless BouncyCastle is first in the list. Also add `Crypto.provider` string which includes the list of JCA providers when using `CryptoJvm`. Print this string in _Software Secure Area_ screen in the testapp.

For testing, use BouncyCastle when running tests on JVM and not when running on Android. This helps ensure `CryptoJvm` gets tested with different sets of JCA providers.

For `multipaz-android-legacy` remove all calls to `BountyCastleProvider()` and adjust the tests so they always run against the default `AndroidOpenSSL` provider on Android (Conscrypt). Still link against BouncyCastle library because it's being using to generate certificates and other things. While we could port this to using the ASN1 and X.509 routines in the core Multipaz library such a change adds risk and we'd rather not make too big changes. Also, `multipaz-android-legacy` will be removed in the near future as known downstreams are actively migrating away from it.

Carefully tested this with TestApp going through the _Software Secure Area_, _Cloud Secure Area_, _Android Secure Area_, and _Secure Enclave Secure Area_ screens testing all combinations. On Android this was done with the new "Prefer BouncyCastle to Conscrypt" setting in both possible places.

Also remove BouncyCastleProvider() calls in `wallet` and `appverifier` modules and test those.

As a result, the only dependencies on BouncyCastle we now have are for testing the core library, in `multipaz-android-legacy`, in `multipazctl` command-line tool (to generate keys/certs with Brainpool curves), and for running the Cloud Secure Area server-side (so it can support Brainpool curves). This should be good news for downstream consumers on Android as this allows them to not include BouncyCastle at all (unless they need Brainpool curve support) which simplifies supply chain management and also helps reduce APK size.

Also rename package and file for `multipazctl` as that seems to have been forgotten in the big rename we had a while ago.

Test: New unit tests and all unit tests pass.
Test: Tested `samples/testapp` manually on Android and iOS (see above).
Test: Tested `wallet` and `appverifier`.
