### PR TITLE
docs: Add developer-friendly deep link comments to `AndroidManifest.xml`

### DIFF
--- a/samples/testapp/src/androidMain/AndroidManifest.xml
+++ b/samples/testapp/src/androidMain/AndroidManifest.xml
@@ -61,6 +61,11 @@
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
 
+            <!-- Deep Link Configuration -->
+            
+            <!-- 1. HTTPS App Links (default) - Requires .well-known/assetlinks.json -->
+            <!-- Examples: https://apps.multipaz.org/landing/ -->
+            <!-- Must match ApplicationSupportLocal.APP_LINK_SERVER -->
             <intent-filter android:autoVerify="true">
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -76,6 +81,20 @@
                     android:pathPattern="/landing/.*"/>
             </intent-filter>
 
+            <!-- 2. Custom URI Scheme - App-specific URLs -->
+            <!-- Examples: multipaz-test-app://landing -->
+            <!-- Must match ApplicationSupportLocal.APP_LINK_SERVER -->
+            <!-- This is an alternative to HTTPS App Links (above) which require .well-known/assetlinks.json -->
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data android:scheme="multipaz-test-app"/>
+                <data android:host="landing"/>
+            </intent-filter>
+
+            <!-- 3. OpenID4VCI Credential Offers -->
+            <!-- Examples: openid-credential-offer://, haip:// -->
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -86,15 +105,6 @@
                 <data android:scheme="haip"/>
                 <!-- Accept all hosts for any of the defined schemes above -->
                 <data android:host="*"/>
-            </intent-filter>
-            
-            <intent-filter>
-                <action android:name="android.intent.action.VIEW" />
-                <category android:name="android.intent.category.DEFAULT" />
-                <category android:name="android.intent.category.BROWSABLE" />
-                <!-- Custom URI scheme -->
-                <data android:scheme="multipaz-test-app"/>
-                <data android:host="landing"/>
             </intent-filter>
         </activity>
 


### PR DESCRIPTION
Add comments explaining HTTPS app links, custom URI schemes, and OpenID4VCI schemes with examples and implementation guidance.

Why This Change is Needed
Developers don't know how to implement custom URI schemes because the AndroidManifest.xml shows intent filters but provides no guidance on handling custom intents in MainActivity or testing them.
This adds documentation explaining:
* Purpose of each intent filter type
* Example URLs
* Cross-references to related code
* Changed the order to reflect https (default) and custom scheme
Now developers can understand both HTTPS and custom schemes for their own apps.

> It's a good idea to open an issue first for discussion.

- [X] Tests pass
- [N/A] Appropriate changes to README are included in PR

CC - @hanluOMH @VishnuSanal 