### PR TITLE
Fix BLE GATT on older Android devices

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
@@ -312,6 +312,17 @@ internal class BleCentralManagerAndroid : BleCentralManager {
             }
         }
 
+        @Suppress("DEPRECATION")
+        @Deprecated(
+            "Used natively in Android 12 and lower",
+            ReplaceWith("onCharacteristicRead(gatt, characteristic, characteristic.value, status)")
+        )
+        override fun onCharacteristicRead(
+            gatt: BluetoothGatt?,
+            characteristic: BluetoothGattCharacteristic?,
+            status: Int
+        ) = onCharacteristicRead(gatt!!, characteristic!!, characteristic.value, status)
+
         override fun onCharacteristicWrite(
             gatt: BluetoothGatt?,
             characteristic: BluetoothGattCharacteristic?,
@@ -370,6 +381,16 @@ internal class BleCentralManagerAndroid : BleCentralManager {
                 onError(Error("onCharacteristicChanged failed", error))
             }
         }
+
+        @Suppress("DEPRECATION")
+        @Deprecated(
+            "Used natively in Android 12 and lower",
+            ReplaceWith("onCharacteristicChanged(gatt, characteristic, characteristic.value)")
+        )
+        override fun onCharacteristicChanged(
+            gatt: BluetoothGatt?,
+            characteristic: BluetoothGattCharacteristic?
+        ) = onCharacteristicChanged(gatt!!, characteristic!!, characteristic.value)
     }
 
     var incomingMessage = ByteStringBuilder()


### PR DESCRIPTION
Older Android implementations below API 33 may still call the deprecated `onCharacteristicRead()` and `onCharacteristicChanged()` methods, ignoring the new memory-safe callbacks. Fix the issue by routing the deprecated function calls to the new callbacks.

Test: ./gradlew test connectedCheck
Test: Manually tested with Finnish EUDI Demo implementation on a previously non-functioning Android 9 device