### PR TITLE
feat(openid4vci-server): improve HTML to auto-redirect without continue button click

### DIFF
--- a/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/finishAuthorization.kt
+++ b/multipaz-openid4vci-server/src/main/java/org/multipaz/openid4vci/request/finishAuthorization.kt
@@ -43,9 +43,15 @@ suspend fun finishAuthorization(call: ApplicationCall) {
                     <html>
                     <head>
                     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+                    <title>Redirecting...</title>
                     </head>
                     <body>
-                    <a href="$parameterizedUri">Continue</a>
+                    <p>Redirecting to your app...</p>
+                    <script>
+                        // Automatically trigger the URI redirect
+                        window.location.href = "$parameterizedUri";
+                    </script>
+                    <p>If you are not redirected automatically, <a href="$parameterizedUri">click here</a>.</p>
                     </body>
                     </html>
                 """.trimIndent(),


### PR DESCRIPTION
Updated the HTML: originally, there was a "Continue" button that users had to click to trigger a redirect. Now, an automatic redirect is implemented. If the auto-redirect fails, users can still manually click the button to proceed.

Depends on Peter's [feedback](https://discord.com/channels/1022962884864643214/1179828955717574707/1389853010682974279), merge the improvement