### PR TITLE
ZKP: Minor fixes.

### DIFF
--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/DrivingLicense.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/DrivingLicense.kt
@@ -827,6 +827,26 @@ object DrivingLicense {
                 ),
             )
             .addSampleRequest(
+                id = "age_over_18_zkp",
+                displayName ="Age Over 18 (ZKP)",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_18" to false,
+                    )
+                ),
+                mdocUseZkp = true
+            )
+            .addSampleRequest(
+                id = "age_over_21_zkp",
+                displayName ="Age Over 21 (ZKP)",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_21" to false,
+                    )
+                ),
+                mdocUseZkp = true
+            )
+            .addSampleRequest(
                 id = "age_over_18_and_portrait",
                 displayName ="Age Over 18 + Portrait",
                 mdocDataElements = mapOf(

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/EUPersonalID.kt
@@ -478,6 +478,17 @@ object EUPersonalID {
                 jsonClaims = listOf("age_equal_or_over.18")
             )
             .addSampleRequest(
+                id = "age_over_18_zkp",
+                displayName = "Age Over 18 (ZKP)",
+                mdocDataElements = mapOf(
+                    EUPID_NAMESPACE to mapOf(
+                        "age_over_18" to false,
+                    )
+                ),
+                mdocUseZkp = true,
+                jsonClaims = listOf("age_equal_or_over.18")
+            )
+            .addSampleRequest(
                 id = "age_over_18_and_portrait",
                 displayName = "Age Over 18 + Portrait",
                 mdocDataElements = mapOf(

--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PhotoID.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/PhotoID.kt
@@ -693,6 +693,16 @@ object PhotoID {
                 ),
             )
             .addSampleRequest(
+                id = "age_over_18_zkp",
+                displayName ="Age Over 18 (ZKP)",
+                mdocDataElements = mapOf(
+                    ISO_23220_2_NAMESPACE to mapOf(
+                        "age_over_18" to false,
+                    )
+                ),
+                mdocUseZkp = true
+            )
+            .addSampleRequest(
                 id = "age_over_18_and_portrait",
                 displayName ="Age Over 18 + Portrait",
                 mdocDataElements = mapOf(

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerAndroid.kt
@@ -680,7 +680,7 @@ internal class BleCentralManagerAndroid : BleCentralManager {
         // Needed since l2capSocket.outputStream.flush() isn't working
         l2capSocket?.let {
             CoroutineScope(Dispatchers.IO).launch() {
-                delay(10000)
+                delay(15_000)
                 it.close()
             }
         }

--- a/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
+++ b/multipaz/src/androidMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerAndroid.kt
@@ -548,7 +548,7 @@ internal class BlePeripheralManagerAndroid: BlePeripheralManager {
         incomingMessages.close()
         l2capSocket?.let {
             CoroutineScope(Dispatchers.IO).launch() {
-                delay(5000)
+                delay(15_000)
                 it.close()
             }
         }

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -229,6 +229,7 @@ class DocumentType private constructor(
          * @param mdocDataElements the mdoc data elements in the request, per namespace, with the intent to retain
          *   value. If the list of a namespace is empty, all defined data elements will be included with intent to
          *   retain set to false.
+         * @param mdocUseZkp `true` if the sample request should indicate a preference for use of Zero-Knowledge Proofs.
          * @param jsonClaims the claim names for JSON-based credentials in the request. If the list is empty, all
          *   defined claims will be included. Each claim name must use `.` to separate path components, e.g.
          *   `age_equal_or_over.18`.
@@ -237,7 +238,8 @@ class DocumentType private constructor(
             id: String,
             displayName: String,
             mdocDataElements: Map<String, Map<String, Boolean>>? = null,
-            jsonClaims: List<String>? = null
+            mdocUseZkp: Boolean = false,
+            jsonClaims: List<String>? = null,
         ) = apply {
             val mdocRequest = if (mdocDataElements == null) {
                 null
@@ -255,7 +257,7 @@ class DocumentType private constructor(
                     }
                     nsRequests.add(MdocNamespaceRequest(namespace, map))
                 }
-                MdocCannedRequest(mdocBuilder!!.docType, nsRequests)
+                MdocCannedRequest(mdocBuilder!!.docType, mdocUseZkp, nsRequests)
             }
             val jsonRequest = if (jsonClaims == null) {
                 null

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocCannedRequest.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocCannedRequest.kt
@@ -4,9 +4,11 @@ package org.multipaz.documenttype
  * A class representing a request for a particular set of namespaces and data elements for a particular document type.
  *
  * @param docType the ISO mdoc doctype.
+ * @param useZkp `true` if the canned request should indicate a preference for use of Zero-Knowledge Proofs.
  * @param namespacesToRequest the namespaces to request.
  */
 data class MdocCannedRequest(
     val docType: String,
+    val useZkp: Boolean,
     val namespacesToRequest: List<MdocNamespaceRequest>
 )

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BleCentralManagerIos.kt
@@ -580,7 +580,7 @@ internal class BleCentralManagerIos : BleCentralManager {
         // Delayed closed because there's no way to flush L2CAP connections...
         peripheral?.let {
             CoroutineScope(Dispatchers.IO).launch {
-                delay(5000)
+                delay(15_000)
                 centralManager.cancelPeripheralConnection(it)
             }
         }

--- a/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/mdoc/transport/BlePeripheralManagerIos.kt
@@ -458,7 +458,7 @@ internal class BlePeripheralManagerIos: BlePeripheralManager {
         // Delayed closed because there's no way to flush L2CAP connections...
         _l2capPsm?.let {
             CoroutineScope(Dispatchers.IO).launch {
-                delay(5000)
+                delay(15_000)
                 peripheralManager.unpublishL2CAPChannel(it.toUShort())
             }
         }

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/TestAppUtils.kt
@@ -92,7 +92,6 @@ object TestAppUtils {
         readerCert: X509Cert,
         readerRootCert: X509Cert,
         zkSystemRepository: ZkSystemRepository? = null,
-        useZeroKnowledge: Boolean = false,
     ): ByteArray {
         val mdocRequest = request.mdocRequest!!
         val itemsToRequest = mutableMapOf<String, MutableMap<String, Boolean>>()
@@ -103,7 +102,7 @@ object TestAppUtils {
             }
         }
 
-        var zkSystemSpecs: List<ZkSystemSpec> = if (useZeroKnowledge) {
+        val zkSystemSpecs = if (mdocRequest.useZkp) {
             if (zkSystemRepository == null){
                 throw IllegalStateException("zkSystemRepository is null")
             }


### PR DESCRIPTION
- Add support for ZKP in DocumentType.addSampleRequest() and define ZKP requests for mDL, PhotoID, and EU PID. Remove the custom "Use Zero Knowledge" checkbox in the testapp reader screen since this is no longer needed.

- Use ZkDocumentData.msoX5chain to validate the issuer.

- Fix IsoMdocProximityReadingScreen to actually show the issuer trust-point validation, both for normal and ZKP responses.

- Fix registration of testapp reader root so reader auth using testapp to testapp works again.

Test: Manually tested.