### PR TITLE
Implement SecureArea.batchCreateKey() for Multipaz Cloud Secure Area.

### DIFF
--- a/multipaz-csa-server/src/main/java/org/multipaz/csa/server/ApplicationExt.kt
+++ b/multipaz-csa-server/src/main/java/org/multipaz/csa/server/ApplicationExt.kt
@@ -161,10 +161,15 @@ private fun createCloudSecureArea(
         androidGmsAttestation = settings.androidRequireGmsAttestation,
         androidVerifiedBootGreen = settings.androidRequireVerifiedBootGreen,
         androidAppSignatureCertificateDigests = settings.androidRequireAppSignatureCertificateDigests,
+        openid4vciKeyAttestationIssuer = settings.openid4vciKeyAttestationIssuer,
+        openid4vciKeyAttestationKeyStorage = settings.openid4vciKeyAttestationKeyStorage,
+        openid4vciKeyAttestationUserAuthentication = settings.openid4vciKeyAttestationUserAuthentication,
+        openid4vciKeyAttestationUserAuthenticationNoPassphrase = settings.openid4vciKeyAttestationUserAuthenticationNoPassphrase,
+        openid4vciKeyAttestationCertification = settings.openid4vciKeyAttestationCertification,
         passphraseFailureEnforcer = SimplePassphraseFailureEnforcer(
             settings.cloudSecureAreaLockoutNumFailedAttempts,
             settings.cloudSecureAreaLockoutDurationSeconds.seconds
-        )
+        ),
     )
 }
 

