### PR TITLE
add `rememberBluetoothEnabledState` composable to keep track of state of bluetooth state on device

### DIFF
--- a/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothEnabledState.android.kt
+++ b/multipaz-compose/src/androidMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothEnabledState.android.kt
@@ -1,0 +1,60 @@
+package org.multipaz.compose.permissions
+
+import android.bluetooth.BluetoothAdapter
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+
+actual class BluetoothEnabledState internal constructor(
+    private val context: Context,
+    private val adapter: BluetoothAdapter?
+) {
+    private val _isEnabled = mutableStateOf(adapter?.isEnabled == true)
+    actual val isEnabled: Boolean get() = _isEnabled.value
+
+    private val receiver = object : BroadcastReceiver() {
+        override fun onReceive(context: Context?, intent: Intent?) {
+            if (intent?.action == BluetoothAdapter.ACTION_STATE_CHANGED) {
+                _isEnabled.value = adapter?.isEnabled == true
+            }
+        }
+    }
+
+    init {
+        context.registerReceiver(receiver, IntentFilter(BluetoothAdapter.ACTION_STATE_CHANGED))
+    }
+
+    actual suspend fun enable() {
+        try {
+            context.startActivity(Intent(BluetoothAdapter.ACTION_REQUEST_ENABLE).apply {
+                addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+            })
+        } catch (e: SecurityException) {
+            throw IllegalStateException("Bluetooth permission is required to enable Bluetooth", e)
+        }
+    }
+
+    fun unregister() {
+        context.unregisterReceiver(receiver)
+    }
+}
+
+@Composable
+actual fun rememberBluetoothEnabledState(): BluetoothEnabledState {
+    val context = androidx.compose.ui.platform.LocalContext.current.applicationContext
+    val adapter = remember { BluetoothAdapter.getDefaultAdapter() }
+    val state = remember {
+        BluetoothEnabledState(context, adapter)
+    }
+    DisposableEffect(Unit) {
+        onDispose {
+            state.unregister()
+        }
+    }
+    return state
+}

--- a/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothEnabledState.kt
+++ b/multipaz-compose/src/commonMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothEnabledState.kt
@@ -1,0 +1,30 @@
+package org.multipaz.compose.permissions
+
+import androidx.compose.runtime.Composable
+
+/**
+ * Represents the state of Bluetooth on the device.
+ * Provides information about whether Bluetooth is enabled and allows enabling it.
+ */
+expect class BluetoothEnabledState {
+
+    /**
+     * Indicates if Bluetooth is currently enabled.
+     */
+    val isEnabled: Boolean
+
+    /**
+     * Enables Bluetooth on the device.
+     */
+    suspend fun enable()
+}
+
+/**
+ * Remembers and provides the current [BluetoothEnabledState].
+ *
+ * If the bluetooth state changes this will trigger a recomposition.
+ * This is useful for the case where the user goes into the settings or
+ * notification drawer to manually grant or deny the permission.
+ */
+@Composable
+expect fun rememberBluetoothEnabledState(): BluetoothEnabledState

