### PR TITLE
Use original eReaderKey bytes for encodedSessionTranscript

### DIFF
--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/mdocPresentment.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/presentment/mdocPresentment.kt
@@ -78,14 +78,14 @@ internal suspend fun mdocPresentment(
                     Cbor.encode(
                         buildCborArray {
                             add(Tagged(24, Bstr(mechanism.encodedDeviceEngagement.toByteArray())))
-                            add(Tagged(24, Bstr(Cbor.encode(eReaderKey.toCoseKey().toDataItem()))))
+                            add(Tagged(24, Bstr(eReaderKey.encodedCoseKey)))
                             add(mechanism.handover)
                         }
                     )
                 sessionEncryption = SessionEncryption(
                     MdocRole.MDOC,
                     mechanism.eDeviceKey,
-                    eReaderKey,
+                    eReaderKey.publicKey,
                     encodedSessionTranscript,
                 )
             }
@@ -188,7 +188,7 @@ internal suspend fun mdocPresentment(
                     credential = mdocCredential,
                     requestedClaims = request.requestedClaims,
                     encodedSessionTranscript = encodedSessionTranscript,
-                    eReaderKey = SessionEncryption.getEReaderKey(sessionData),
+                    eReaderKey = SessionEncryption.getEReaderKey(sessionData).publicKey,
                 )
 
                 if (zkSystemMatch != null) {

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/EReaderKey.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/EReaderKey.kt
@@ -1,0 +1,25 @@
+package org.multipaz.mdoc.sessionencryption
+
+import org.multipaz.crypto.EcPublicKey
+
+/**
+ * Represents an ephemeral reader public key used in session establishment.
+ *
+ * Contains both the decoded [EcPublicKey] and its original encoded COSE representation.
+ *
+ * @param publicKey the decoded ephemeral reader public key.
+ * @param encodedCoseKey the original CBOR-encoded COSE key as received.
+ */
+data class EReaderKey(
+    val publicKey: EcPublicKey,
+    val encodedCoseKey: ByteArray
+) {
+    override fun equals(other: Any?): Boolean = other is EReaderKey &&
+            publicKey == other.publicKey && encodedCoseKey contentEquals other.encodedCoseKey
+
+    override fun hashCode(): Int {
+        var result = publicKey.hashCode()
+        result = 31 * result + encodedCoseKey.contentHashCode()
+        return result
+    }
+}

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/sessionencryption/SessionEncryption.kt
@@ -217,13 +217,15 @@ class SessionEncryption(
         /**
          * Gets the ephemeral reader key in a `SessionEstablishment` message.
          *
-         * @param the bytes of a `SessionEstablishment` message.
-         * @return the reader key, as a [EcPublicKey].
+         * @param sessionEstablishmentMessage the bytes of a `SessionEstablishment` message.
+         * @return the reader key, as an [EReaderKey], which contains both the decoded
+         * public key and original encoded bytes.
          */
-        fun getEReaderKey(sessionEstablishmentMessage: ByteArray): EcPublicKey {
+        fun getEReaderKey(sessionEstablishmentMessage: ByteArray): EReaderKey {
             val map = Cbor.decode(sessionEstablishmentMessage)
-            val encodedEReaderKey = map["eReaderKey"].asTagged.asBstr
-            return Cbor.decode(encodedEReaderKey).asCoseKey.ecPublicKey
+            val encodedCoseKey = map["eReaderKey"].asTagged.asBstr
+            val publicKey = Cbor.decode(encodedCoseKey).asCoseKey.ecPublicKey
+            return EReaderKey(publicKey, encodedCoseKey)
         }
     }
 }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/multidevicetests/MultiDeviceTestsServer.kt
@@ -188,7 +188,7 @@ class MultiDeviceTestsServer(
                 val sessionEncryption = SessionEncryption(
                     role = MdocRole.MDOC,
                     eSelfKey = eDeviceKey,
-                    remotePublicKey = eReaderKey,
+                    remotePublicKey = eReaderKey.publicKey,
                     encodedSessionTranscript = encodedSessionTranscript
                 )
                 val (deviceRequest, statusCode) = sessionEncryption.decryptMessage(sessionEstablishmentMessage)


### PR DESCRIPTION
This PR addresses the issue described in #1133 by modifying `SessionEncryption.getEReaderKey` to return both:

- the decoded `EcPublicKey`
- the original encoded COSE key as a `ByteArray`

The intention is to allow consumers to use the original encoded bytes when constructing the `SessionTranscript`, preserving the exact byte-level encoding and helping avoid interoperability issues.

While this approach appears to resolve the encoding mismatch and we are using it in our Android wallet application right now, it may not be the final or ideal solution.
Feedback and suggestions on improving this design are welcome to ensure it aligns well with the library’s architecture and usage patterns.
