### PR TITLE
multipazctl: add generateReaderCert and printJwk verbs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,28 @@ The project provides libraries written in [Kotlin Multiplatform](https://kotlinl
   non-negligible and not all applications need this or they may bring their
   own.
 
+## Command-line tool
+
 A command-line tool `multipazctl` is also included which can be used to generate
 ISO/IEC 18013-5:2021 IACA certificates among other things. Use
 `./gradlew --quiet runMultipazCtl --args "help"` for documentation on supported
-verbs and options.
+verbs and options. To set up a wrapper, first build the fat jar
+
+```shell
+$ ./gradlew multipazctl:buildFatJar
+```
+
+then create a wrapper like this
+```shell
+#!/bin/sh
+MAIN_CLASS="org.multipaz.multipazctl.MultipazCtl"
+CLASSPATH="/Users/davidz/StudioProjects/identity-credential/multipazctl/build/libs/multipazctl-all.jar"
+JVM_OPTS="-Xms256m -Xmx512m"
+exec java $JVM_OPTS -cp "$CLASSPATH" "$MAIN_CLASS" "$@"
+```
+
+in e.g. `~/bin/multipazctl` adjusting paths as needed. With this you can now
+invoke `multipazctl` like any other system tool.
 
 ## Library releases, Versioning, and Stability
 

--- a/multipazctl/build.gradle.kts
+++ b/multipazctl/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm")
     alias(libs.plugins.buildconfig)
+    alias(libs.plugins.ktor)
 }
 
 val projectVersionCode: Int by rootProject.extra
@@ -34,4 +35,10 @@ tasks.register("runMultipazCtl", JavaExec::class) {
     description = "Invoke multipazctl"
     classpath = sourceSets["main"].runtimeClasspath
     mainClass = "org.multipaz.multipazctl.MultipazCtl"
+    workingDir = project.rootDir
+}
+
+project.setProperty("mainClassName", "org.multipaz.multipazctl.MultipazCtl")
+
+ktor {
 }


### PR DESCRIPTION
Also change build rules to make it possible to create a fat jar and provide instructions in README.md for how to set up a `multipazctl` wrapper.

Test: Manually tested.