--- a/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothEnabledState.ios.kt
+++ b/multipaz-compose/src/iosMain/kotlin/org/multipaz/compose/permissions/rememberBluetoothEnabledState.ios.kt
@@ -1,0 +1,138 @@
+package org.multipaz.compose.permissions
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import platform.CoreBluetooth.CBCentralManager
+import platform.CoreBluetooth.CBCentralManagerDelegateProtocol
+import platform.CoreBluetooth.CBManagerStatePoweredOff
+import platform.CoreBluetooth.CBManagerStatePoweredOn
+import platform.CoreBluetooth.CBManagerStateResetting
+import platform.CoreBluetooth.CBManagerStateUnauthorized
+import platform.CoreBluetooth.CBManagerStateUnknown
+import platform.CoreBluetooth.CBManagerStateUnsupported
+import platform.Foundation.NSURL
+import platform.UIKit.UIApplication
+import platform.UIKit.UIApplicationOpenSettingsURLString
+import platform.darwin.NSObject
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
+
+actual class BluetoothEnabledState internal constructor(
+    private val scope: CoroutineScope
+) {
+    private val _isEnabled = mutableStateOf(false)
+    actual val isEnabled: Boolean get() = _isEnabled.value
+
+    private var centralManager: CBCentralManager? = null
+
+    private val delegate = object : NSObject(), CBCentralManagerDelegateProtocol {
+        override fun centralManagerDidUpdateState(central: CBCentralManager) {
+            scope.launch(Dispatchers.Main) {
+                _isEnabled.value = central.state == CBManagerStatePoweredOn
+            }
+        }
+    }
+
+    init {
+        centralManager = CBCentralManager(delegate, null)
+        _isEnabled.value = centralManager?.state == CBManagerStatePoweredOn
+    }
+
+    actual suspend fun enable() {
+        when (centralManager?.state) {
+            CBManagerStatePoweredOff -> {
+                // On iOS, we can't programmatically enable Bluetooth
+                // Direct the user to Settings
+                val settingsUrl = NSURL.URLWithString(UIApplicationOpenSettingsURLString)
+                if (settingsUrl != null && UIApplication.sharedApplication.canOpenURL(settingsUrl)) {
+                    UIApplication.sharedApplication.openURL(settingsUrl, mapOf<Any?, Any?>(), null)
+                }
+            }
+
+            CBManagerStateUnauthorized -> {
+                // Bluetooth permission not granted
+                throw IllegalStateException("Unauthorized: Bluetooth permission not granted")
+            }
+
+            CBManagerStateUnsupported -> {
+                // Bluetooth is not supported on this device
+                throw UnsupportedOperationException("Bluetooth is not supported on this device.")
+            }
+
+            CBManagerStateUnknown, CBManagerStateResetting -> {
+                // Wait for state to be determined
+                suspendCoroutine<Unit> { continuation ->
+                    val tempDelegate = object : NSObject(), CBCentralManagerDelegateProtocol {
+                        override fun centralManagerDidUpdateState(central: CBCentralManager) {
+                            when (central.state) {
+                                CBManagerStatePoweredOn -> {
+                                    scope.launch(Dispatchers.Main) {
+                                        _isEnabled.value = true
+                                    }
+                                    continuation.resume(Unit)
+                                }
+
+                                CBManagerStatePoweredOff -> {
+                                    continuation.resume(Unit)
+                                    // try to open settings
+                                    scope.launch {
+                                        val settingsUrl =
+                                            NSURL.URLWithString(UIApplicationOpenSettingsURLString)
+                                        if (settingsUrl != null && UIApplication.sharedApplication.canOpenURL(
+                                                settingsUrl
+                                            )
+                                        ) {
+                                            UIApplication.sharedApplication.openURL(
+                                                settingsUrl, mapOf<Any?, Any?>(), null
+                                            )
+                                        }
+                                    }
+                                }
+
+                                else -> {
+                                    continuation.resume(Unit)
+                                }
+                            }
+                        }
+                    }
+                    centralManager = CBCentralManager(tempDelegate, null)
+                }
+            }
+
+            CBManagerStatePoweredOn -> {
+                // Already enabled, nothing to do
+            }
+
+            else -> {
+                // Only throw for truly unexpected states
+                throw IllegalStateException("Unexpected Bluetooth state: ${centralManager?.state}")
+            }
+        }
+    }
+
+    fun cleanup() {
+        centralManager = null
+    }
+}
+
+@Composable
+actual fun rememberBluetoothEnabledState(): BluetoothEnabledState {
+    val scope = rememberCoroutineScope()
+    val state = remember {
+        BluetoothEnabledState(scope)
+    }
+
+    DisposableEffect(Unit) {
+        onDispose {
+            state.cleanup()
+        }
+    }
+
+    return state
+}

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocMultiDeviceTestingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocMultiDeviceTestingScreen.kt
@@ -35,6 +35,7 @@ import kotlinx.coroutines.IO
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import org.multipaz.compose.permissions.rememberBluetoothEnabledState
 import org.multipaz.compose.permissions.rememberBluetoothPermissionState
 import org.multipaz.testapp.ui.ScanQrCodeDialog
 import org.multipaz.testapp.ui.ShowQrCodeDialog
