### PR TITLE
Update 18013-7 Annex C implementation to use response instead of Response.

### DIFF
--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentment.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/digitalCredentialsPresentment.kt
@@ -894,7 +894,7 @@ private suspend fun digitalCredentialsMdocApiProtocol(
         )
 
     val responseJson = buildJsonObject {
-        put("Response", encryptedResponse.toBase64Url())
+        put("response", encryptedResponse.toBase64Url())
     }
     presentmentMechanism.sendResponse(responseJson.toString())
     mdocCredential.increaseUsageCount()

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -675,7 +675,7 @@ private fun handleDcGetDataMdocApi(
     credentialResponse: String
 ) {
     val response = Json.parseToJsonElement(credentialResponse).jsonObject
-    val encryptedResponseBase64 = response["Response"]!!.jsonPrimitive.content
+    val encryptedResponseBase64 = response["response"]!!.jsonPrimitive.content
 
     val array = Cbor.decode(encryptedResponseBase64.fromBase64Url()).asArray
     if (array.get(0).asTstr != "dcapi") {

--- a/multipaz-verifier-server/src/main/resources/resources/www/verifier.js
+++ b/multipaz-verifier-server/src/main/resources/resources/www/verifier.js
@@ -414,6 +414,7 @@ async function dcRequestCredential(sessionId, dcRequestProtocol, dcRequest) {
             },
             mediation: 'required',
           })
+        console.log('credentialResponse ', credentialResponse)
         dcProcessResponse(sessionId, credentialResponse)
     } catch (err) {
         alert(err)


### PR DESCRIPTION
This was changed in Annex C last minute before the publication of ISO/IEC 18013-7:2025.

Test: Tested against another Annex C reader.
