### PR TITLE
KSP fixes.

### DIFF
--- a/multipaz/src/commonMain/kotlin/org/multipaz/cbor/annotation/CborSerializable.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/cbor/annotation/CborSerializable.kt
@@ -20,9 +20,13 @@ package org.multipaz.cbor.annotation
  *
  * Single-level sealed class hierarchies are supported. Annotation is required only on the root
  * class of the sealed hierarchy. A special key ("type" by default, see [typeKey]) is added to
- * CBOR map to indicate the actual value type (type id). It is recommended that leaf class names
- * include base class name either as a prefix or a suffix. Type id is generated from the leaf
- * class name, stripping base class name if possible or can be specified explicitly by [typeId].
+ * CBOR map to indicate the actual value type (type id). To avoid name conflicts it is
+ * recommended that either:
+ *   - leaf class names include base class name either as a prefix or a suffix (type id is
+ *     generated from the leaf class name, stripping base class name),
+ *   - or, leaf classes are scoped in the base class,
+ *   - or, leaf classes and the base class are scoped in some other class or object,
+ *   - or, explicit [typeId] is specified.
  */
 @Target(AnnotationTarget.CLASS)
 @Retention(AnnotationRetention.BINARY)

--- a/multipaz/src/commonMain/kotlin/org/multipaz/securearea/PassphraseConstraints.kt
+++ b/multipaz/src/commonMain/kotlin/org/multipaz/securearea/PassphraseConstraints.kt
@@ -11,7 +11,7 @@ import org.multipaz.cbor.annotation.CborSerializable
  * @param maxLength the maximum allowed length of the passphrase.
  * @param requireNumerical if `true`, each character in the passphrase must be decimal digits (0-9).
  */
-@CborSerializable(schemaId = "uvM3E3bDjLlMMDv9rQeipnZxlfnqpkbh401zi6v-nAk")
+@CborSerializable(schemaHash = "uvM3E3bDjLlMMDv9rQeipnZxlfnqpkbh401zi6v-nAk")
 data class PassphraseConstraints(
     val minLength: Int,
     val maxLength: Int,


### PR DESCRIPTION
KSP sometimes does not return us all annotated classes in a compilation unit. Detect this situation and work around it.

Also allow scoping instead of name prefix/suffix for sealed class hierarchies. This quiets a long-standing annoying warning.

Use schemaHash instead of schemaId for stability check.

Functionally, there should be no changes, as generated code should not change at all.