@@ -50,6 +51,7 @@ fun IsoMdocMultiDeviceTestingScreen(
     showToast: (message: String) -> Unit,
 ) {
     val blePermissionState = rememberBluetoothPermissionState()
+    val bleEnabledState = rememberBluetoothEnabledState()
 
     val coroutineScope = rememberCoroutineScope()
 
@@ -158,6 +160,22 @@ fun IsoMdocMultiDeviceTestingScreen(
                 }
             ) {
                 Text("Request BLE permissions")
+            }
+        }
+    } else if (!bleEnabledState.isEnabled) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        bleEnabledState.enable()
+                    }
+                }
+            ) {
+                Text("Enable Bluetooth")
             }
         }
     } else {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximityReadingScreen.kt
@@ -90,6 +90,7 @@ import kotlinx.io.bytestring.ByteString
 import org.multipaz.compose.cards.InfoCard
 import org.multipaz.compose.cards.WarningCard
 import org.multipaz.compose.decodeImage
+import org.multipaz.compose.permissions.rememberBluetoothEnabledState
 import org.multipaz.compose.permissions.rememberBluetoothPermissionState
 import org.multipaz.mdoc.role.MdocRole
 import org.multipaz.mdoc.zkp.ZkDocument
@@ -141,6 +142,7 @@ fun IsoMdocProximityReadingScreen(
     val dropdownExpanded = remember { mutableStateOf(false) }
     val selectedRequest = remember { mutableStateOf(availableRequests[0]) }
     val blePermissionState = rememberBluetoothPermissionState()
+    val bleEnabledState = rememberBluetoothEnabledState()
     val coroutineScope = rememberCoroutineScope { app.promptModel }
     val readerShowQrScanner = remember { mutableStateOf(false) }
     val readerTransport = remember { mutableStateOf<MdocTransport?>(null) }
@@ -286,6 +288,22 @@ fun IsoMdocProximityReadingScreen(
                 }
             ) {
                 Text("Request BLE permissions")
+            }
+        }
+    }  else if (!bleEnabledState.isEnabled) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        bleEnabledState.enable()
+                    }
+                }
+            ) {
+                Text("Enable Bluetooth")
             }
         }
     } else {

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximitySharingScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/IsoMdocProximitySharingScreen.kt
@@ -37,6 +37,7 @@ import org.multipaz.util.toBase64Url
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.compose.permissions.rememberBluetoothEnabledState
 import org.multipaz.compose.permissions.rememberBluetoothPermissionState
 import org.multipaz.testapp.ui.ShowQrCodeDialog
 import org.multipaz.mdoc.engagement.EngagementGenerator
@@ -57,6 +58,7 @@ fun IsoMdocProximitySharingScreen(
 ) {
     val coroutineScope = rememberCoroutineScope { promptModel }
     val blePermissionState = rememberBluetoothPermissionState()
+    val bleEnabledState = rememberBluetoothEnabledState()
 
     val showQrCode = remember { mutableStateOf<ByteString?>(null) }
     if (showQrCode.value != null && presentmentModel.state.collectAsState().value != PresentmentModel.State.PROCESSING) {
@@ -88,6 +90,22 @@ fun IsoMdocProximitySharingScreen(
                 }
             ) {
                 Text("Request BLE permissions")
+            }
+        }
+    }  else if (!bleEnabledState.isEnabled) {
+        Column(
+            modifier = Modifier.fillMaxSize(),
+            verticalArrangement = Arrangement.Center,
+            horizontalAlignment = Alignment.CenterHorizontally
+        ) {
+            Button(
+                onClick = {
+                    coroutineScope.launch {
+                        bleEnabledState.enable()
+                    }
+                }
+            ) {
+                Text("Enable Bluetooth")
             }
         }
     } else {


### PR DESCRIPTION
one issue I was facing was that the `rememberBluetoothPermissionState` composable doesn’t take into account whether the device has bluetooth turned on or not. I expected the composable to handle all the permission related nuances. I have created a simple implementation in the above branch - it is still buggy (doesn’t auto update the state). can I get a confirmation on whether this approach is right? and we can have this feature in `rememberBluetoothPermissionState`?

cc: @davidz25 @dzuluaga 