### PR TITLE
OpenID4VP: Fix handover for URI schemes.

### DIFF
--- a/multipaz-models/src/commonMain/kotlin/org/multipaz/models/openid/OpenID4VP.kt
+++ b/multipaz-models/src/commonMain/kotlin/org/multipaz/models/openid/OpenID4VP.kt
@@ -651,12 +651,17 @@ object OpenID4VP {
         )
         Logger.iCbor(TAG, "handoverInfo", handoverInfo)
 
+        val handoverString = if (responseUri != null) {
+            "OpenID4VPHandover"
+        } else {
+            "OpenID4VPDCAPIHandover"
+        }
         val encodedSessionTranscript = Cbor.encode(
             buildCborArray {
                 add(Simple.NULL) // DeviceEngagementBytes
                 add(Simple.NULL) // EReaderKeyBytes
                 addCborArray {
-                    add("OpenID4VPDCAPIHandover")
+                    add(handoverString)
                     add(Crypto.digest(Algorithm.SHA256, handoverInfo))
                 }
             }

--- a/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
+++ b/multipaz-verifier-server/src/main/java/org/multipaz/verifier/request/verifier.kt
@@ -1045,7 +1045,7 @@ private suspend fun handleOpenID4VPResponse(
                 add(Simple.NULL) // DeviceEngagementBytes
                 add(Simple.NULL) // EReaderKeyBytes
                 addCborArray {
-                    add("OpenID4VPDCAPIHandover")
+                    add("OpenID4VPHandover")
                     add(Crypto.digest(Algorithm.SHA256, handoverInfo))
                 }
             }


### PR DESCRIPTION
We were using `OpenID4VPDCAPIHandover` but for URI schemes it's supposed to just be "OpenID4VPHandover". Fixes #1174.

Test: Manually tested.