### PR TITLE
fix: add missing credential types to resolve DCQL matching issues

### DIFF
--- a/multipaz-verifier-server/src/main/resources/resources/www/verifier.js
+++ b/multipaz-verifier-server/src/main/resources/resources/www/verifier.js
@@ -342,6 +342,41 @@ function rawDcqlReset_complex_credential_set() {
   textArea.value = `{
   "credentials": [
     {
+      "id": "photoid",
+      "format": "mso_mdoc",
+      "meta": {
+        "doctype_value": "org.iso.23220.photoID.1"
+      },
+      "claims": [
+        { "path": ["org.iso.23220.1", "family_name_unicode" ] },
+        { "path": ["org.iso.23220.1", "given_name_unicode" ] },
+        { "path": ["org.iso.23220.1", "portrait" ] }
+      ]
+    },
+    {
+      "id": "mdl",
+      "format": "mso_mdoc",
+      "meta": {
+        "doctype_value": "org.iso.18013.5.1.mDL"
+      },
+      "claims": [
+        { "path": ["org.iso.18013.5.1", "family_name" ] },
+        { "path": ["org.iso.18013.5.1", "given_name" ] },
+        { "path": ["org.iso.18013.5.1", "portrait" ] }
+      ]
+    },
+    {
+      "id": "movieticket",
+      "format": "dc+sd-jwt",
+      "meta": {
+        "vct_values": ["https://utopia.example.com/vct/movieticket"]
+      },
+      "claims": [
+        {"path": ["ticket_number"]},
+        {"path": ["cinema_id"]}
+      ]
+    },
+    {
       "id": "pid",
       "format": "dc+sd-jwt",
       "meta": {
@@ -402,6 +437,7 @@ function rawDcqlReset_complex_credential_set() {
   "credential_sets": [
     {
       "options": [
+        ["mdl", "photoid", "movieticket"],
         [ "pid" ],
         [ "other_pid" ],
         [ "pid_reduced_cred_1", "pid_reduced_cred_2" ]


### PR DESCRIPTION
Add photoid, mdl, and movieticket credentials to complex credential set to fix ["No ID found" errors](https://cdn.discordapp.com/attachments/1179828955717574707/1409664898912485547/Image_2025-08-25_151014_312.jpg?ex=68aedcfe&is=68ad8b7e&hm=17e920e825ae8fce9f85d339436c6b4d16a20347ce46c808e2119fd61f2713b3) when scanning QR codes with DCQL.

Fixes # (not created yet. Reported on Discord https://discord.com/channels/1022962884864643214/1179828955717574707/1410033780630097930)

> It's a good idea to open an issue first for discussion.

- [X] Tests pass - Tested locally. https://www.youtube.com/watch?v=dxwSvIgIDTU
- [N/A] Appropriate changes to README are included in PR

CC - @VishnuSanal @hanluOMH 