### PR TITLE
Some small NFC and OpenID4VP fixes.

### DIFF
--- a/multipaz/src/androidMain/kotlin/org/multipaz/nfc/scanNfcTag.android.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/nfc/scanNfcTag.android.kt
@@ -1,10 +1,17 @@
 package org.multipaz.nfc
 
+import android.content.pm.PackageManager
+import org.multipaz.context.applicationContext
 import org.multipaz.prompt.AndroidPromptModel
 import org.multipaz.prompt.NfcDialogParameters
 import kotlin.coroutines.coroutineContext
 
-actual val nfcTagSupportsScanningWithoutDialog: Boolean = true
+
+actual val nfcTagScanningSupported by lazy {
+    applicationContext.packageManager.hasSystemFeature(PackageManager.FEATURE_NFC)
+}
+
+actual val nfcTagScanningSupportedWithoutDialog: Boolean = nfcTagScanningSupported
 
 actual suspend fun<T: Any> scanNfcTag(
     message: String?,

--- a/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanNfcMdocReader.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/mdoc/nfc/scanNfcMdocReader.kt
@@ -37,7 +37,7 @@ private data class ScanNfcMdocReaderResult(
  * from this method.
  *
  * @param message the message to display in the NFC tag scanning dialog or `null` to not show a dialog. Not all
- *   platforms supports not showing a dialog, use [org.multipaz.nfc.nfcTagSupportsScanningWithoutDialog] to check at
+ *   platforms supports not showing a dialog, use [org.multipaz.nfc.nfcTagScanningSupportedWithoutDialog] to check at
  *   runtime if the platform supports this.
  * @param options the [MdocTransportOptions] used to create new [MdocTransport] instances.
  * @param transportFactory the factory used to create [MdocTransport] instances.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/nfc/scanNfcTag.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/nfc/scanNfcTag.kt
@@ -3,12 +3,19 @@ package org.multipaz.nfc
 import org.multipaz.prompt.PromptDismissedException
 
 /**
- * Is set to true if [scanNfcTag] works without showing a dialog.
+ * Is set to true if the device supports NFC scanning.
  */
-expect val nfcTagSupportsScanningWithoutDialog: Boolean
+expect val nfcTagScanningSupported: Boolean
+
+/**
+ * Is set to true if the device supports NFC scanning and [scanNfcTag] works without showing a dialog.
+ */
+expect val nfcTagScanningSupportedWithoutDialog: Boolean
 
 /**
  * Shows a dialog prompting the user to scan a NFC tag.
+ *
+ * This only works if [nfcTagScanningSupported] is `true`.
  *
  * When a tag is in the field, [tagInteractionFunc] is called and is passed a [NfcIsoTag] which can be
  * used to communicate with the remote tag and also a function to update the message shown in the dialog.
@@ -32,12 +39,12 @@ expect val nfcTagSupportsScanningWithoutDialog: Boolean
  * or programmatically dismissed by canceling the coroutine this is launched from.
  *
  * @param message the message to initially show in the dialog or `null` to not show a dialog. Not all
- *   platforms supports not showing a dialog, use [nfcTagSupportsScanningWithoutDialog] to check at runtime
+ *   platforms supports not showing a dialog, use [nfcTagScanningSupportedWithoutDialog] to check at runtime
  *   if the platform supports this.
  * @param tagInteractionFunc the function which is called when the tag is in the field, see above.
  * @return return value of [tagInteractionFunc]
  * @throws PromptDismissedException if the user canceled the dialog
- * @throws IllegalArgumentException if [message] is `null` and [nfcTagSupportsScanningWithoutDialog] is `false`.
+ * @throws IllegalArgumentException if [message] is `null` and [nfcTagScanningSupportedWithoutDialog] is `false`.
  * @throws Throwable exceptions thrown in [tagInteractionFunc] are rethrown.
  */
 expect suspend fun<T: Any> scanNfcTag(

--- a/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/openid/OpenID4VP.kt
@@ -76,6 +76,7 @@ object OpenID4VP {
                                 .toJwk(additionalClaims = buildJsonObject {
                                     put("kid", "response-encryption-key")
                                     put("alg", "ECDH-ES")
+                                    put("use", "enc")
                                 }))
                         }
                     }
@@ -154,6 +155,8 @@ object OpenID4VP {
                                 responseEncryptionKey
                                 .toJwk(additionalClaims = buildJsonObject {
                                     put("kid", "response-encryption-key")
+                                    put("alg", "ECDH-ES")
+                                    put("use", "enc")
                                 })
                             )
                         }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/nfc/scanNfcTag.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/nfc/scanNfcTag.ios.kt
@@ -22,7 +22,9 @@ import platform.CoreNFC.NFCReaderSessionInvalidationErrorUserCanceled
 import platform.darwin.NSObject
 import kotlin.coroutines.resumeWithException
 
-actual val nfcTagSupportsScanningWithoutDialog: Boolean = false
+actual val nfcTagScanningSupported = true
+
+actual val nfcTagScanningSupportedWithoutDialog: Boolean = false
 
 private class NfcTagReader<T> {
 

--- a/multipaz/src/jvmMain/kotlin/org/multipaz/nfc/scanNfcTag.jvm.kt
+++ b/multipaz/src/jvmMain/kotlin/org/multipaz/nfc/scanNfcTag.jvm.kt
@@ -1,6 +1,8 @@
 package org.multipaz.nfc
 
-actual val nfcTagSupportsScanningWithoutDialog: Boolean = false
+actual val nfcTagScanningSupported = false
+
+actual val nfcTagScanningSupportedWithoutDialog: Boolean = false
 
 actual suspend fun<T: Any> scanNfcTag(
     message: String?,


### PR DESCRIPTION
This adds `nfcTagScanningSupported` property to convey if the device we're running on supports NFC and also renames the property `nfcTagSupportsScanningWithoutDialog` to `nfcTagScanningSupportedWithoutDialog` for consistency.

Also add `alg` and `use` claims to the keys used for OpenID4VP requests.

Test: Manually tested by wallet who needs these claims in the OpenID4VP request.
