### PR TITLE
Add Google Wallet ID pass doctype.

### DIFF
--- a/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/IDPass.kt
+++ b/multipaz-doctypes/src/commonMain/kotlin/org/multipaz/documenttype/knowntypes/IDPass.kt
@@ -1,0 +1,106 @@
+package org.multipaz.documenttype.knowntypes
+
+import org.multipaz.documenttype.DocumentType
+import org.multipaz.documenttype.knowntypes.DrivingLicense.MDL_NAMESPACE
+
+/**
+ * Object containing Google Wallet ID pass metadata.
+ *
+ * See https://developers.google.com/wallet/identity/verify/supported-credential-attributes#id-pass-fields for
+ * more information.
+ */
+object IDPass {
+    const val IDPASS_DOCTYPE = "com.google.wallet.idcard.1"
+
+    fun getDocumentType(): DocumentType {
+        val mDLNamespace = DrivingLicense.getDocumentType().mdocDocumentType!!.namespaces[MDL_NAMESPACE]!!
+        return DocumentType.Builder("Google Wallet ID pass")
+            .addMdocDocumentType(IDPASS_DOCTYPE)
+            .addMdocNamespace(mDLNamespace)
+            .addSampleRequest(
+                id = "age_over_18",
+                displayName ="Age Over 18",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_18" to false,
+                    )
+                ),
+            )
+            .addSampleRequest(
+                id = "age_over_21",
+                displayName ="Age Over 21",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_21" to false,
+                    )
+                ),
+            )
+            .addSampleRequest(
+                id = "age_over_18_zkp",
+                displayName ="Age Over 18 (ZKP)",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_18" to false,
+                    )
+                ),
+                mdocUseZkp = true
+            )
+            .addSampleRequest(
+                id = "age_over_21_zkp",
+                displayName ="Age Over 21 (ZKP)",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_21" to false,
+                    )
+                ),
+                mdocUseZkp = true
+            )
+            .addSampleRequest(
+                id = "age_over_18_and_portrait",
+                displayName ="Age Over 18 + Portrait",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_18" to false,
+                        "portrait" to false
+                    )
+                ),
+            )
+            .addSampleRequest(
+                id = "age_over_21_and_portrait",
+                displayName ="Age Over 21 + Portrait",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "age_over_21" to false,
+                        "portrait" to false
+                    )
+                ),
+            )
+            .addSampleRequest(
+                id = "mandatory",
+                displayName = "Mandatory Data Elements",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(
+                        "family_name" to false,
+                        "given_name" to false,
+                        "birth_date" to false,
+                        "issue_date" to false,
+                        "expiry_date" to false,
+                        "issuing_country" to false,
+                        "issuing_authority" to false,
+                        "document_number" to false,
+                        "portrait" to false,
+                        "driving_privileges" to false,
+                        "un_distinguishing_sign" to false,
+                    )
+                )
+            )
+            .addSampleRequest(
+                id = "full",
+                displayName ="All Data Elements",
+                mdocDataElements = mapOf(
+                    MDL_NAMESPACE to mapOf(),
+                )
+            )
+            .build()
+    }
+}

--- a/multipaz-verifier-server/src/main/resources/resources/www/index.html
+++ b/multipaz-verifier-server/src/main/resources/resources/www/index.html
@@ -90,8 +90,10 @@
 
     </main>
     <footer class="pt-5 my-5 text-body-secondary border-top">
-        This verifier is part of the <a href="https://github.com/openwallet-foundation-labs/identity-credential">OWF Multipaz</a> project
-        and is considered experimental software. Use at your own risk. <a href="verifier/readerRootCert">Reader Root Certificate</a>.
+        This is a testing website that doesn't collect any data.
+        It is part of the <a href="https://github.com/openwallet-foundation-labs/identity-credential">OWF Multipaz</a> project
+        and is considered experimental software. Use at your own risk.
+        <a href="verifier/readerRootCert">Reader Root Certificate</a>.
     </footer>
 </div>
 

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/DocumentType.kt
@@ -97,6 +97,18 @@ class DocumentType private constructor(
         }
 
         /**
+         * Adds an existing namespace to this document type.
+         *
+         * @param namespace the existing namespace to add.
+         * @return the builder.
+         */
+        fun addMdocNamespace(
+            namespace: MdocNamespace
+        ) = apply {
+            mdocBuilder?.addNamespace(namespace)
+        }
+
+        /**
          * Add an attribute for both ISO mdoc and JSON-based document, using the same identifier.
          *
          * @param type the datatype of this attribute.

--- a/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocDocumentType.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/documenttype/MdocDocumentType.kt
@@ -35,7 +35,7 @@ class MdocDocumentType private constructor(
      */
     data class Builder(
         val docType: String,
-        internal val namespaces: MutableMap<String, MdocNamespace.Builder> = mutableMapOf()
+        internal val namespaces: MutableMap<String, MdocNamespace.Builder> = mutableMapOf(),
     ) {
         /**
          * Add a data element to a namespace in the mDoc Document Type.
@@ -48,6 +48,7 @@ class MdocDocumentType private constructor(
          * @param mandatory indication whether the ISO mdoc attribute is mandatory.
          * @param icon the icon, if available.
          * @param sampleValue a sample value for the attribute, if available.
+         * @return the builder.
          */
         fun addDataElement(
             namespace: String,
@@ -71,6 +72,29 @@ class MdocDocumentType private constructor(
                 icon,
                 sampleValue
             )
+        }
+
+        /**
+         * Adds an existing namespace to this type.
+         *
+         * @param namespace the existing namespace to add.
+         * @return the builder.
+         */
+        fun addNamespace(
+            namespace: MdocNamespace
+        ) = apply {
+            namespace.dataElements.forEach { (dataElementName, dataElement) ->
+                addDataElement(
+                    namespace = namespace.namespace,
+                    type = dataElement.attribute.type,
+                    identifier = dataElement.attribute.identifier,
+                    displayName = dataElement.attribute.displayName,
+                    description = dataElement.attribute.description,
+                    mandatory = dataElement.mandatory,
+                    icon = dataElement.attribute.icon,
+                    sampleValue = dataElement.attribute.sampleValueMdoc
+                )
+            }
         }
 
         /**

--- a/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
+++ b/samples/testapp/src/commonMain/kotlin/org/multipaz/testapp/App.kt
@@ -115,6 +115,7 @@ import org.jetbrains.compose.resources.stringResource
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.multipaz.compose.prompt.PromptDialogs
 import org.multipaz.document.buildDocumentStore
+import org.multipaz.documenttype.knowntypes.IDPass
 import org.multipaz.facematch.FaceMatchLiteRtModel
 import org.multipaz.mdoc.zkp.ZkSystemRepository
 import org.multipaz.mdoc.zkp.longfellow.LongfellowZkSystem
@@ -254,6 +255,7 @@ class App private constructor (val promptModel: PromptModel) {
         documentTypeRepository.addDocumentType(PhotoID.getDocumentType())
         documentTypeRepository.addDocumentType(EUPersonalID.getDocumentType())
         documentTypeRepository.addDocumentType(UtopiaMovieTicket.getDocumentType())
+        documentTypeRepository.addDocumentType(IDPass.getDocumentType())
     }
 
     private suspend fun documentStoreInit() {


### PR DESCRIPTION
Additionally, include the two ID pass IACA certificates available on [Google's website](https://developers.google.com/wallet/identity/verify/supported-issuers-iaca-certs) in our issuer trust manager.

Also update the language on the verifier front page including calling out that it's a test website and no data is collected. Modify verifier.kt so no responses are logged on the server-side.

Test: Manually tested.
