### PR TITLE
Work around bug in Android Keystore ECDH / BiometricPrompt.

### DIFF
--- a/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
+++ b/samples/testapp/src/androidMain/kotlin/org/multipaz/testapp/PlatformAndroid.kt
@@ -100,9 +100,15 @@ actual fun platformCreateKeySettings(
     check(algorithm.fullySpecified)
     var timeoutMillis = 0L
     // Work around Android bug where ECDH keys don't work with timeout 0, see
-    // AndroidKeystoreUnlockData.cryptoObjectForKeyAgreement for details.
+    // AndroidKeystoreUnlockData.cryptoObjectForKeyAgreement for details...
+    //
+    // Also, on some devices (not all!) using both face and fingerprint the time
+    // spent in the biometric prompt counts against the timeout... so if we use a low
+    // value like one second it'll cause a second biometric prompt to appear. Work
+    // around this bug by using a high timeout.
+    //
     if (algorithm.isKeyAgreement) {
-        timeoutMillis = 1000L
+        timeoutMillis = 15_000L
     }
     return AndroidKeystoreCreateKeySettings.Builder(challenge)
         .setAlgorithm(algorithm)


### PR DESCRIPTION
On some Android devices using both face / fingerprint and where face isn't available (if e.g. not enough light) authenticating with fingerprint will cause the biometric prompt for face to appear again which is counterintuitive.

Notably this only happens when using ECDH for DeviceKey (e.g. only in-person, not via Credman since that's always ECDSA) and the root cause is that the timeout for the ECDH keys are only 1 second. This should be enough but the problem is that either Keymint or the Biometric subsystem (likely the latter) sets the timestamp to when the authentication event _began_, not when it ended.

This bug only manifests itself on my Pixel 9 Pro Fold it doesn't happen on the Pixel 8 Pro so it looks like this is a problem in the biometric stack for the former.

Of course the root problem is that we can't use timeout 0 for ECDH keys because that's still not properly exposed in the platform or Jetpack and this is tracked by b/282058146 and b/400115331.

Test: Manually tested.
