### PR TITLE
NFC: Propagate PromptDismissedException on iOS.

### DIFF
--- a/multipaz/src/iosMain/kotlin/org/multipaz/nfc/scanNfcTag.ios.kt
+++ b/multipaz/src/iosMain/kotlin/org/multipaz/nfc/scanNfcTag.ios.kt
@@ -121,7 +121,7 @@ private class NfcTagReader<T> {
             session.invalidateSessionWithErrorMessage("Dialog was canceled")
             throw e
         } catch (e: Throwable) {
-            session.invalidateSessionWithErrorMessage(e.message!!)
+            e.message?.let { session.invalidateSessionWithErrorMessage(it) } ?: session.invalidateSession()
             throw e
         }
     }


### PR DESCRIPTION
On iOS when the user dismisses the NFC scanning dialog we end up dereferencing a null pointer which causes PromptDismissedException not to be propagated to the application.

Test: Manually tested on iOS.