--- a/multipaz-csa-server/src/main/java/org/multipaz/csa/server/CloudSecureAreaSettings.kt
+++ b/multipaz-csa-server/src/main/java/org/multipaz/csa/server/CloudSecureAreaSettings.kt
@@ -8,30 +8,45 @@ import org.multipaz.util.fromBase64Url
 class CloudSecureAreaSettings(private val conf: Configuration) {
 
     val iosReleaseBuild
-        get() = getBool("iosRequireReleaseBuild", false)
+        get() = getBool("ios_require_release_build", false)
 
     val iosAppIdentifier
-        get() = getString("iosRequireAppIdentifier")
+        get() = getString("ios_require_app_identifier")
 
     val androidRequireGmsAttestation
-        get() = getBool("androidRequireGmsAttestation", true)
+        get() = getBool("android_require_gms_attestation", true)
 
     val androidRequireVerifiedBootGreen
-        get() = getBool("androidRequireVerifiedBootGreen", true)
+        get() = getBool("android_require_verified_boot_green", true)
 
     val androidRequireAppSignatureCertificateDigests: List<ByteString>
-        get() = getStringList("androidRequireAppSignatureCertificateDigests").map {
+        get() = getStringList("android_require_app_signature_certificate_digests").map {
             ByteString(it.fromBase64Url())
         }
 
     val cloudSecureAreaRekeyingIntervalSeconds: Int
-        get() = getInt("cloudSecureAreaRekeyingIntervalSeconds", 300)
+        get() = getInt("cloud_secure_area_rekeying_interval_seconds", 300)
 
     val cloudSecureAreaLockoutNumFailedAttempts: Int
-        get() = getInt("cloudSecureAreaLockoutNumFailedAttempts", 3)
+        get() = getInt("cloud_secure_area_lockout_num_failed_attempts", 3)
 
     val cloudSecureAreaLockoutDurationSeconds: Int
-        get() = getInt("cloudSecureAreaLockoutDurationSeconds", 60)
+        get() = getInt("cloud_secure_area_lockout_duration_seconds", 60)
+
+    val openid4vciKeyAttestationIssuer
+        get() = getString("openid4vci_key_attestation_issuer")
+
+    val openid4vciKeyAttestationKeyStorage
+        get() = getString("openid4vci_key_attestation_key_storage")
+
+    val openid4vciKeyAttestationUserAuthentication
+        get() = getString("openid4vci_key_attestation_user_authentication")
+
+    val openid4vciKeyAttestationUserAuthenticationNoPassphrase
+        get() = getString("openid4vci_key_attestation_user_authentication_no_passphrase")
+
+    val openid4vciKeyAttestationCertification
+        get() = getString("openid4vci_key_attestation_certification")
 
     private fun getString(key: String) = conf.getValue(key)
 

--- a/multipaz-csa-server/src/main/java/org/multipaz/csa/server/KeyMaterial.kt
+++ b/multipaz-csa-server/src/main/java/org/multipaz/csa/server/KeyMaterial.kt
@@ -128,7 +128,7 @@ data class KeyMaterial(
 
             // Create instance-specific intermediate certificate.
             val attestationKey = Crypto.createEcPrivateKey(EcCurve.P256)
-            val attestationKeySignatureAlgorithm = Algorithm.ES256
+            val attestationKeySignatureAlgorithm = Algorithm.ESP256
             val attestationKeySubject = "CN=Cloud Secure Area Attestation Root"
             val rootCertificate = attestationRoot.certificateChain.certificates.first()
             val attestationKeyCertificate = X509Cert.Builder(
@@ -150,7 +150,7 @@ data class KeyMaterial(
             // Create Cloud Binding Key Attestation Root w/ self-signed certificate.
             val bindingRoot = BackendEnvironment.getServerIdentity("csa_binding_identity") {
                 val cloudBindingKeyAttestationKey = Crypto.createEcPrivateKey(EcCurve.P256)
-                val cloudBindingKeySignatureAlgorithm = Algorithm.ES256
+                val cloudBindingKeySignatureAlgorithm = Algorithm.ESP256
                 val cloudBindingKeySubject =
                     "CN=Cloud Secure Area Cloud Binding Key Attestation Root"
                 val cloudBindingKeyAttestationCertificate = X509Cert.Builder(

--- a/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/securearea/AndroidKeystoreSecureArea.kt
@@ -293,7 +293,7 @@ class AndroidKeystoreSecureArea private constructor(
         } catch (e: Exception) {
             throw IllegalStateException(e)
         }
-        Logger.d(TAG, "EC key with alias '$alias' created")
+        //Logger.d(TAG, "EC key with alias '$alias' created")
         saveKeyMetadata(newKeyAlias, aSettings, X509CertChain(attestationCerts))
         return getKeyInfo(newKeyAlias)
     }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/util/Platform.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/util/Platform.android.kt
@@ -1,6 +1,8 @@
 package org.multipaz.util
 
 import android.os.Build
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
 import org.multipaz.context.applicationContext
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.PromptModel
@@ -8,27 +10,33 @@ import org.multipaz.securearea.AndroidKeystoreSecureArea
 import org.multipaz.securearea.SecureArea
 import org.multipaz.storage.Storage
 import org.multipaz.storage.android.AndroidStorage
+import org.multipaz.storage.ephemeral.EphemeralStorage
 import java.io.File
 
 actual object Platform {
     actual val name = "Android ${Build.VERSION.SDK_INT}"
 
-    actual val promptModel: PromptModel
-        get() = AndroidPromptModel()
-
-    actual suspend fun getStorage(): Storage {
-        return AndroidStorage(
-            File(applicationContext.dataDir.path, "storage.db").absolutePath
-        )
+    actual val promptModel by lazy {
+        AndroidPromptModel() as PromptModel
     }
 
-    actual suspend fun getNonBackedUpStorage(): Storage {
-        return AndroidStorage(
-            File(applicationContext.noBackupFilesDir.path, "storage.db").absolutePath
-        )
+    actual val storage by lazy {
+        AndroidStorage(File(applicationContext.dataDir.path, "storage.db").absolutePath) as Storage
     }
 
-    actual suspend fun getSecureArea(storage: Storage): SecureArea {
-        return AndroidKeystoreSecureArea.create(storage)
+    actual val nonBackedUpStorage by lazy {
+        AndroidStorage(File(applicationContext.noBackupFilesDir.path, "storage.db").absolutePath) as Storage
+    }
+
+    private var secureArea: SecureArea? = null
+    private val secureAreaLock = Mutex()
+
+    actual suspend fun getSecureArea(): SecureArea {
+        secureAreaLock.withLock {
+            if (secureArea == null) {
+                secureArea = AndroidKeystoreSecureArea.create(nonBackedUpStorage)
+            }
+            return secureArea!!
+        }
     }
 }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509Cert.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/crypto/X509Cert.kt
@@ -20,6 +20,7 @@ import org.multipaz.cbor.DataItem
 import org.multipaz.util.Logger
 import kotlinx.datetime.Instant
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializationImplemented
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -28,6 +29,7 @@ import kotlin.io.encoding.ExperimentalEncodingApi
  *
  * @param encodedCertificate the bytes of the X.509 certificate.
  */
+@CborSerializationImplemented(schemaId = "")
 class X509Cert(
     val encodedCertificate: ByteArray
 ) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/credential/MdocCredential.kt
@@ -68,7 +68,8 @@ class MdocCredential : SecureAreaBoundCredential {
          * @param createKeySettings The settings to use for key creation, including algorithm parameters.
          * @return A pair containing:
          *   - A list of created [MdocCredential] instances, ready to be certified
-         *   - An optional [JsonObject] containing OpenID4VCI key attestation data if supported by the secure area
+         *   - An optional string containing the compact serialization of a JWS with OpenID4VCI key attestation
+         *     data if supported by the secure area.
          */
         suspend fun createBatch(
             numberOfCredentials: Int,
@@ -77,7 +78,7 @@ class MdocCredential : SecureAreaBoundCredential {
             secureArea: SecureArea,
             docType: String,
             createKeySettings: CreateKeySettings
-        ): Pair<List<MdocCredential>, JsonObject?> {
+        ): Pair<List<MdocCredential>, String?> {
             val batchResult = secureArea.batchCreateKey(numberOfCredentials, createKeySettings)
             val credentials = batchResult.keyInfos
                 .map { it.alias }
@@ -92,9 +93,7 @@ class MdocCredential : SecureAreaBoundCredential {
                         useExistingKey(keyAlias)
                     }
                 }
-
-            return Pair(credentials, batchResult.openid4vciKeyAttestation)
-
+            return Pair(credentials, batchResult.openid4vciKeyAttestationJws)
         }
 
         suspend fun create(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/sdjwt/credential/KeyBoundSdJwtVcCredential.kt
@@ -39,7 +39,8 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
          * @param createKeySettings The settings to use for key creation, including algorithm parameters.
          * @return A pair containing:
          *   - A list of created [KeyBoundSdJwtVcCredential] instances, ready to be certified
-         *   - An optional [JsonObject] containing OpenID4VCI key attestation data if supported by the secure area
+         *   - An optional string containing the compact serialization of a JWS with OpenID4VCI key attestation
+         *     data if supported by the secure area.
          */
         suspend fun createBatch(
             numberOfCredentials: Int,
@@ -48,7 +49,7 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
             secureArea: SecureArea,
             vct: String,
             createKeySettings: CreateKeySettings
-        ): Pair<List<KeyBoundSdJwtVcCredential>, JsonObject?> {
+        ): Pair<List<KeyBoundSdJwtVcCredential>, String?> {
             val batchResult = secureArea.batchCreateKey(numberOfCredentials, createKeySettings)
             val credentials = batchResult.keyInfos
                 .map { it.alias }
@@ -63,9 +64,7 @@ class KeyBoundSdJwtVcCredential : SecureAreaBoundCredential, SdJwtVcCredential {
                         useExistingKey(keyAlias)
                     }
                 }
-
-            return Pair(credentials, batchResult.openid4vciKeyAttestation)
-
+            return Pair(credentials, batchResult.openid4vciKeyAttestationJws)
         }
 
         suspend fun create(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/BatchCreateKeyResult.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/BatchCreateKeyResult.kt
@@ -1,16 +1,15 @@
 package org.multipaz.securearea
 
-import kotlinx.serialization.json.JsonObject
-
 /**
  * Result of a [SecureArea.batchCreateKey] call.
  *
  * @property keyInfos a list [KeyInfo], one for each of the created keys.
- * @property openid4vciKeyAttestation an attestation over all the keys according to
+ * @property openid4vciKeyAttestationJws the compact serialization of a Json Web Signature where the
+ *   body contains an attestation over all the keys according to
  *   [OpenID4VCI Key Attestation](https://openid.github.io/OpenID4VCI/openid-4-verifiable-credential-issuance-wg-draft.html#name-key-attestation-in-jwt-form)
  *   or `null` if the implementation doesn't provide such an attestation or wasn't requested.
  */
 data class BatchCreateKeyResult(
     val keyInfos: List<KeyInfo>,
-    val openid4vciKeyAttestation: JsonObject?,
+    val openid4vciKeyAttestationJws: String?,
 )

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureArea.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/SecureArea.kt
@@ -101,7 +101,7 @@ interface SecureArea {
         }
         return BatchCreateKeyResult(
             keyInfos = keyInfos,
-            openid4vciKeyAttestation = null
+            openid4vciKeyAttestationJws = null
         )
     }
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/util/Platform.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/util/Platform.kt
@@ -23,24 +23,24 @@ expect object Platform {
     val promptModel: PromptModel
 
     /**
-     * Gets a [Storage] instance suitable for the platform.
+     * A [Storage] instance suitable for the platform.
      *
      * @throws NotImplementedError if called on a platform which isn't Android or iOS.
      */
-    suspend fun getStorage(): Storage
+    val storage: Storage
 
     /**
-     * Gets a [Storage] instance suitable for the platform in a location where the
+     * A [Storage] instance suitable for the platform in a location where the
      * underlying data file is excluded from backups.
      *
      * @throws NotImplementedError if called on a platform which isn't Android or iOS.
      */
-    suspend fun getNonBackedUpStorage(): Storage
+    val nonBackedUpStorage: Storage
 
     /**
      * Gets a [SecureArea] implementation suitable for the platform.
      *
      * @throws NotImplementedError if called on a platform which isn't Android or iOS.
      */
-    suspend fun getSecureArea(storage: Storage): SecureArea
+    suspend fun getSecureArea(): SecureArea
 }

--- a/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
+++ b/multipaz/src/commonTest/kotlin/org/multipaz/securearea/SoftwareSecureAreaTest.kt
@@ -393,7 +393,7 @@ class SoftwareSecureAreaTest {
         val sa = SoftwareSecureArea.create(storage)
         val batchCreateKeyResult = sa.batchCreateKey(10, CreateKeySettings(algorithm = Algorithm.ESP256))
         assertEquals(batchCreateKeyResult.keyInfos.size, 10)
-        assertNull(batchCreateKeyResult.openid4vciKeyAttestation)
+        assertNull(batchCreateKeyResult.openid4vciKeyAttestationJws)
         for (n in 0..9) {
             val keyInfo = batchCreateKeyResult.keyInfos[n]
             val dataToSign = byteArrayOf(4, 5, 6)

--- a/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/securearea/SecureEnclaveSecureArea.kt
@@ -8,7 +8,6 @@ import org.multipaz.crypto.EcSignature
 import org.multipaz.storage.Storage
 import org.multipaz.storage.StorageTable
 import org.multipaz.storage.StorageTableSpec
-import org.multipaz.util.Logger
 import kotlinx.io.bytestring.ByteString
 
 /**
@@ -102,7 +101,7 @@ class SecureEnclaveSecureArea private constructor(
             settings.algorithm,
             accessControlCreateFlags
         )
-        Logger.d(TAG, "EC key with alias '$alias' created")
+        //Logger.d(TAG, "EC key with alias '$alias' created")
         val newAlias = insertKey(alias, settings, keyBlob, pubKey)
         return getKeyInfo(newAlias)
     }

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/util/Platform.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/util/Platform.jvm.kt
@@ -10,15 +10,13 @@ actual object Platform {
     actual val promptModel: PromptModel
         get() = throw NotImplementedError()
 
-    actual suspend fun getStorage(): Storage {
-        throw NotImplementedError()
-    }
+    actual val storage: Storage
+        get() = throw NotImplementedError()
 
-    actual suspend fun getNonBackedUpStorage(): Storage {
-        throw NotImplementedError()
-    }
+    actual val nonBackedUpStorage: Storage
+        get() = throw NotImplementedError()
 
-    actual suspend fun getSecureArea(storage: Storage): SecureArea {
+    actual suspend fun getSecureArea(): SecureArea {
         throw NotImplementedError()
     }
 }

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
@@ -84,29 +84,7 @@ actual fun getLocalIpAddress(): String {
     throw IllegalStateException("Unable to determine address")
 }
 
-private val androidStorage: AndroidStorage by lazy {
-    AndroidStorage(
-        // We do not want our database to be backed-up as it is useless without private keys
-        // in the secure area (which are not, and cannot be backed-up). In the future we
-        // may want to have another database which would be backed-up (and may be used as a way
-        // to re-provision credentials to a new device).
-        File(applicationContext.noBackupFilesDir.path, "storage.db").absolutePath
-    )
-}
-
-actual fun platformStorage(): Storage {
-    return androidStorage
-}
-
 actual fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*> = Android
-
-private val androidKeystoreSecureAreaProvider = SecureAreaProvider {
-    AndroidKeystoreSecureArea.create(androidStorage)
-}
-
-actual fun platformSecureAreaProvider(): SecureAreaProvider<SecureArea> {
-    return androidKeystoreSecureAreaProvider
-}
 
 actual val platformSecureAreaHasKeyAgreement by lazy {
     AndroidKeystoreSecureArea.Capabilities().keyAgreementSupported

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNdefService.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/TestAppMdocNdefService.kt
@@ -1,5 +1,6 @@
 package org.multipaz.testapp
 
+import org.multipaz.util.Platform
 import org.multipaz.compose.mdoc.MdocNdefService
 import org.multipaz.mdoc.transport.MdocTransportOptions
 
@@ -8,7 +9,7 @@ class TestAppMdocNdefService: MdocNdefService() {
 
     override suspend fun getSettings(): Settings {
         settingsModel = TestAppSettingsModel.create(
-            storage = platformStorage(),
+            storage = Platform.storage,
             readOnly = true
         )
         platformCryptoInit(settingsModel)

--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/ui/AndroidKeystoreSecureAreaScreenAndroid.kt
@@ -57,7 +57,6 @@ import org.multipaz.crypto.javaX509Certificate
 import org.multipaz.prompt.PromptModel
 import org.multipaz.securearea.KeyUnlockInteractive
 import org.multipaz.securearea.KeyAttestation
-import org.multipaz.testapp.platformSecureAreaProvider
 import org.multipaz.util.Logger
 import org.multipaz.util.toBase64Url
 import org.multipaz.util.toHex
@@ -67,6 +66,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.datetime.Clock
 import kotlinx.io.bytestring.encodeToByteString
 import org.multipaz.crypto.Algorithm
+import org.multipaz.util.Platform
 import kotlin.time.Duration.Companion.days
 
 private const val TAG = "AndroidKeystoreSecureAreaScreen"
@@ -475,7 +475,7 @@ private fun getFeatureVersionKeystore(appContext: Context, useStrongbox: Boolean
 private suspend fun aksAttestation(strongBox: Boolean): KeyAttestation {
     val now = Clock.System.now()
     val thirtyDaysFromNow = now + 30.days
-    val androidKeystoreSecureArea = platformSecureAreaProvider().get() as AndroidKeystoreSecureArea
+    val androidKeystoreSecureArea = Platform.getSecureArea() as AndroidKeystoreSecureArea
     androidKeystoreSecureArea.createKey(
         "testKey",
         AndroidKeystoreCreateKeySettings.Builder("Challenge".encodeToByteString())
@@ -520,7 +520,7 @@ private suspend fun aksTestUnguarded(
     strongBox: Boolean,
     showToast: (message: String) -> Unit) {
 
-    val androidKeystoreSecureArea = platformSecureAreaProvider().get() as AndroidKeystoreSecureArea
+    val androidKeystoreSecureArea = Platform.getSecureArea() as AndroidKeystoreSecureArea
     androidKeystoreSecureArea.createKey(
         "testKey",
         AndroidKeystoreCreateKeySettings.Builder("Challenge".encodeToByteString())

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/DocumentModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/DocumentModel.kt
@@ -61,7 +61,7 @@ class DocumentModel(
                             if (document != null) {
                                 documentInfos[event.documentId] = DocumentInfo(
                                     document = document,
-                                    cardArt = decodeImage(document.metadata.cardArt!!.toByteArray()),
+                                    cardArt = decodeImage(document.metadata.cardArt?.toByteArray() ?: byteArrayOf(0)),
                                     credentialInfos = document.buildCredentialInfos()
                                 )
                             }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Platform.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/Platform.kt
@@ -33,15 +33,9 @@ expect fun getLocalIpAddress(): String
 
 expect val platformIsEmulator: Boolean
 
-expect fun platformStorage(): Storage
-
 expect fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*>
 
 expect fun platformRestartApp()
-/**
- * Gets a provider for the preferred [SecureArea] implementation for the platform.
- */
-expect fun platformSecureAreaProvider(): SecureAreaProvider<SecureArea>
 
 expect val platformSecureAreaHasKeyAgreement: Boolean
 

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppSettingsModel.kt
@@ -178,8 +178,7 @@ class TestAppSettingsModel private constructor(
     val cryptoPreferBouncyCastle = MutableStateFlow<Boolean>(false)
 }
 
-// On the Android Emulator, 10.0.2.2 points to the host so this will work
-// nicely if you are running the server on the same machine you are running
-// Android Studio on.
+// Default to our open CSA, where "open" means it'll work with even unlocked bootloaders
+// and any application signing key.
 //
-private val CSA_URL_DEFAULT: String = "http://10.0.2.2:8080/server/csa"
+private val CSA_URL_DEFAULT: String = "https://csa.multipaz.org/open"

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -52,6 +52,7 @@ import org.jetbrains.compose.resources.getSystemResourceEnvironment
 import org.multipaz.cbor.buildCborArray
 import org.multipaz.cbor.buildCborMap
 import org.multipaz.sdjwt.SdJwt
+import org.multipaz.testapp.ui.CsaCreationMode
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.iterator
@@ -134,6 +135,7 @@ object TestAppUtils {
     )
 
     suspend fun provisionTestDocuments(
+        csaCreationMode: CsaCreationMode,
         documentStore: DocumentStore,
         secureArea: SecureArea,
         secureAreaCreateKeySettingsFunc: (
@@ -148,9 +150,26 @@ object TestAppUtils {
         deviceKeyAlgorithm: Algorithm,
         deviceKeyMacAlgorithm: Algorithm,
         numCredentialsPerDomain: Int,
-    ) {
+    ): String? {
         require(deviceKeyAlgorithm.isSigning)
         require(deviceKeyMacAlgorithm == Algorithm.UNSET || deviceKeyMacAlgorithm.isKeyAgreement)
+        if (csaCreationMode == CsaCreationMode.EUPID_WITH_10_CREDENTIALS ||
+            csaCreationMode == CsaCreationMode.EUPID_WITH_10_CREDENTIALS_BATCH) {
+            return provisionCsaEuPid(
+                csaCreationMode == CsaCreationMode.EUPID_WITH_10_CREDENTIALS_BATCH,
+                documentStore,
+                secureArea,
+                secureAreaCreateKeySettingsFunc,
+                dsKey,
+                dsCert,
+                deviceKeyAlgorithm,
+                deviceKeyMacAlgorithm,
+                EUPersonalID.getDocumentType(),
+                "Erika",
+                "Erika's EU PID in CSA",
+                Res.drawable.pid_card_art
+            )
+        }
         provisionDocument(
             documentStore,
             secureArea,
@@ -220,6 +239,62 @@ object TestAppUtils {
             "Erika",
             "Erika's Movie Ticket",
             Res.drawable.movie_ticket_cart_art
+        )
+        return null
+    }
+
+    @OptIn(ExperimentalResourceApi::class)
+    private suspend fun provisionCsaEuPid(
+        useBatching: Boolean,
+        documentStore: DocumentStore,
+        secureArea: SecureArea,
+        secureAreaCreateKeySettingsFunc: (
+            challenge: ByteString,
+            algorithm: Algorithm,
+            userAuthenticationRequired: Boolean,
+            validFrom: Instant,
+            validUntil: Instant
+        ) -> CreateKeySettings,
+        dsKey: EcPrivateKey,
+        dsCert: X509Cert,
+        deviceKeyAlgorithm: Algorithm,
+        deviceKeyMacAlgorithm: Algorithm,
+        documentType: DocumentType,
+        givenNameOverride: String,
+        displayName: String,
+        cardArtResource: DrawableResource,
+    ): String? {
+        val cardArt = getDrawableResourceBytes(
+            getSystemResourceEnvironment(),
+            cardArtResource,
+        )
+
+        val document = documentStore.createDocument(
+            displayName = displayName,
+            typeDisplayName = documentType.displayName,
+            cardArt = ByteString(cardArt),
+        )
+
+        val now = Clock.System.now()
+        val signedAt = now - 1.hours
+        val validFrom =  now - 1.hours
+        val validUntil = now + 365.days
+
+        return addMdocCredentialsSameType(
+            useBatching = useBatching,
+            document = document,
+            documentType = documentType,
+            secureArea = secureArea,
+            secureAreaCreateKeySettingsFunc = secureAreaCreateKeySettingsFunc,
+            deviceKeyAlgorithm = deviceKeyAlgorithm,
+            deviceKeyMacAlgorithm = deviceKeyMacAlgorithm,
+            signedAt = signedAt,
+            validFrom = validFrom,
+            validUntil = validUntil,
+            dsKey = dsKey,
+            dsCert = dsCert,
+            numCredentialsPerDomain = 10,
+            givenNameOverride = givenNameOverride
         )
     }
 
@@ -429,6 +504,144 @@ object TestAppUtils {
             }
         }
 
+    }
+
+    private suspend fun addMdocCredentialsSameType(
+        useBatching: Boolean,
+        document: Document,
+        documentType: DocumentType,
+        secureArea: SecureArea,
+        secureAreaCreateKeySettingsFunc: (
+            challenge: ByteString,
+            algorithm: Algorithm,
+            userAuthenticationRequired: Boolean,
+            validFrom: Instant,
+            validUntil: Instant
+        ) -> CreateKeySettings,
+        deviceKeyAlgorithm: Algorithm,
+        deviceKeyMacAlgorithm: Algorithm,
+        signedAt: Instant,
+        validFrom: Instant,
+        validUntil: Instant,
+        dsKey: EcPrivateKey,
+        dsCert: X509Cert,
+        numCredentialsPerDomain: Int,
+        givenNameOverride: String
+    ): String? {
+        val issuerNamespaces = buildIssuerNamespaces {
+            for ((nsName, ns) in documentType.mdocDocumentType?.namespaces!!) {
+                addNamespace(nsName) {
+                    for ((deName, de) in ns.dataElements) {
+                        val sampleValue = de.attribute.sampleValueMdoc
+                        if (sampleValue != null) {
+                            val value = if (deName.startsWith("given_name")) {
+                                Tstr(givenNameOverride)
+                            } else {
+                                sampleValue
+                            }
+                            addDataElement(deName, value)
+                        } else {
+                            Logger.w(TAG, "No sample value for data element $deName")
+                        }
+                    }
+                }
+            }
+        }
+
+        val domain = CREDENTIAL_DOMAIN_MDOC_USER_AUTH
+        val algorithm = deviceKeyAlgorithm
+
+        val (credentials, openid4vciAttestationCompactSerialization) = if (useBatching) {
+            MdocCredential.createBatch(
+                numberOfCredentials = 10,
+                document = document,
+                domain = CREDENTIAL_DOMAIN_MDOC_USER_AUTH,
+                secureArea = secureArea,
+                docType = documentType.mdocDocumentType!!.docType,
+                createKeySettings = secureAreaCreateKeySettingsFunc(
+                    "Challenge".encodeToByteString(),
+                    deviceKeyAlgorithm,
+                    true,
+                    validFrom,
+                    validUntil
+                )
+            )
+        } else {
+            val creds = mutableListOf<MdocCredential>()
+            for (n in 1..numCredentialsPerDomain) {
+                val mdocCredential = MdocCredential.create(
+                    document = document,
+                    asReplacementForIdentifier = null,
+                    domain = CREDENTIAL_DOMAIN_MDOC_USER_AUTH,
+                    secureArea = secureArea,
+                    docType = documentType.mdocDocumentType!!.docType,
+                    createKeySettings = secureAreaCreateKeySettingsFunc(
+                        "Challenge".encodeToByteString(),
+                        deviceKeyAlgorithm,
+                        true,
+                        validFrom,
+                        validUntil
+                    )
+                )
+                creds.add(mdocCredential)
+            }
+            Pair(creds, null)
+        }
+
+        for (mdocCredential in credentials) {
+            // Generate an MSO and issuer-signed data for this authentication key.
+            val msoGenerator = MobileSecurityObjectGenerator(
+                Algorithm.SHA256,
+                documentType.mdocDocumentType!!.docType,
+                mdocCredential.getAttestation().publicKey
+            )
+            msoGenerator.setValidityInfo(signedAt, validFrom, validUntil, null)
+            msoGenerator.addValueDigests(issuerNamespaces)
+
+            val mso = msoGenerator.generate()
+            val taggedEncodedMso = Cbor.encode(Tagged(24, Bstr(mso)))
+
+            // IssuerAuth is a COSE_Sign1 where payload is MobileSecurityObjectBytes
+            //
+            // MobileSecurityObjectBytes = #6.24(bstr .cbor MobileSecurityObject)
+            //
+            val protectedHeaders = mapOf<CoseLabel, DataItem>(
+                Pair(
+                    CoseNumberLabel(Cose.COSE_LABEL_ALG),
+                    Algorithm.ES256.coseAlgorithmIdentifier!!.toDataItem()
+                )
+            )
+            val unprotectedHeaders = mapOf<CoseLabel, DataItem>(
+                Pair(
+                    CoseNumberLabel(Cose.COSE_LABEL_X5CHAIN),
+                    X509CertChain(listOf(dsCert)).toDataItem()
+                )
+            )
+            val encodedIssuerAuth = Cbor.encode(
+                Cose.coseSign1Sign(
+                    dsKey,
+                    taggedEncodedMso,
+                    true,
+                    dsKey.publicKey.curve.defaultSigningAlgorithm,
+                    protectedHeaders,
+                    unprotectedHeaders
+                ).toDataItem()
+            )
+            val issuerProvidedAuthenticationData = Cbor.encode(
+                buildCborMap {
+                    put("nameSpaces", issuerNamespaces.toDataItem())
+                    put("issuerAuth", RawCbor(encodedIssuerAuth))
+                }
+            )
+
+            // Now that we have issuer-provided authentication data we certify the authentication key.
+            mdocCredential.certify(
+                issuerProvidedAuthenticationData,
+                validFrom,
+                validUntil
+            )
+        }
+        return openid4vciAttestationCompactSerialization
     }
 
     // Technically - according to RFC 7800 at least - SD-JWT could do MACing too but it would

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/backend/BackendEnvironmentLocal.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/backend/BackendEnvironmentLocal.kt
@@ -16,8 +16,7 @@ import org.multipaz.rpc.handler.RpcNotifier
 import org.multipaz.securearea.SecureAreaProvider
 import org.multipaz.storage.Storage
 import org.multipaz.testapp.platformHttpClientEngineFactory
-import org.multipaz.testapp.platformSecureAreaProvider
-import org.multipaz.testapp.platformStorage
+import org.multipaz.util.Platform
 import org.multipaz.util.fromBase64Url
 import kotlin.reflect.KClass
 import kotlin.reflect.cast
@@ -30,7 +29,7 @@ class BackendEnvironmentLocal(
     private val deviceAssertionMaker: DeviceAssertionMaker
 ): BackendEnvironment {
     private var configuration = ConfigurationImpl()
-    private val storage = platformStorage()
+    private val storage = Platform.storage
     private val resources = ResourcesImpl()
     private val notificationsLocal = RpcNotificationsLocal(NoopCipher)
     private val httpClient = HttpClient(platformHttpClientEngineFactory()) {
@@ -46,7 +45,7 @@ class BackendEnvironmentLocal(
             RpcNotifications::class -> notificationsLocal
             RpcNotifier::class -> notificationsLocal
             HttpClient::class -> httpClient
-            SecureAreaProvider::class -> platformSecureAreaProvider()
+            SecureAreaProvider::class -> SecureAreaProvider { Platform.getSecureArea() }
             DeviceAssertionMaker::class -> deviceAssertionMaker
             ApplicationSupport::class -> applicationSupportLocal
             RpcAuthInspector::class -> RpcAuthInspectorAssertion.Default

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/backend/ProvisioningBackendProviderLocal.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/provisioning/backend/ProvisioningBackendProviderLocal.kt
@@ -15,7 +15,7 @@ import org.multipaz.rpc.backend.getTable
 import org.multipaz.rpc.handler.RpcAuthContext
 import org.multipaz.rpc.handler.RpcAuthInspectorAssertion
 import org.multipaz.storage.StorageTableSpec
-import org.multipaz.testapp.platformSecureAreaProvider
+import org.multipaz.util.Platform
 import kotlin.coroutines.CoroutineContext
 
 class ProvisioningBackendProviderLocal: ProvisioningBackendProvider {
@@ -47,7 +47,7 @@ class ProvisioningBackendProviderLocal: ProvisioningBackendProvider {
     ): DeviceAssertion {
         init()
         return DeviceCheck.generateAssertion(
-            secureArea = platformSecureAreaProvider().get(),
+            secureArea = Platform.getSecureArea(),
             deviceAttestationId = deviceAttestationId!!,
             assertion = assertionFactory(CLIENT_ID)
         )
@@ -66,7 +66,7 @@ class ProvisioningBackendProviderLocal: ProvisioningBackendProvider {
                 val clientTable =
                     BackendEnvironment.getTable(RpcAuthInspectorAssertion.rpcClientTableSpec)
                 val newAttestationResult = DeviceCheck.generateAttestation(
-                    secureArea = platformSecureAreaProvider().get(),
+                    secureArea = Platform.getSecureArea(),
                     challenge = CLIENT_ID.encodeToByteString()
                 )
                 deviceAttestation = newAttestationResult.deviceAttestation

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CloudSecureAreaScreen.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/ui/CloudSecureAreaScreen.kt
@@ -320,9 +320,10 @@ fun CsaConnectDialog(
                         onDismissRequest = { expanded.value = false }
                     ) {
                         for (urlOption in listOf(
-                            "http://10.0.2.2:8080/server/csa",
-                            "http://localhost:8080/server/csa",
-                            "https://ws.davidz25.net/server/csa"
+                            "https://csa.multipaz.org/",
+                            "https://csa.multipaz.org/open",
+                            "http://10.0.2.2:8005",
+                            "http://localhost:8005",
                         )) {
                             DropdownMenuItem(
                                 text = { Text(urlOption) },

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/PlatformIos.kt
@@ -131,31 +131,7 @@ private fun openDatabase(): SQLiteConnection {
     return NativeSQLiteDriver().open(rootPath.path() + "/storage.db")
 }
 
-@OptIn(ExperimentalCoroutinesApi::class, DelicateCoroutinesApi::class)
-private val iosStorage = SqliteStorage(
-    connection = openDatabase(),
-    // native sqlite crashes when used with Dispatchers.IO
-    coroutineContext = newSingleThreadContext("DB")
-)
-
-// SecureEnclaveSecureArea doesn't work on the iOS simulator so use SoftwareSecureArea there
-private val secureEnclaveSecureAreaProvider = SecureAreaProvider {
-    if (platformIsEmulator) {
-        SoftwareSecureArea.create(iosStorage)
-    } else {
-        SecureEnclaveSecureArea.create(iosStorage)
-    }
-}
-
-actual fun platformStorage(): Storage {
-    return iosStorage
-}
-
 actual fun platformHttpClientEngineFactory(): HttpClientEngineFactory<*> = Darwin
-
-actual fun platformSecureAreaProvider(): SecureAreaProvider<SecureArea> {
-    return secureEnclaveSecureAreaProvider
-}
 
 actual val platformSecureAreaHasKeyAgreement = true
 

--- a/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.ios.kt
+++ b/samples/testapp/src/iosMain/kotlin/com/android/identity/testapp/provisioning/model/SecureAreaRepositoryExt.ios.kt
@@ -11,13 +11,12 @@ import org.multipaz.securearea.config.SecureAreaConfigurationAndroidKeystore
 import org.multipaz.securearea.config.SecureAreaConfigurationCloud
 import org.multipaz.securearea.config.SecureAreaConfigurationSoftware
 import org.multipaz.securearea.software.SoftwareCreateKeySettings
-import org.multipaz.testapp.platformSecureAreaProvider
 
 actual suspend fun SecureAreaRepository.byConfiguration(
     secureAreaConfiguration: SecureAreaConfiguration,
     challenge: ByteString
 ): Pair<SecureArea, CreateKeySettings> {
-    return when(secureAreaConfiguration) {
+    return when (secureAreaConfiguration) {
         is SecureAreaConfigurationSoftware -> Pair(
             getImplementation("SoftwareSecureArea")!!,
             SoftwareCreateKeySettings.Builder()
@@ -26,7 +25,7 @@ actual suspend fun SecureAreaRepository.byConfiguration(
         )
 
         is SecureAreaConfigurationAndroidKeystore -> Pair(
-            platformSecureAreaProvider().get(),
+            getImplementation("SecureEnclaveSecureArea")!!,
             SecureEnclaveCreateKeySettings.Builder()
                 .build()
         )


### PR DESCRIPTION
This primary motivation for this was Issue #1125 in order to assess if optimizations for Multipaz are needed.

This change also implements OpenID4VCI key attestations for `batchCreateKey()` and implementing this made me realize that we used the wrong return type for these attestations. We were returning `JsonObject` for the body of the attestation but in order for this to be useful the caller really needs the whole JWS, including header and, crucially, the signature. So change this to return a String and specify it should be the compact serialization encoding of the JWS. Existing users can easily migrate, it didn't really work anyway before this.

In DocumentStoreScreen in the Testapp also add two new buttons "Create EUPID in CSA w/ 10 creds" and "Create EUPID in CSA w/ 10 creds (batch)" to easily test batching and compare timings against non-batching. Also show show a dialog when provisioning is done. This shows the amount of time it took and also the OpenID4VCI attestation in case one is returned.

For Multipaz Cloud Secure Area it takes ~2 seconds on Android and ~1 second on iOS to create a PID with 10 credentials using batching when using a CSA with 120ms pings (Berlin to US Central). This seems to be acceptable and on Android we can even get a bit faster, see the ongoing discussion in #1125.

Also change the settings for Cloud Secure Area to use snake_case instead of CamelCase. Add new settings to configure OpenID4VCI attestation, in particular `iss`, `certification`, `key_storage`, and `authentication` values in the returned JWT.

Also rearrange things in the TestApp so it's using the org.multipaz.util.Platform helpers instead of its own abstractions. This makes it easier to wholesale e.g. use EphemeralStorage() in a single place which is handy when evaluating performance.

Test: New unit tests and all unit tests pass.
Test: Manually tested.
