### PR TITLE
TrustManagerLocal: Add deleteAll() and make TrustEntry reusable.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustEntry.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustEntry.kt
@@ -1,19 +1,16 @@
 package org.multipaz.trustmanagement
 
-import kotlinx.datetime.Instant
 import kotlinx.io.bytestring.ByteString
+import org.multipaz.cbor.annotation.CborSerializable
 import org.multipaz.crypto.X509Cert
 
 /**
- * Base class for trust entries added to [TrustManagerLocal]
+ * Base class for trust entries.
  *
- * @property id an identifier for the entry.
- * @property timeAdded the point in time this was added.
- * @property metadata a [TrustMetadata] with metadata about the trust point.
+ * @property metadata a [TrustMetadata] with metadata about the trust entry.
  */
+@CborSerializable
 sealed class TrustEntry(
-    open val id: String,
-    open val timeAdded: Instant,
     open val metadata: TrustMetadata,
 ) {
     companion object
@@ -22,28 +19,19 @@ sealed class TrustEntry(
 /**
  * A X.509 certificate based trust entry.
  *
- * @property ski the Subject Key Identifier in hexadecimal.
  * @property certificate the X.509 root certificate for the CA for the trustpoint.
  */
 data class TrustEntryX509Cert(
-    override val id: String,
-    override val timeAdded: Instant,
     override val metadata: TrustMetadata,
-    val ski: String,
     val certificate: X509Cert,
-): TrustEntry(id, timeAdded, metadata)
+): TrustEntry(metadata)
 
 /**
  * A VICAL based trust entry.
  *
- * @property numCertificates number of certificates in the VICAL.
  * @property encodedSignedVical the bytes of the VICAL.
  */
 data class TrustEntryVical(
-    override val id: String,
-    override val timeAdded: Instant,
     override val metadata: TrustMetadata,
-    val numCertificates: Int,
     val encodedSignedVical: ByteString
-): TrustEntry(id, timeAdded, metadata)
-
+): TrustEntry(metadata)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustMetadata.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/trustmanagement/TrustMetadata.kt
@@ -16,13 +16,15 @@ import org.multipaz.cbor.annotation.CborSerializable
  *   use this if they support importing test certificates / VICALs and wish to convey in
  *   the user interface that the particular reader or issuer being authenticated is used
  *   only for testing.
+ * @param extensions additional metadata which can be used by the application.
  */
 @CborSerializable
 data class TrustMetadata(
     val displayName: String? = null,
     val displayIcon: ByteString? = null,
     val privacyPolicyUrl: String? = null,
-    val testOnly: Boolean = false
+    val testOnly: Boolean = false,
+    val extensions: Map<String, String> = emptyMap()
 ) {
     companion object
 }


### PR DESCRIPTION
For `TrustEntry`, move `id` and `timeAdded` fields out of the public interface and mark it as `CborSerializable`. This allows for applications to nicely reuse these types for e.g. sending a list of trusted IACA certs and VICALs from the server-side to an app.

Test: New unit test and all unit test pass.
